### PR TITLE
Автоматическое форматирование кода в файлах `*.php`

### DIFF
--- a/archive/archive.php
+++ b/archive/archive.php
@@ -1,111 +1,117 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 // Check execution mode
 if (!pluginGetVariable('archive', 'mode')) {
-	add_act('index', 'plugin_archive'); // auto
+    add_act('index', 'plugin_archive'); // auto
 } else {
-	global $template;
-	$template['vars']['plugin_archive'] = ''; // twig
+    global $template;
+    $template['vars']['plugin_archive'] = ''; // twig
 }
 // Load lang file
 LoadPluginLang('archive', 'main', '', '', ':');
-function plugin_archive() {
-
-	global $template, $config;
-	$template['vars']['plugin_archive'] = plug_arch(pluginGetVariable('archive', 'maxnum') ? pluginGetVariable('archive', 'maxnum') : 12, pluginGetVariable('archive', 'counter') ? pluginGetVariable('archive', 'counter') : 0, pluginGetVariable('archive', 'tcounter') ? pluginGetVariable('archive', 'tcounter') : 0, false, pluginGetVariable('archive', 'cache') ? pluginGetVariable('archive', 'cacheExpire') : 0);
+function plugin_archive()
+{
+    global $template, $config;
+    $template['vars']['plugin_archive'] = plug_arch(pluginGetVariable('archive', 'maxnum') ? pluginGetVariable('archive', 'maxnum') : 12, pluginGetVariable('archive', 'counter') ? pluginGetVariable('archive', 'counter') : 0, pluginGetVariable('archive', 'tcounter') ? pluginGetVariable('archive', 'tcounter') : 0, false, pluginGetVariable('archive', 'cache') ? pluginGetVariable('archive', 'cacheExpire') : 0);
 }
 
-function plug_arch($maxnum, $counter, $tcounter, $overrideTemplateName, $cacheExpire) {
+function plug_arch($maxnum, $counter, $tcounter, $overrideTemplateName, $cacheExpire)
+{
+    global $config, $mysql, $tpl, $template, $twig, $twigLoader, $langMonths, $lang;
+    //	$maxnum    = intval(pluginGetVariable('archive','maxnum'));
+    //	$counter   = intval(pluginGetVariable('archive','counter'));
+    if (($maxnum < 1) || ($maxnum > 50)) {
+        $maxnum = 12;
+    }
+    if ($overrideTemplateName) {
+        $templateName = $overrideTemplateName;
+    } else {
+        $templateName = 'archive';
+    }
+    // Generate cache file name [ we should take into account SWITCHER plugin ]
+    $cacheFileName = md5('archive'.$config['theme'].$templateName.$config['default_lang']).'.txt';
+    if ($cacheExpire > 0) {
+        $cacheData = cacheRetrieveFile($cacheFileName, $cacheExpire, 'archive');
+        if ($cacheData != false) {
+            // We got data from cache. Return it and stop
+            return $cacheData;
+        }
+    }
+    // Determine paths for all template files
+    $tpath = locatePluginTemplates([$templateName, 'entries'], 'archive', pluginGetVariable('archive', 'localsource'));
+    // Load list
+    $caseList = explode(',', $lang['archive:counter.case']);
+    foreach ($mysql->select('SELECT month(from_unixtime(postdate)) as month, year(from_unixtime(postdate)) as year, COUNT(id) AS cnt FROM '.prefix."_news WHERE approve = '1' GROUP BY year, month ORDER BY year DESC, month DESC limit $maxnum") as $row) {
+        $month_link = checkLinkAvailable('news', 'by.month') ?
+            generateLink('news', 'by.month', ['year' => $row['year'], 'month' => sprintf('%02u', $row['month'])]) :
+            generateLink('core', 'plugin', ['plugin' => 'news', 'handler' => 'by.month'], ['year' => $row['year'], 'month' => sprintf('%02u', $row['month'])]);
+        if ($tcounter) {
+            // Determine current case
+            $sCase = 99;
+            $cnt = $row['cnt'];
+            if ($cnt == 1) {
+                $sCase = 1;
+            } elseif (($cnt >= 2) && ($cnt <= 4)) {
+                $sCase = 2;
+            } elseif (($cnt >= 5) && ($cnt <= 20)) {
+                $sCase = 4;
+            } else {
+                $tsCase = $sCase % 10;
+                if ($tsCase == 0) {
+                    $sCase = 4;
+                } elseif ($tsCase == 1) {
+                    $sCase = 1;
+                } elseif (($tsCase >= 2) && ($tsCase <= 4)) {
+                    $sCase = 2;
+                } else {
+                    $sCase = 4;
+                }
+            }
+            $ctext = $caseList[$sCase - 1];
+        } else {
+            $ctext = '';
+        }
+        $tEntries[] = [
+            'link'    => $month_link,
+            'title'   => $langMonths[$row['month'] - 1].' '.$row['year'],
+            'cnt'     => $row['cnt'],
+            'counter' => $counter,
+            'ctext'   => $ctext,
+        ];
+    }
+    $tVars['entries'] = $tEntries;
+    $tVars['tpl_url'] = tpl_url;
+    // Prepare conversion table
+    $conversionConfig = [
+        '{archive}' => '{% for entry in entries %}{% include localPath(0) ~ "entries.tpl" %}{% endfor %}',
+        '{tpl_url}' => '{{ tpl_url }}',
+    ];
+    $conversionConfigE = [
+        '{link}'  => '{{ entry.link }}',
+        '{title}' => '{{ entry.title }}',
+        '{cnt}'   => '{{ entry.cnt }}',
+        '{ctext}' => '{{ entry.ctext }}',
+    ];
+    $conversionConfigRegex = [
+        '#\[counter\](.+?)\[/counter\]#is' => '{% if (entry.counter) %}$1{% endif %}',
+    ];
+    $twigLoader->setConversion($tpath['archive'].'archive.tpl', $conversionConfig);
+    $twigLoader->setConversion($tpath['entries'].'entries.tpl', $conversionConfigE, $conversionConfigRegex);
+    // Предзагрузка шаблона entries [ чтобы отработал setConversion ] при его наличии
+    if (isset($tpath['entries'])) {
+        $twig->loadTemplate($tpath['entries'].'entries.tpl');
+    }
+    $xt = $twig->loadTemplate($tpath[$templateName].$templateName.'.tpl');
+    $output = $xt->render($tVars);
+    if ($cacheExpire > 0) {
+        cacheStoreFile($cacheFileName, $output, 'archive');
+    }
 
-	global $config, $mysql, $tpl, $template, $twig, $twigLoader, $langMonths, $lang;
-	//	$maxnum    = intval(pluginGetVariable('archive','maxnum'));
-	//	$counter   = intval(pluginGetVariable('archive','counter'));
-	if (($maxnum < 1) || ($maxnum > 50)) $maxnum = 12;
-	if ($overrideTemplateName) {
-		$templateName = $overrideTemplateName;
-	} else {
-		$templateName = 'archive';
-	}
-	// Generate cache file name [ we should take into account SWITCHER plugin ]
-	$cacheFileName = md5('archive' . $config['theme'] . $templateName . $config['default_lang']) . '.txt';
-	if ($cacheExpire > 0) {
-		$cacheData = cacheRetrieveFile($cacheFileName, $cacheExpire, 'archive');
-		if ($cacheData != false) {
-			// We got data from cache. Return it and stop
-			return $cacheData;
-		}
-	}
-	// Determine paths for all template files
-	$tpath = locatePluginTemplates(array($templateName, 'entries'), 'archive', pluginGetVariable('archive', 'localsource'));
-	// Load list
-	$caseList = explode(',', $lang['archive:counter.case']);
-	foreach ($mysql->select("SELECT month(from_unixtime(postdate)) as month, year(from_unixtime(postdate)) as year, COUNT(id) AS cnt FROM " . prefix . "_news WHERE approve = '1' GROUP BY year, month ORDER BY year DESC, month DESC limit $maxnum") as $row) {
-		$month_link = checkLinkAvailable('news', 'by.month') ?
-			generateLink('news', 'by.month', array('year' => $row['year'], 'month' => sprintf('%02u', $row['month']))) :
-			generateLink('core', 'plugin', array('plugin' => 'news', 'handler' => 'by.month'), array('year' => $row['year'], 'month' => sprintf('%02u', $row['month'])));
-		if ($tcounter) {
-			// Determine current case
-			$sCase = 99;
-			$cnt = $row['cnt'];
-			if ($cnt == 1) {
-				$sCase = 1;
-			} else if (($cnt >= 2) && ($cnt <= 4)) {
-				$sCase = 2;
-			} else if (($cnt >= 5) && ($cnt <= 20)) {
-				$sCase = 4;
-			} else {
-				$tsCase = $sCase % 10;
-				if ($tsCase == 0) {
-					$sCase = 4;
-				} else if ($tsCase == 1) {
-					$sCase = 1;
-				} else if (($tsCase >= 2) && ($tsCase <= 4)) {
-					$sCase = 2;
-				} else {
-					$sCase = 4;
-				}
-			}
-			$ctext = $caseList[$sCase - 1];
-		} else {
-			$ctext = '';
-		}
-		$tEntries [] = array(
-			'link'    => $month_link,
-			'title'   => $langMonths[$row['month'] - 1] . ' ' . $row['year'],
-			'cnt'     => $row['cnt'],
-			'counter' => $counter,
-			'ctext'   => $ctext,
-		);
-	}
-	$tVars['entries'] = $tEntries;
-	$tVars['tpl_url'] = tpl_url;
-	// Prepare conversion table
-	$conversionConfig = array(
-		'{archive}' => '{% for entry in entries %}{% include localPath(0) ~ "entries.tpl" %}{% endfor %}',
-		'{tpl_url}' => '{{ tpl_url }}',
-	);
-	$conversionConfigE = array(
-		'{link}'  => '{{ entry.link }}',
-		'{title}' => '{{ entry.title }}',
-		'{cnt}'   => '{{ entry.cnt }}',
-		'{ctext}' => '{{ entry.ctext }}',
-	);
-	$conversionConfigRegex = array(
-		'#\[counter\](.+?)\[/counter\]#is' => '{% if (entry.counter) %}$1{% endif %}',
-	);
-	$twigLoader->setConversion($tpath['archive'] . 'archive.tpl', $conversionConfig);
-	$twigLoader->setConversion($tpath['entries'] . 'entries.tpl', $conversionConfigE, $conversionConfigRegex);
-	// Предзагрузка шаблона entries [ чтобы отработал setConversion ] при его наличии
-	if (isset($tpath['entries']))
-		$twig->loadTemplate($tpath['entries'] . 'entries.tpl');
-	$xt = $twig->loadTemplate($tpath[$templateName] . $templateName . '.tpl');
-	$output = $xt->render($tVars);
-	if ($cacheExpire > 0) {
-		cacheStoreFile($cacheFileName, $output, 'archive');
-	}
-
-	return $output;
+    return $output;
 }
 
 //
@@ -116,11 +122,11 @@ function plug_arch($maxnum, $counter, $tcounter, $overrideTemplateName, $cacheEx
 // * tcounter		- Show text counter in the entries
 // * template	- Personal template for plugin
 // * cacheExpire		- age of cache [in seconds]
-function plugin_archive_showTwig($params) {
+function plugin_archive_showTwig($params)
+{
+    global $CurrentHandler, $config;
 
-	global $CurrentHandler, $config;
-
-	return plug_arch(isset($params['maxnum']) ? $params['maxnum'] : pluginGetVariable('archive', 'maxnum'), isset($params['counter']) ? $params['counter'] : false, isset($params['tcounter']) ? $params['tcounter'] : false, isset($params['template']) ? $params['template'] : false, isset($params['cacheExpire']) ? $params['cacheExpire'] : 0);
+    return plug_arch(isset($params['maxnum']) ? $params['maxnum'] : pluginGetVariable('archive', 'maxnum'), isset($params['counter']) ? $params['counter'] : false, isset($params['tcounter']) ? $params['tcounter'] : false, isset($params['template']) ? $params['template'] : false, isset($params['cacheExpire']) ? $params['cacheExpire'] : 0);
 }
 
 twigRegisterFunction('archive', 'show', plugin_archive_showTwig);

--- a/archive/config.php
+++ b/archive/config.php
@@ -1,6 +1,9 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
@@ -8,29 +11,28 @@ if (!defined('NGCMS')) die ('HAL');
 plugins_load_config();
 LoadPluginLang('archive', 'config', '', '', ':');
 // Fill configuration parameters
-$cfg = array();
-$cfgX = array();
-array_push($cfg, array('descr' => $lang['archive:description']));
-array_push($cfgX, array('name' => 'maxnum', 'title' => $lang['archive:maxnum'], 'descr' => $lang['archive:maxnum#desc'], 'type' => 'input', 'value' => intval(pluginGetVariable($plugin, 'maxnum')) ? pluginGetVariable($plugin, 'maxnum') : '12'));
-array_push($cfgX, array('name' => 'counter', 'title' => $lang['archive:counter'], 'descr' => $lang['archive:counter#desc'], 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(pluginGetVariable($plugin, 'counter'))));
-array_push($cfgX, array('name' => 'tcounter', 'title' => $lang['archive:tcounter'], 'descr' => $lang['archive:tcounter#desc'], 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(pluginGetVariable($plugin, 'tcounter'))));
-array_push($cfg, array('mode' => 'group', 'title' => $lang['archive:group.config'], 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'mode', 'title' => "В каком режиме генерируется вывод плагина<br /><small><b>Автоматически</b> - при включении плагина автоматически генерируется блок {plugin_comments}<br /><b>TWIG</b> - вывод плагина генерируется только через TWIG функцию <b>callPlugin()</b></small>", 'type' => 'select', 'values' => array('0' => 'Автоматически', '1' => 'TWIG'), 'value' => intval(pluginGetVariable($plugin, 'mode'))));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Режим запуска</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'localsource', 'title' => $lang['archive:localsource'], 'descr' => $lang['archive:localsource#desc'], 'type' => 'select', 'values' => array('0' => 'Шаблон сайта', '1' => 'Плагин'), 'value' => intval(pluginGetVariable($plugin, 'localsource'))));
-array_push($cfg, array('mode' => 'group', 'title' => $lang['archive:group.source'], 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'cache', 'title' => $lang['archive:cache'], $lang['archive:cache#desc'], 'type' => 'select', 'values' => array('1' => 'Да', '0' => 'Нет'), 'value' => intval(pluginGetVariable($plugin, 'cache'))));
-array_push($cfgX, array('name' => 'cacheExpire', 'title' => $lang['archive:cacheExpire'], 'descr' => $lang['archive:cacheExpire#desc'], 'type' => 'input', 'value' => intval(pluginGetVariable($plugin, 'cacheExpire')) ? pluginGetVariable($plugin, 'cacheExpire') : '60'));
-array_push($cfg, array('mode' => 'group', 'title' => $lang['archive:group.cache'], 'entries' => $cfgX));
+$cfg = [];
+$cfgX = [];
+array_push($cfg, ['descr' => $lang['archive:description']]);
+array_push($cfgX, ['name' => 'maxnum', 'title' => $lang['archive:maxnum'], 'descr' => $lang['archive:maxnum#desc'], 'type' => 'input', 'value' => intval(pluginGetVariable($plugin, 'maxnum')) ? pluginGetVariable($plugin, 'maxnum') : '12']);
+array_push($cfgX, ['name' => 'counter', 'title' => $lang['archive:counter'], 'descr' => $lang['archive:counter#desc'], 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(pluginGetVariable($plugin, 'counter'))]);
+array_push($cfgX, ['name' => 'tcounter', 'title' => $lang['archive:tcounter'], 'descr' => $lang['archive:tcounter#desc'], 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(pluginGetVariable($plugin, 'tcounter'))]);
+array_push($cfg, ['mode' => 'group', 'title' => $lang['archive:group.config'], 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'mode', 'title' => 'В каком режиме генерируется вывод плагина<br /><small><b>Автоматически</b> - при включении плагина автоматически генерируется блок {plugin_comments}<br /><b>TWIG</b> - вывод плагина генерируется только через TWIG функцию <b>callPlugin()</b></small>', 'type' => 'select', 'values' => ['0' => 'Автоматически', '1' => 'TWIG'], 'value' => intval(pluginGetVariable($plugin, 'mode'))]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Режим запуска</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'localsource', 'title' => $lang['archive:localsource'], 'descr' => $lang['archive:localsource#desc'], 'type' => 'select', 'values' => ['0' => 'Шаблон сайта', '1' => 'Плагин'], 'value' => intval(pluginGetVariable($plugin, 'localsource'))]);
+array_push($cfg, ['mode' => 'group', 'title' => $lang['archive:group.source'], 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'cache', 'title' => $lang['archive:cache'], $lang['archive:cache#desc'], 'type' => 'select', 'values' => ['1' => 'Да', '0' => 'Нет'], 'value' => intval(pluginGetVariable($plugin, 'cache'))]);
+array_push($cfgX, ['name' => 'cacheExpire', 'title' => $lang['archive:cacheExpire'], 'descr' => $lang['archive:cacheExpire#desc'], 'type' => 'input', 'value' => intval(pluginGetVariable($plugin, 'cacheExpire')) ? pluginGetVariable($plugin, 'cacheExpire') : '60']);
+array_push($cfg, ['mode' => 'group', 'title' => $lang['archive:group.cache'], 'entries' => $cfgX]);
 // RUN
 if ($_REQUEST['action'] == 'commit') {
-	// If submit requested, do config save
-	commit_plugin_config_changes($plugin, $cfg);
-	print_commit_complete($plugin);
+    // If submit requested, do config save
+    commit_plugin_config_changes($plugin, $cfg);
+    print_commit_complete($plugin);
 } else {
-	generate_config_page($plugin, $cfg);
+    generate_config_page($plugin, $cfg);
 }
-?>

--- a/auth_basic/auth_basic.php
+++ b/auth_basic/auth_basic.php
@@ -1,6 +1,9 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Прописываем свой модуль
 //
@@ -8,594 +11,592 @@ global $AUTH_METHOD;
 global $AUTH_CAPABILITIES;
 global $config;
 
-class auth_basic extends CoreAuthPlugin {
+class auth_basic extends CoreAuthPlugin
+{
+    // Осуществить вход
+    // $username	= логин
+    // $password	= пароль
+    // $auto_scan	= если 1, то функция сама должна найти нужные параметры среди POST'ов
+    public function login($auto_scan = 1, $username = '', $password = '')
+    {
+        global $mysql;
+        if ($auto_scan) {
+            $username = $_REQUEST['username'];
+            $password = $_REQUEST['password'];
+        }
+        $password = EncodePassword($password);
+        //
+        $flagError = false;
+        $flagErrorText = '';
+        $returnValue = '';
+        $row = [];
+        // Request record for specific user
+        if (!is_array($row = $mysql->record('select * from '.uprefix.'_users where name ='.db_squote($username)))) {
+            // ** UNKNOWN USER **
+            return 'ERR:INVALID.USER ['.$username.']';
+        }
+        // Check password
+        if ($row['pass'] != $password) {
+            // ** WRONG PASSWORD **
+            return 'ERR:INVALID.PASSWORD ['.$username.']';
+        }
+        // Check is activation is required
+        if ($row['activation']) {
+            return 'ERR:NEED.ACTIVATE ['.$username.']';
+        }
 
-	// Осуществить вход
-	// $username	= логин
-	// $password	= пароль
-	// $auto_scan	= если 1, то функция сама должна найти нужные параметры среди POST'ов
-	function login($auto_scan = 1, $username = '', $password = '') {
+        // Return user's record
+        return $row;
+    }
 
-		global $mysql;
-		if ($auto_scan) {
-			$username = $_REQUEST['username'];
-			$password = $_REQUEST['password'];
-		}
-		$password = EncodePassword($password);
-		//
-		$flagError = false;
-		$flagErrorText = '';
-		$returnValue = '';
-		$row = array();
-		// Request record for specific user
-		if (!is_array($row = $mysql->record("select * from " . uprefix . "_users where name =" . db_squote($username)))) {
-			// ** UNKNOWN USER **
-			return 'ERR:INVALID.USER [' . $username . ']';
-		}
-		// Check password
-		if ($row['pass'] != $password) {
-			// ** WRONG PASSWORD **
-			return 'ERR:INVALID.PASSWORD [' . $username . ']';
-		}
-		// Check is activation is required
-		if ($row['activation']) {
-			return 'ERR:NEED.ACTIVATE [' . $username . ']';
-		}
+    //
+    // Сохранить в БД информацию о том, что пользователь авторизовался
+    // $dbrow	= строка из нашей таблицы пользователей
+    public function save_auth($dbrow)
+    {
+        global $config, $mysql, $ip, $ngCookieDomain;
+        // создаём random cookie
+        $auth_cookie = md5((isset($config['crypto_salt']) ? $config['crypto_salt'] : '').uniqid(rand(), 1));
+        // Multilogin is allowed. Session information is stored in separate table
+        if (pluginGetVariable('auth_basic', 'multilogin')) {
+            // Drop old session (if applicable)
+            if (isset($_COOKIE['zz_auth']) && $_COOKIE['zz_auth']) {
+                $mysql->query('delete from '.uprefix.'_users_sessions where authcookie = '.db_squote($_COOKIE['zz_auth']).' limit 1');
+            }
+            // Register new session
+            $query = 'insert into '.uprefix.'_users_sessions (userID, ip, last, authcookie) values ('.db_squote($dbrow['id']).', '.db_squote($ip).', '.db_squote(time()).', '.db_squote($auth_cookie).')';
+            $mysql->query($query);
+            // Update user's last login time
+            $query = 'update '.uprefix.'_users set last = '.db_squote(time()).' where id = '.db_squote($dbrow['id']);
+            $mysql->query($query);
+        } else {
+            // SINGLE LOGIN mode
+            $query = 'update '.uprefix.'_users set last = '.db_squote(time()).', ip='.db_squote($ip).', authcookie = '.db_squote($auth_cookie).' where id='.db_squote($dbrow['id']);
+            $mysql->query($query);
+        }
+        // Fix: http://stackoverflow.com/a/5849409/4331870
+        if ($ngCookieDomain == 'localhost') {
+            $ngCookieDomain = null;
+        }
+        // Вставить юзеру куку
+        @setcookie('zz_auth', $auth_cookie, ($config['remember'] ? (time() + 3600 * 24 * 365) : 0), '/', $ngCookieDomain, 0, 1);
 
-		// Return user's record
-		return $row;
-	}
+        return 1;
+    }
 
-	//
-	// Сохранить в БД информацию о том, что пользователь авторизовался
-	// $dbrow	= строка из нашей таблицы пользователей
-	function save_auth($dbrow) {
+    //
+    // Проверить авторизацию пользователя
+    public function check_auth()
+    {
+        global $config, $mysql, $ip;
+        $auth_cookie = isset($_COOKIE['zz_auth']) ? $_COOKIE['zz_auth'] : '';
+        if (!$auth_cookie) {
+            return '';
+        }
+        // Multilogin is allowed. Session information is stored in separate table
+        if (pluginGetVariable('auth_basic', 'multilogin')) {
+            $query = 'select * from '.uprefix.'_users_sessions where authcookie = '.db_squote($auth_cookie).' limit 1';
+            if (is_array($sRow = $mysql->record($query))) {
+                // Retrieve user row
+                $query = 'select * from '.uprefix.'_users where id = '.db_squote($sRow['userID']);
+                $row = $mysql->record($query);
+                // COMPATIBILITY MODE - replace InMemory authcookie / ip
+                if (is_array($row)) {
+                    $row['ip'] = $sRow['ip'];
+                    $row['authcookie'] = $sRow['authcookie'];
+                }
+            }
+        } else {
+            $query = 'select * from '.uprefix.'_users where authcookie = '.db_squote($auth_cookie).' limit 1';
+            $row = $mysql->record($query);
+        }
+        // Check for "IPLOCK" protection
+        if (pluginGetVariable('auth_basic', 'iplock') && ($ip != $row['ip'])) {
+            return '';
+        }
+        // Auth done
+        if ($row['name']) {
+            // Check if we need to update last visit field
+            if ((pluginGetVariable('auth_basic', 'lastupdate') > 0) && ((time() - $row['last']) > pluginGetVariable('auth_basic', 'lastupdate'))) {
+                $query = 'update '.uprefix.'_users set last = '.db_squote(time()).', ip='.db_squote($ip).' where id='.db_squote($row['id']);
+                $mysql->query($query);
+                // Multilogin is allowed. Session information is stored in separate table
+                if (pluginGetVariable('auth_basic', 'multilogin')) {
+                    $query = 'update '.uprefix.'_users_sessions set last = '.db_squote(time()).' where (userID = '.db_squote($row['id']).') and (authcookie='.db_squote($row['authcookie']).')';
+                    $mysql->query($query);
+                }
+            }
 
-		global $config, $mysql, $ip, $ngCookieDomain;
-		// создаём random cookie
-		$auth_cookie = md5((isset($config['crypto_salt']) ? $config['crypto_salt'] : '') . uniqid(rand(), 1));
-		// Multilogin is allowed. Session information is stored in separate table
-		if (pluginGetVariable('auth_basic', 'multilogin')) {
-			// Drop old session (if applicable)
-			if (isset($_COOKIE['zz_auth']) && $_COOKIE['zz_auth'])
-				$mysql->query("delete from " . uprefix . "_users_sessions where authcookie = " . db_squote($_COOKIE['zz_auth']) . " limit 1");
-			// Register new session
-			$query = "insert into " . uprefix . "_users_sessions (userID, ip, last, authcookie) values (" . db_squote($dbrow['id']) . ", " . db_squote($ip) . ", " . db_squote(time()) . ", " . db_squote($auth_cookie) . ")";
-			$mysql->query($query);
-			// Update user's last login time
-			$query = "update " . uprefix . "_users set last = " . db_squote(time()) . " where id = " . db_squote($dbrow['id']);
-			$mysql->query($query);
-		} else {
-			// SINGLE LOGIN mode
-			$query = "update " . uprefix . "_users set last = " . db_squote(time()) . ", ip=" . db_squote($ip) . ", authcookie = " . db_squote($auth_cookie) . " where id=" . db_squote($dbrow['id']);
-			$mysql->query($query);
-		}
-		// Fix: http://stackoverflow.com/a/5849409/4331870
-		if ($ngCookieDomain == 'localhost') {
-			$ngCookieDomain = null;
-		}
-		// Вставить юзеру куку
-		@setcookie('zz_auth', $auth_cookie, ($config['remember'] ? (time() + 3600 * 24 * 365) : 0), '/', $ngCookieDomain, 0, 1);
+            return $row;
+        }
 
-		return 1;
-	}
+        return '';
+    }
 
-	//
-	// Проверить авторизацию пользователя
-	function check_auth() {
+    //
+    // Отменить авторизацию
+    public function drop_auth()
+    {
+        global $config, $mysql, $userROW;
+        $auth_cookie = $_COOKIE['zz_auth'];
+        if (!$auth_cookie) {
+            return;
+        }
+        // Multilogin is allowed. Session information is stored in separate table
+        if (pluginGetVariable('auth_basic', 'multilogin')) {
+            $mysql->query('delete from '.prefix.'_users_sessions where authcookie = '.db_squote($userROW['authcookie']));
+        } else {
+            $mysql->query('update '.uprefix."_users set authcookie = '' where id=".db_squote($userROW['id']));
+        }
+        @setcookie('zz_auth', '', time() - 3600 * 24 * 365, '/');
+    }
 
-		global $config, $mysql, $ip;
-		$auth_cookie = isset($_COOKIE['zz_auth']) ? $_COOKIE['zz_auth'] : '';
-		if (!$auth_cookie) {
-			return '';
-		}
-		// Multilogin is allowed. Session information is stored in separate table
-		if (pluginGetVariable('auth_basic', 'multilogin')) {
-			$query = "select * from " . uprefix . "_users_sessions where authcookie = " . db_squote($auth_cookie) . " limit 1";
-			if (is_array($sRow = $mysql->record($query))) {
-				// Retrieve user row
-				$query = "select * from " . uprefix . "_users where id = " . db_squote($sRow['userID']);
-				$row = $mysql->record($query);
-				// COMPATIBILITY MODE - replace InMemory authcookie / ip
-				if (is_array($row)) {
-					$row['ip'] = $sRow['ip'];
-					$row['authcookie'] = $sRow['authcookie'];
-				}
-			};
-		} else {
-			$query = "select * from " . uprefix . "_users where authcookie = " . db_squote($auth_cookie) . " limit 1";
-			$row = $mysql->record($query);
-		}
-		// Check for "IPLOCK" protection
-		if (pluginGetVariable('auth_basic', 'iplock') && ($ip != $row['ip'])) {
-			return '';
-		}
-		// Auth done
-		if ($row['name']) {
-			// Check if we need to update last visit field
-			if ((pluginGetVariable('auth_basic', 'lastupdate') > 0) && ((time() - $row['last']) > pluginGetVariable('auth_basic', 'lastupdate'))) {
-				$query = "update " . uprefix . "_users set last = " . db_squote(time()) . ", ip=" . db_squote($ip) . " where id=" . db_squote($row['id']);
-				$mysql->query($query);
-				// Multilogin is allowed. Session information is stored in separate table
-				if (pluginGetVariable('auth_basic', 'multilogin')) {
-					$query = "update " . uprefix . "_users_sessions set last = " . db_squote(time()) . " where (userID = " . db_squote($row['id']) . ") and (authcookie=" . db_squote($row['authcookie']) . ")";
-					$mysql->query($query);
-				}
-			}
+    //
+    // Вернуть массив параметров, необходимых при регистрации
+    public function get_reg_params()
+    {
+        global $config, $lang;
+        $params = [];
+        LoadPluginLang('auth_basic', 'auth', '', 'auth');
+        array_push($params, ['name' => 'login', 'id' => 'reg_login', 'title' => $lang['auth_login'], 'descr' => $lang['auth_login_descr'], 'type' => 'input']);
+        if ($config['register_type'] >= 3) {
+            array_push($params, ['id' => 'reg_password', 'name' => 'password', title => $lang['auth_pass'], 'descr' => $lang['auth_pass_descr'], 'type' => 'password']);
+            array_push($params, ['id' => 'reg_password2', 'name' => 'password2', title => $lang['auth_pass2'], 'descr' => $lang['auth_pass2_descr'], 'type' => 'password']);
+        }
+        array_push($params, ['name' => 'email', id => 'reg_email', 'title' => $lang['auth_email'], 'descr' => $lang['auth_email_descr'], 'type' => 'input']);
 
-			return $row;
-		}
+        return $params;
+    }
 
-		return '';
-	}
+    //
+    // Провести регистрацию
+    // params = параметры полученные из get_reg_params()
+    // values = значения для вышеуказанных параметрах
+    // msg	= сообщение об ошибке
+    // Возвращаемые значения:
+    // 0 - ошибка
+    // 1 - всё ok
+    public function register(&$params, $values, &$msg)
+    {
+        global $config, $mysql, $lang, $tpl;
+        LoadPluginLang('auth_basic', 'auth', '', 'auth');
+        $error = 0;
+        $userid = 0;
+        $values['login'] = trim($values['login']);
+        // Preprocess login
+        if (strlen($values['login']) < 3) {
+            // Слишком короткий логин
+            $msg = $lang['auth_login_short'];
 
-	//
-	// Отменить авторизацию
-	function drop_auth() {
+            return 0;
+        }
+        // Проверяем логин на запрещенные символы
+        $csError = false;
+        switch (pluginGetVariable('auth_basic', 'regcharset')) {
+            case 0:
+                if (!preg_match('#^[A-Za-z0-9\.\_\-]+$#s', $values['login'])) {
+                    $csError = true;
+                }
+                break;
+            case 1:
+                if (!preg_match('#^[А-Яа-яёЁ0-9\.\_\-]+$#s', $values['login'])) {
+                    $csError = true;
+                }
+                break;
+            case 2:
+                if (!preg_match('#^[А-Яа-яёЁA-Za-z0-9\.\_\-]+$#s', $values['login'])) {
+                    echo 'CASE2-err ['.$values['login'].']';
+                    $csError = true;
+                }
+                break;
+            case 3:
+                if (!preg_match('#^[\x21-\x7e\xc0-\xffёЁ]+$#s', $values['login'])) {
+                    $csError = true;
+                }
+                break;
+            case 4:
+                break;
+        }
+        if (preg_match('/[&<>\\"'."'".']/', $values['login']) || $csError) {
+            // Запрещенные HTML символы
+            $msg = $lang['auth_login_html'];
 
-		global $config, $mysql, $userROW;
-		$auth_cookie = $_COOKIE['zz_auth'];
-		if (!$auth_cookie) {
-			return;
-		}
-		// Multilogin is allowed. Session information is stored in separate table
-		if (pluginGetVariable('auth_basic', 'multilogin')) {
-			$mysql->query("delete from " . prefix . "_users_sessions where authcookie = " . db_squote($userROW['authcookie']));
-		} else {
-			$mysql->query("update " . uprefix . "_users set authcookie = '' where id=" . db_squote($userROW['id']));
-		}
-		@setcookie('zz_auth', '', time() - 3600 * 24 * 365, '/');
+            return 0;
+        }
+        if ($config['register_type'] >= 3) {
+            if (strlen($values['password']) < 3) {
+                // Слишком короткий пароль
+                $msg = $lang['auth_pass_short'];
 
-		return;
-	}
+                return 0;
+            } elseif ($values['password'] != $values['password2']) {
+                // Несовпадение паролей
+                $msg = $lang['auth_pass_diff'];
 
-	//
-	// Вернуть массив параметров, необходимых при регистрации
-	function get_reg_params() {
+                return 0;
+            }
+        }
+        if ((strlen($values['email']) > 70) || (!preg_match("/^[\.A-z0-9_\-]+[@][A-z0-9_\-]+([.][A-z0-9_\-]+)+[A-z]{1,4}$/", $values['email']))) {
+            // Неверный email
+            $msg = $lang['auth_email_wrong'];
 
-		global $config, $lang;
-		$params = array();
-		LoadPluginLang('auth_basic', 'auth', '', 'auth');
-		array_push($params, array('name' => 'login', 'id' => 'reg_login', 'title' => $lang['auth_login'], 'descr' => $lang['auth_login_descr'], 'type' => 'input'));
-		if ($config['register_type'] >= 3) {
-			array_push($params, array('id' => 'reg_password', 'name' => 'password', title => $lang['auth_pass'], 'descr' => $lang['auth_pass_descr'], 'type' => 'password'));
-			array_push($params, array('id' => 'reg_password2', 'name' => 'password2', title => $lang['auth_pass2'], 'descr' => $lang['auth_pass2_descr'], 'type' => 'password'));
-		}
-		array_push($params, array('name' => 'email', id => 'reg_email', 'title' => $lang['auth_email'], 'descr' => $lang['auth_email_descr'], 'type' => 'input'));
+            return 0;
+        }
+        $row = $mysql->record('select * from '.uprefix.'_users where lower(name)='.db_squote(strtolower($values['login'])).' or mail='.db_squote($values['email']));
+        if (is_array($row)) {
+            // Дублирование логина/email'а
+            if (strtolower($row['mail']) == strtolower($values['email'])) {
+                // email dup
+                $msg = $lang['auth_email_dup'];
 
-		return $params;
-	}
+                return 0;
+            }
+            // Если не мыло, то логин
+            $msg = $lang['auth_login_dup'];
 
-	//
-	// Провести регистрацию
-	// params = параметры полученные из get_reg_params()
-	// values = значения для вышеуказанных параметрах
-	// msg	= сообщение об ошибке
-	// Возвращаемые значения:
-	// 0 - ошибка
-	// 1 - всё ok
-	function register(&$params, $values, &$msg) {
+            return 0;
+        }
+        // Всё в порядке, регим
+        $add_time = time() + ($config['date_adjust'] * 60);
+        // Статус пользователя по умолчанию
+        $regGroup = intval(pluginGetVariable('auth_basic', 'regstatus'));
+        if (!isset($UGROUP[$regGroup])) {
+            // If GROUP is not defined - set "4" as default
+            $regGroup = 4; // Commenter
+        }
+        // Определяем действия в зависимости от типа регистрации
+        switch ($config['register_type']) {
+            // 0 - Мгновенная [автогенерация пароля, без email нотификации]
+            case 0:
+                $newpassword = MakeRandomPassword();
+                $mysql->query('INSERT INTO '.uprefix.'_users (name, pass, mail, status, reg, last) VALUES ('.db_squote($values['login']).', '.db_squote(EncodePassword($newpassword)).', '.db_squote($values['email']).', '.$regGroup.", '".$add_time."', '')");
+                $userid = $mysql->result('select LAST_INSERT_ID()');
+                msg([
+                    'text' => $lang['msgo_registered'],
+                    'info' => str_replace(['{login}', '{password}'], [$values['login'], $newpassword], $lang['auth_reg.success0']),
+                ]);
+                break;
+            // 1 - Простая [автогенерация пароля, с email нотификацией]
+            case 1:
+                $newpassword = MakeRandomPassword();
+                $mysql->query('INSERT INTO '.uprefix.'_users (name, pass, mail, status, reg, last) VALUES ('.db_squote($values['login']).', '.db_squote(EncodePassword($newpassword)).', '.db_squote($values['email']).', '.$regGroup.", '".$add_time."', '')");
+                $userid = $mysql->result('select LAST_INSERT_ID()');
+                $tvars['vars'] = [
+                    'login'    => $values['login'],
+                    'home'     => home,
+                    'password' => $newpassword,
+                ];
+                $tvars['regx'] = [
+                    '#\[activation\].+?\[\/activation]#is' => '',
+                ];
+                $tpl->template('register', GetPluginLangDir('auth_basic'));
+                $tpl->vars('register', $tvars);
+                $msg = $tpl->show('register');
+                sendEmailMessage(
+                    $values['email'],
+                    $lang['letter_title'],
+                    $msg,
+                    false,
+                    false,
+                    'html'
+                );
+                msg([
+                    'text' => $lang['msgo_registered'],
+                    'info' => str_replace(['{login}', '{password}', '{email}'], [$values['login'], $newpassword, $values['email']], $lang['auth_reg.success1']),
+                ]);
+                break;
+            // 2 - С подтверждением [автогенерация пароля, пароль отправляется на email адрес и не показывается в админке]
+            case 2:
+                // New password
+                $newpassword = MakeRandomPassword();
+                // Random activation code
+                $actcode = MakeRandomPassword();
+                // Insert into DB
+                $mysql->query('INSERT INTO '.uprefix.'_users (name, pass, mail, status, reg, last, activation) VALUES ('.db_squote($values['login']).', '.db_squote(EncodePassword($newpassword)).', '.db_squote($values['email']).', '.$regGroup.", '".$add_time."', '', ".db_squote($actcode).')');
+                $userid = $mysql->result('select LAST_INSERT_ID()');
+                $link = generatePluginLink('core', 'activation', ['userid' => $userid, 'code' => $actcode], [], false, true);
+                $tvars['vars'] = [
+                    'login'        => $values['login'],
+                    'home'         => home,
+                    'password'     => $newpassword,
+                    'activate_url' => $link,
+                ];
+                $tvars['regx'] = [
+                    '#\[activation\](.+?)\[\/activation]#is' => '$1',
+                ];
+                $tpl->template('register', GetPluginLangDir('auth_basic'));
+                $tpl->vars('register', $tvars);
+                $msg = $tpl->show('register');
+                sendEmailMessage(
+                    $values['email'],
+                    $lang['letter_title'],
+                    $msg,
+                    'html'
+                );
+                msg([
+                    'text' => $lang['msgo_registered'],
+                    'info' => str_replace(['{login}', '{password}', '{email}'], [$values['login'], $newpassword, $values['email']], $lang['auth_reg.success2']),
+                ]);
+                break;
+            // 3 - Ручная с нотификацией [ручная генерация пароля, email нотификация]
+            case 3:
+                $mysql->query('INSERT INTO '.uprefix.'_users (name, pass, mail, status, reg, last) VALUES ('.db_squote($values['login']).', '.db_squote(EncodePassword($values['password'])).', '.db_squote($values['email']).', '.$regGroup.", '".$add_time."', '')");
+                $userid = $mysql->result('select LAST_INSERT_ID()');
+                $tvars['vars'] = [
+                    'login'    => $values['login'],
+                    'home'     => home,
+                    'password' => $values['password'],
+                ];
+                $tvars['regx'] = [
+                    '#\[activation\].+?\[\/activation]#is' => '',
+                ];
+                $tpl->template('register', GetPluginLangDir('auth_basic'));
+                $tpl->vars('register', $tvars);
+                $msg = $tpl->show('register');
+                sendEmailMessage(
+                    $values['email'],
+                    $lang['letter_title'],
+                    $msg,
+                    'html'
+                );
+                msg([
+                    'text' => $lang['msgo_registered'],
+                    'info' => str_replace(['{login}', '{password}', '{email}'], [$values['login'], $values['password'], $values['email']], $lang['auth_reg.success3']),
+                ]);
+                break;
+            // 4 - Ручная с подтверждением [ручная генерация пароля, подтверждение email адреса]
+            case 4:
+                $actcode = MakeRandomPassword();
+                $mysql->query('INSERT INTO '.uprefix.'_users (name, pass, mail, status, reg, last, activation) VALUES ('.db_squote($values['login']).', '.db_squote(EncodePassword($values['password'])).', '.db_squote($values['email']).', '.$regGroup.", '".$add_time."', '', ".db_squote($actcode).')');
+                $userid = $mysql->result('select LAST_INSERT_ID()');
+                $link = generatePluginLink('core', 'activation', ['userid' => $userid, 'code' => $actcode], [], false, true);
+                $tvars['vars'] = [
+                    'login'        => $values['login'],
+                    'home'         => home,
+                    'password'     => $values['password'],
+                    'activate_url' => $link,
+                ];
+                $tvars['regx'] = [
+                    '#\[activation\](.+?)\[\/activation]#is' => '$1',
+                ];
+                $tpl->template('register', GetPluginLangDir('auth_basic'));
+                $tpl->vars('register', $tvars);
+                $msg = $tpl->show('register');
+                sendEmailMessage(
+                    $values['email'],
+                    $lang['letter_title'],
+                    $msg,
+                    'html'
+                );
+                msg([
+                    'text' => $lang['msgo_registered'],
+                    'info' => str_replace(['{login}', '{password}', '{email}'], [$values['login'], $values['password'], $values['email']], $lang['auth_reg.success4']),
+                ]);
+            //print "<pre>".var_export($lang, true)."</pre>";
+        }
 
-		global $config, $mysql, $lang, $tpl;
-		LoadPluginLang('auth_basic', 'auth', '', 'auth');
-		$error = 0;
-		$userid = 0;
-		$values['login'] = trim($values['login']);
-		// Preprocess login
-		if (strlen($values['login']) < 3) {
-			// Слишком короткий логин
-			$msg = $lang['auth_login_short'];
+        return ($userid > 0) ? $userid : 1;
+    }
 
-			return 0;
-		}
-		// Проверяем логин на запрещенные символы
-		$csError = false;
-		switch (pluginGetVariable('auth_basic', 'regcharset')) {
-			case 0:
-				if (!preg_match('#^[A-Za-z0-9\.\_\-]+$#s', $values['login'])) {
-					$csError = true;
-				}
-				break;
-			case 1:
-				if (!preg_match('#^[А-Яа-яёЁ0-9\.\_\-]+$#s', $values['login'])) {
-					$csError = true;
-				}
-				break;
-			case 2:
-				if (!preg_match('#^[А-Яа-яёЁA-Za-z0-9\.\_\-]+$#s', $values['login'])) {
-					print "CASE2-err [" . $values['login'] . "]";
-					$csError = true;
-				}
-				break;
-			case 3:
-				if (!preg_match('#^[\x21-\x7e\xc0-\xffёЁ]+$#s', $values['login'])) {
-					$csError = true;
-				}
-				break;
-			case 4:
-				break;
-		}
-		if (preg_match('/[&<>\\"' . "'" . ']/', $values['login']) || $csError) {
-			// Запрещенные HTML символы
-			$msg = $lang['auth_login_html'];
+    //
+    // Вернуть массив параметров, необходимых для восстановления пароля
+    public function get_restorepw_params()
+    {
+        global $config, $lang;
+        $params = [];
+        LoadPluginLang('auth_basic', 'auth', '', 'auth');
+        $mode = pluginGetVariable('auth_basic', 'restorepw');
+        if (!$mode) {
+            return false;
+            //array_push($params, array('text' => $lang['auth_norestore']));
+            //return $params;
+        }
+        array_push($params, ['text' => $lang['auth_restore_'.$mode]]);
+        if ($mode != 'email') {
+            array_push($params, ['name' => 'login', title => $lang['auth_login'], 'type' => 'input']);
+        }
+        if ($mode != 'login') {
+            array_push($params, ['name' => 'email', title => $lang['auth_email'], 'type' => 'input']);
+        }
 
-			return 0;
-		}
-		if ($config['register_type'] >= 3) {
-			if (strlen($values['password']) < 3) {
-				// Слишком короткий пароль
-				$msg = $lang['auth_pass_short'];
+        return $params;
+    }
 
-				return 0;
-			} else if ($values['password'] != $values['password2']) {
-				// Несовпадение паролей
-				$msg = $lang['auth_pass_diff'];
+    //
+    // Восстановить пароль
+    public function restorepw(&$params, $values, &$msg)
+    {
+        global $config, $mysql, $lang, $tpl;
+        $error = 0;
+        $values['login'] = trim($values['login']);
+        $values['email'] = trim($values['email']);
+        LoadPluginLang('auth_basic', 'auth', '', 'auth');
+        $mode = pluginGetVariable('auth_basic', 'restorepw');
+        if (!$mode) {
+            $msg = $lang['auth_norestore'];
 
-				return 0;
-			}
-		}
-		if ((strlen($values['email']) > 70) || (!preg_match("/^[\.A-z0-9_\-]+[@][A-z0-9_\-]+([.][A-z0-9_\-]+)+[A-z]{1,4}$/", $values['email']))) {
-			// Неверный email
-			$msg = $lang['auth_email_wrong'];
+            return 0;
+        }
+        $px = [];
+        if ($mode != 'email') {
+            if (!$values['login']) {
+                $msg = $lang['auth_login_require'];
 
-			return 0;
-		}
-		$row = $mysql->record("select * from " . uprefix . "_users where lower(name)=" . db_squote(strtolower($values['login'])) . " or mail=" . db_squote($values['email']));
-		if (is_array($row)) {
-			// Дублирование логина/email'а
-			if (strtolower($row['mail']) == strtolower($values['email'])) {
-				// email dup
-				$msg = $lang['auth_email_dup'];
+                return 0;
+            }
+            array_push($px, 'name = '.db_squote($values['login']));
+        }
+        if ($mode != 'login') {
+            if (!$values['email']) {
+                $msg = $lang['auth_email_require'];
 
-				return 0;
-			}
-			// Если не мыло, то логин
-			$msg = $lang['auth_login_dup'];
+                return 0;
+            }
+            array_push($px, 'mail = '.db_squote($values['email']));
+        }
+        $query = 'select * from '.uprefix.'_users where '.implode(' and ', $px);
+        $row = $mysql->record($query);
+        if (is_array($row)) {
+            // Нашли юзера
+            $newpassword = MakeRandomPassword();
+            $mysql->query('UPDATE '.uprefix.'_users SET newpw='.db_squote(EncodePassword($newpassword)).' WHERE id='.$row['id']);
+            $tvars['vars'] = [
+                'login' => $row['name'],
+                'home'  => home,
+                'newpw' => $newpassword,
+            ];
+            $tvars['vars']['pwurl'] = generatePluginLink('core', 'lostpassword', ['userid' => $row['id'], 'code' => EncodePassword($newpassword)], [], false, true);
+            $tpl->template('restorepw', GetPluginLangDir('auth_basic'));
+            $tpl->vars('restorepw', $tvars);
+            sendEmailMessage($row['mail'], $lang['auth_mail_subj'], $tpl->show('restorepw'));
+            msg(['text' => $lang['msgo_sent']]);
 
-			return 0;
-		}
-		// Всё в порядке, регим
-		$add_time = time() + ($config['date_adjust'] * 60);
-		// Статус пользователя по умолчанию
-		$regGroup = intval(pluginGetVariable('auth_basic', 'regstatus'));
-		if (!isset($UGROUP[$regGroup])) {
-			// If GROUP is not defined - set "4" as default
-			$regGroup = 4; // Commenter
-		}
-		// Определяем действия в зависимости от типа регистрации
-		switch ($config['register_type']) {
-			// 0 - Мгновенная [автогенерация пароля, без email нотификации]
-			case 0:
-				$newpassword = MakeRandomPassword();
-				$mysql->query("INSERT INTO " . uprefix . "_users (name, pass, mail, status, reg, last) VALUES (" . db_squote($values['login']) . ", " . db_squote(EncodePassword($newpassword)) . ", " . db_squote($values['email']) . ", " . $regGroup . ", '" . $add_time . "', '')");
-				$userid = $mysql->result('select LAST_INSERT_ID()');
-				msg(array(
-					"text" => $lang['msgo_registered'],
-					"info" => str_replace(array('{login}', '{password}'), array($values['login'], $newpassword), $lang['auth_reg.success0'])
-				));
-				break;
-			// 1 - Простая [автогенерация пароля, с email нотификацией]
-			case 1:
-				$newpassword = MakeRandomPassword();
-				$mysql->query("INSERT INTO " . uprefix . "_users (name, pass, mail, status, reg, last) VALUES (" . db_squote($values['login']) . ", " . db_squote(EncodePassword($newpassword)) . ", " . db_squote($values['email']) . ", " . $regGroup . ", '" . $add_time . "', '')");
-				$userid = $mysql->result('select LAST_INSERT_ID()');
-				$tvars['vars'] = array(
-					'login'    => $values['login'],
-					'home'     => home,
-					'password' => $newpassword
-				);
-				$tvars['regx'] = array(
-					'#\[activation\].+?\[\/activation]#is' => '',
-				);
-				$tpl->template('register', GetPluginLangDir('auth_basic'));
-				$tpl->vars('register', $tvars);
-				$msg = $tpl->show('register');
-				sendEmailMessage(
-					$values['email'],
-					$lang['letter_title'],
-					$msg,
-					false,
-					false,
-					'html'
-				);
-				msg(array(
-					"text" => $lang['msgo_registered'],
-					"info" => str_replace(array('{login}', '{password}', '{email}'), array($values['login'], $newpassword, $values['email']), $lang['auth_reg.success1'])
-				));
-				break;
-			// 2 - С подтверждением [автогенерация пароля, пароль отправляется на email адрес и не показывается в админке]
-			case 2:
-				// New password
-				$newpassword = MakeRandomPassword();
-				// Random activation code
-				$actcode = MakeRandomPassword();
-				// Insert into DB
-				$mysql->query("INSERT INTO " . uprefix . "_users (name, pass, mail, status, reg, last, activation) VALUES (" . db_squote($values['login']) . ", " . db_squote(EncodePassword($newpassword)) . ", " . db_squote($values['email']) . ", " . $regGroup . ", '" . $add_time . "', '', " . db_squote($actcode) . ")");
-				$userid = $mysql->result('select LAST_INSERT_ID()');
-				$link = generatePluginLink('core', 'activation', array('userid' => $userid, 'code' => $actcode), array(), false, true);
-				$tvars['vars'] = array(
-					'login'        => $values['login'],
-					'home'         => home,
-					'password'     => $newpassword,
-					'activate_url' => $link,
-				);
-				$tvars['regx'] = array(
-					'#\[activation\](.+?)\[\/activation]#is' => '$1',
-				);
-				$tpl->template('register', GetPluginLangDir('auth_basic'));
-				$tpl->vars('register', $tvars);
-				$msg = $tpl->show('register');
-				sendEmailMessage(
-					$values['email'],
-					$lang['letter_title'],
-					$msg,
-					'html'
-				);
-				msg(array(
-					"text" => $lang['msgo_registered'],
-					"info" => str_replace(array('{login}', '{password}', '{email}'), array($values['login'], $newpassword, $values['email']), $lang['auth_reg.success2'])
-				));
-				break;
-			// 3 - Ручная с нотификацией [ручная генерация пароля, email нотификация]
-			case 3:
-				$mysql->query("INSERT INTO " . uprefix . "_users (name, pass, mail, status, reg, last) VALUES (" . db_squote($values['login']) . ", " . db_squote(EncodePassword($values['password'])) . ", " . db_squote($values['email']) . ", " . $regGroup . ", '" . $add_time . "', '')");
-				$userid = $mysql->result('select LAST_INSERT_ID()');
-				$tvars['vars'] = array(
-					'login'    => $values['login'],
-					'home'     => home,
-					'password' => $values['password']
-				);
-				$tvars['regx'] = array(
-					'#\[activation\].+?\[\/activation]#is' => '',
-				);
-				$tpl->template('register', GetPluginLangDir('auth_basic'));
-				$tpl->vars('register', $tvars);
-				$msg = $tpl->show('register');
-				sendEmailMessage(
-					$values['email'],
-					$lang['letter_title'],
-					$msg,
-					'html'
-				);
-				msg(array(
-					"text" => $lang['msgo_registered'],
-					"info" => str_replace(array('{login}', '{password}', '{email}'), array($values['login'], $values['password'], $values['email']), $lang['auth_reg.success3'])
-				));
-				break;
-			// 4 - Ручная с подтверждением [ручная генерация пароля, подтверждение email адреса]
-			case 4:
-				$actcode = MakeRandomPassword();
-				$mysql->query("INSERT INTO " . uprefix . "_users (name, pass, mail, status, reg, last, activation) VALUES (" . db_squote($values['login']) . ", " . db_squote(EncodePassword($values['password'])) . ", " . db_squote($values['email']) . ", " . $regGroup . ", '" . $add_time . "', '', " . db_squote($actcode) . ")");
-				$userid = $mysql->result('select LAST_INSERT_ID()');
-				$link = generatePluginLink('core', 'activation', array('userid' => $userid, 'code' => $actcode), array(), false, true);
-				$tvars['vars'] = array(
-					'login'        => $values['login'],
-					'home'         => home,
-					'password'     => $values['password'],
-					'activate_url' => $link
-				);
-				$tvars['regx'] = array(
-					'#\[activation\](.+?)\[\/activation]#is' => '$1',
-				);
-				$tpl->template('register', GetPluginLangDir('auth_basic'));
-				$tpl->vars('register', $tvars);
-				$msg = $tpl->show('register');
-				sendEmailMessage(
-					$values['email'],
-					$lang['letter_title'],
-					$msg,
-					'html'
-				);
-				msg(array(
-					"text" => $lang['msgo_registered'],
-					"info" => str_replace(array('{login}', '{password}', '{email}'), array($values['login'], $values['password'], $values['email']), $lang['auth_reg.success4'])
-				));
-			//print "<pre>".var_export($lang, true)."</pre>";
-		}
+            return 1;
+        } else {
+            $msg = $lang['auth_nouser'];
 
-		return ($userid > 0) ? $userid : 1;
-	}
+            return 0;
+        }
+    }
 
-	//
-	// Вернуть массив параметров, необходимых для восстановления пароля
-	function get_restorepw_params() {
+    // AJAX call - online check registration parameters for correct valuescheck if login is available
+    // Input:
+    // $params - array of 'fieldName' => 'fieldValue' for checking
+    // Returns:
+    // $result - array of 'fieldName' => status
+    // List of statuses:
+    // 0	- Method not implemented [ this field is not checked/can't be checked/... ] OR NOT SET
+    // 1	- Occupied
+    // 2	- Incorrect length
+    // 3	- Incorrect format
+    // 100	- Available for registration
+    public function onlineCheckRegistration($params)
+    {
+        global $config, $mysql;
+        // Prepare basic reply array
+        $results = [];
+        // Check for login
+        if (isset($params['login'])) {
+            $params['login'] = iconv('UTF-8', 'Windows-1251', trim($params['login']));
+            // Check for incorrect chars
+            if (strlen($params['login']) < 3) {
+                // Login is too short
+                $results['login'] = 2;
+                goto endLoginCheck;
+            }
+            // Check for incorrect chars
+            $csError = false;
+            switch (pluginGetVariable('auth_basic', 'regcharset')) {
+                case 0:
+                    if (!preg_match('#^[A-Za-z0-9\.\_\-]+$#s', $params['login'])) {
+                        $csError = true;
+                    }
+                    break;
+                case 1:
+                    if (!preg_match('#^[А-Яа-яёЁ0-9\.\_\-]+$#s', $params['login'])) {
+                        $csError = true;
+                    }
+                    break;
+                case 2:
+                    if (!preg_match('#^[А-Яа-яёЁA-Za-z0-9\.\_\-]+$#s', $params['login'])) {
+                        echo 'CASE2-err ['.$params['login'].']';
+                        $csError = true;
+                    }
+                    break;
+                case 3:
+                    if (!preg_match('#^[\x21-\x7e\xc0-\xffёЁ]+$#s', $params['login'])) {
+                        $csError = true;
+                    }
+                    break;
+                case 4:
+                    break;
+            }
+            if (preg_match('/[&<>\\"'."'".']/', $params['login']) || $csError) {
+                // Incorrect chars
+                $results['login'] = 3;
+                goto endLoginCheck;
+            }
+            // Check if login is occupied
+            $row = $mysql->record('select * from '.uprefix.'_users where lower(name)='.db_squote(strtolower($params['login'])));
+            if (is_array($row)) {
+                $results['login'] = 1;
+                goto endLoginCheck;
+            }
+            // All tests are passed, login can be used
+            $results['login'] = 100;
+        }
+        endLoginCheck:
+        // Check for email
+        if (isset($params['email'])) {
+            $params['email'] = trim($params['email']);
+            if (strlen($params['email']) > 70) {
+                $results['email'] = 2;
+                goto endEmailCheck;
+            }
+            if (!preg_match("/^[\.A-z0-9_\-]+[@][A-z0-9_\-]+([.][A-z0-9_\-]+)+[A-z]{1,4}$/", $params['email'])) {
+                $results['email'] = 3;
+                // Неверный email
+                goto endEmailCheck;
+            }
+            $row = $mysql->record('select * from '.uprefix.'_users where lower(mail)='.db_squote($params['email']));
+            if (is_array($row)) {
+                $results['email'] = 1;
+                goto endEmailCheck;
+            }
+            // All tests are passed, email can be used
+            $results['email'] = 100;
+        }
+        endEmailCheck:
 
-		global $config, $lang;
-		$params = array();
-		LoadPluginLang('auth_basic', 'auth', '', 'auth');
-		$mode = pluginGetVariable('auth_basic', 'restorepw');
-		if (!$mode) {
-			return false;
-			//array_push($params, array('text' => $lang['auth_norestore']));
-			//return $params;
-		}
-		array_push($params, array('text' => $lang['auth_restore_' . $mode]));
-		if ($mode != 'email') {
-			array_push($params, array('name' => 'login', title => $lang['auth_login'], 'type' => 'input'));
-		}
-		if ($mode != 'login') {
-			array_push($params, array('name' => 'email', title => $lang['auth_email'], 'type' => 'input'));
-		}
+        // Return
+        return $results;
+    }
 
-		return $params;
-	}
+    //
+    // Подтверждение восстановления пароля
+    //
+    public function confirm_restorepw(&$msg, $reqid = null, $reqsecret = null)
+    {
+        global $config, $mysql, $lang, $tpl;
+        LoadPluginLang('auth_basic', 'auth', '', 'auth');
+        $row = $mysql->record('select * from '.uprefix.'_users where id = '.db_squote($reqid));
+        if (is_array($row)) {
+            if ($reqsecret == $row['newpw']) {
+                // OK !!!
+                $msg = $lang['auth_newpw_ok'];
+                $mysql->query('update '.uprefix.'_users set pass=newpw where id = '.db_squote($reqid));
 
-	//
-	// Восстановить пароль
-	function restorepw(&$params, $values, &$msg) {
+                return 1;
+            }
+        }
+        $msg = $lang['auth_newpw_fail'];
 
-		global $config, $mysql, $lang, $tpl;
-		$error = 0;
-		$values['login'] = trim($values['login']);
-		$values['email'] = trim($values['email']);
-		LoadPluginLang('auth_basic', 'auth', '', 'auth');
-		$mode = pluginGetVariable('auth_basic', 'restorepw');
-		if (!$mode) {
-			$msg = $lang['auth_norestore'];
-
-			return 0;
-		}
-		$px = array();
-		if ($mode != 'email') {
-			if (!$values['login']) {
-				$msg = $lang['auth_login_require'];
-
-				return 0;
-			}
-			array_push($px, "name = " . db_squote($values['login']));
-		}
-		if ($mode != 'login') {
-			if (!$values['email']) {
-				$msg = $lang['auth_email_require'];
-
-				return 0;
-			}
-			array_push($px, "mail = " . db_squote($values['email']));
-		}
-		$query = "select * from " . uprefix . "_users where " . implode(' and ', $px);
-		$row = $mysql->record($query);
-		if (is_array($row)) {
-			// Нашли юзера
-			$newpassword = MakeRandomPassword();
-			$mysql->query("UPDATE " . uprefix . "_users SET newpw=" . db_squote(EncodePassword($newpassword)) . " WHERE id=" . $row['id']);
-			$tvars['vars'] = array(
-				'login' => $row['name'],
-				'home'  => home,
-				'newpw' => $newpassword
-			);
-			$tvars['vars']['pwurl'] = generatePluginLink('core', 'lostpassword', array('userid' => $row['id'], 'code' => EncodePassword($newpassword)), array(), false, true);
-			$tpl->template('restorepw', GetPluginLangDir('auth_basic'));
-			$tpl->vars('restorepw', $tvars);
-			sendEmailMessage($row['mail'], $lang['auth_mail_subj'], $tpl->show('restorepw'));
-			msg(array("text" => $lang['msgo_sent']));
-
-			return 1;
-		} else {
-			$msg = $lang['auth_nouser'];
-
-			return 0;
-		}
-	}
-
-	// AJAX call - online check registration parameters for correct valuescheck if login is available
-	// Input:
-	// $params - array of 'fieldName' => 'fieldValue' for checking
-	// Returns:
-	// $result - array of 'fieldName' => status
-	// List of statuses:
-	// 0	- Method not implemented [ this field is not checked/can't be checked/... ] OR NOT SET
-	// 1	- Occupied
-	// 2	- Incorrect length
-	// 3	- Incorrect format
-	// 100	- Available for registration
-	function onlineCheckRegistration($params) {
-
-		global $config, $mysql;
-		// Prepare basic reply array
-		$results = array();
-		// Check for login
-		if (isset($params['login'])) {
-			$params['login'] = iconv('UTF-8', 'Windows-1251', trim($params['login']));
-			// Check for incorrect chars
-			if (strlen($params['login']) < 3) {
-				// Login is too short
-				$results['login'] = 2;
-				goto endLoginCheck;
-			}
-			// Check for incorrect chars
-			$csError = false;
-			switch (pluginGetVariable('auth_basic', 'regcharset')) {
-				case 0:
-					if (!preg_match('#^[A-Za-z0-9\.\_\-]+$#s', $params['login'])) {
-						$csError = true;
-					}
-					break;
-				case 1:
-					if (!preg_match('#^[А-Яа-яёЁ0-9\.\_\-]+$#s', $params['login'])) {
-						$csError = true;
-					}
-					break;
-				case 2:
-					if (!preg_match('#^[А-Яа-яёЁA-Za-z0-9\.\_\-]+$#s', $params['login'])) {
-						print "CASE2-err [" . $params['login'] . "]";
-						$csError = true;
-					}
-					break;
-				case 3:
-					if (!preg_match('#^[\x21-\x7e\xc0-\xffёЁ]+$#s', $params['login'])) {
-						$csError = true;
-					}
-					break;
-				case 4:
-					break;
-			}
-			if (preg_match('/[&<>\\"' . "'" . ']/', $params['login']) || $csError) {
-				// Incorrect chars
-				$results['login'] = 3;
-				goto endLoginCheck;
-			}
-			// Check if login is occupied
-			$row = $mysql->record("select * from " . uprefix . "_users where lower(name)=" . db_squote(strtolower($params['login'])));
-			if (is_array($row)) {
-				$results['login'] = 1;
-				goto endLoginCheck;
-			}
-			// All tests are passed, login can be used
-			$results['login'] = 100;
-		}
-		endLoginCheck:
-		// Check for email
-		if (isset($params['email'])) {
-			$params['email'] = trim($params['email']);
-			if (strlen($params['email']) > 70) {
-				$results['email'] = 2;
-				goto endEmailCheck;
-			}
-			if (!preg_match("/^[\.A-z0-9_\-]+[@][A-z0-9_\-]+([.][A-z0-9_\-]+)+[A-z]{1,4}$/", $params['email'])) {
-				$results['email'] = 3;
-				// Неверный email
-				goto endEmailCheck;
-			}
-			$row = $mysql->record("select * from " . uprefix . "_users where lower(mail)=" . db_squote($params['email']));
-			if (is_array($row)) {
-				$results['email'] = 1;
-				goto endEmailCheck;
-			}
-			// All tests are passed, email can be used
-			$results['email'] = 100;
-		}
-		endEmailCheck:
-
-		// Return
-		return $results;
-	}
-
-
-	//
-	// Подтверждение восстановления пароля
-	//
-	function confirm_restorepw(&$msg, $reqid = null, $reqsecret = null) {
-
-		global $config, $mysql, $lang, $tpl;
-		LoadPluginLang('auth_basic', 'auth', '', 'auth');
-		$row = $mysql->record("select * from " . uprefix . "_users where id = " . db_squote($reqid));
-		if (is_array($row)) {
-			if ($reqsecret == $row['newpw']) {
-				// OK !!!
-				$msg = $lang['auth_newpw_ok'];
-				$mysql->query('update ' . uprefix . '_users set pass=newpw where id = ' . db_squote($reqid));
-
-				return 1;
-			}
-		}
-		$msg = $lang['auth_newpw_fail'];
-
-		return 0;
-	}
+        return 0;
+    }
 }
 
-$AUTH_METHOD['basic'] = new auth_basic;
-$AUTH_CAPABILITIES['basic'] = array('login' => '1', 'db' => '1');
+$AUTH_METHOD['basic'] = new auth_basic();
+$AUTH_CAPABILITIES['basic'] = ['login' => '1', 'db' => '1'];
 if (pluginGetVariable('auth_basic', 'en_dbprefix')) {
-	$config['uprefix'] = pluginGetVariable('auth_basic', 'dbprefix');
+    $config['uprefix'] = pluginGetVariable('auth_basic', 'dbprefix');
 }

--- a/auth_basic/config.php
+++ b/auth_basic/config.php
@@ -1,6 +1,9 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
@@ -12,38 +15,37 @@ LoadPluginLang('auth_basic', 'config', '', 'auth', ':');
 // Default user group for new users
 $regGroup = intval(pluginGetVariable('auth_basic', 'regstatus'));
 if (!isset($UGROUP[$regGroup])) {
-	// If GROUP is not defined - set "4" as default
-	$regGroup = 4; // Commenter
+    // If GROUP is not defined - set "4" as default
+    $regGroup = 4; // Commenter
 }
-$groupOptions = array();
+$groupOptions = [];
 foreach ($UGROUP as $k => $v) {
-	$groupOptions[$k] = $k . ' - ' . $v['name'];
+    $groupOptions[$k] = $k.' - '.$v['name'];
 }
 $lastupdate = intval(pluginGetVariable('auth_basic', 'lastupdate'));
 if ($lastupdate < 1) {
-	$lastupdate = '';
+    $lastupdate = '';
 }
 // Fill configuration parameters
-$cfg = array();
-$cfgX = array();
-array_push($cfg, array('descr' => $lang['auth:description']));
-array_push($cfgX, array('name' => 'lastupdate', 'title' => $lang['auth:lastupdate'], 'descr' => $lang['auth:lastupdate_descr'], 'type' => 'input', value => $lastupdate));
-array_push($cfgX, array('name' => 'regstatus', 'title' => $lang['auth:regstatus'], 'descr' => $lang['auth:regstatus_descr'], 'type' => 'select', 'values' => $groupOptions, value => $regGroup));
-array_push($cfgX, array('name' => 'restorepw', 'title' => $lang['auth:restorepw'], 'descr' => $lang['auth:restorepw_descr'], 'type' => 'select', 'values' => array('0' => $lang['auth:restore_disabled'], 'login' => $lang['auth:restore_login'], 'email' => $lang['auth:restore_email'], 'both' => $lang['auth:restore_both']), value => pluginGetVariable('auth_basic', 'restorepw')));
-array_push($cfgX, array('name' => 'regcharset', 'title' => $lang['auth:regcharset'], 'descr' => $lang['auth:regcharset_descr'], 'type' => 'select', 'values' => array('0' => 'Eng', '1' => 'Rus', '2' => 'Eng+Rus', '3' => 'All'), value => pluginGetVariable('auth_basic', 'regcharset')));
-array_push($cfgX, array('name' => 'iplock', 'title' => $lang['auth:iplock'], 'descr' => $lang['auth:iplock_descr'], 'type' => 'select', 'values' => array('0' => $lang['noa'], '1' => $lang['yesa']), value => pluginGetVariable('auth_basic', 'iplock')));
-array_push($cfgX, array('name' => 'multilogin', 'title' => $lang['auth:multilogin'], 'descr' => $lang['auth:multilogin_descr'], 'type' => 'select', 'values' => array('0' => $lang['noa'], '1' => $lang['yesa']), value => pluginGetVariable('auth_basic', 'multilogin')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>' . $lang['auth:block.main'] . '</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'en_dbprefix', 'title' => $lang['auth:en_dbprefix'], 'descr' => $lang['auth:en_dbprefix_descr'], 'type' => 'checkbox', value => pluginGetVariable('auth_basic', 'en_dbprefix')));
-array_push($cfgX, array('name' => 'dbprefix', 'title' => $lang['auth:dbprefix'], 'descr' => $lang['auth:dbprefix_descr'], 'type' => 'input', value => pluginGetVariable('auth_basic', 'dbprefix')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>' . $lang['auth:block.uprefix'] . '</b>', 'entries' => $cfgX));
+$cfg = [];
+$cfgX = [];
+array_push($cfg, ['descr' => $lang['auth:description']]);
+array_push($cfgX, ['name' => 'lastupdate', 'title' => $lang['auth:lastupdate'], 'descr' => $lang['auth:lastupdate_descr'], 'type' => 'input', value => $lastupdate]);
+array_push($cfgX, ['name' => 'regstatus', 'title' => $lang['auth:regstatus'], 'descr' => $lang['auth:regstatus_descr'], 'type' => 'select', 'values' => $groupOptions, value => $regGroup]);
+array_push($cfgX, ['name' => 'restorepw', 'title' => $lang['auth:restorepw'], 'descr' => $lang['auth:restorepw_descr'], 'type' => 'select', 'values' => ['0' => $lang['auth:restore_disabled'], 'login' => $lang['auth:restore_login'], 'email' => $lang['auth:restore_email'], 'both' => $lang['auth:restore_both']], value => pluginGetVariable('auth_basic', 'restorepw')]);
+array_push($cfgX, ['name' => 'regcharset', 'title' => $lang['auth:regcharset'], 'descr' => $lang['auth:regcharset_descr'], 'type' => 'select', 'values' => ['0' => 'Eng', '1' => 'Rus', '2' => 'Eng+Rus', '3' => 'All'], value => pluginGetVariable('auth_basic', 'regcharset')]);
+array_push($cfgX, ['name' => 'iplock', 'title' => $lang['auth:iplock'], 'descr' => $lang['auth:iplock_descr'], 'type' => 'select', 'values' => ['0' => $lang['noa'], '1' => $lang['yesa']], value => pluginGetVariable('auth_basic', 'iplock')]);
+array_push($cfgX, ['name' => 'multilogin', 'title' => $lang['auth:multilogin'], 'descr' => $lang['auth:multilogin_descr'], 'type' => 'select', 'values' => ['0' => $lang['noa'], '1' => $lang['yesa']], value => pluginGetVariable('auth_basic', 'multilogin')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>'.$lang['auth:block.main'].'</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'en_dbprefix', 'title' => $lang['auth:en_dbprefix'], 'descr' => $lang['auth:en_dbprefix_descr'], 'type' => 'checkbox', value => pluginGetVariable('auth_basic', 'en_dbprefix')]);
+array_push($cfgX, ['name' => 'dbprefix', 'title' => $lang['auth:dbprefix'], 'descr' => $lang['auth:dbprefix_descr'], 'type' => 'input', value => pluginGetVariable('auth_basic', 'dbprefix')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>'.$lang['auth:block.uprefix'].'</b>', 'entries' => $cfgX]);
 // RUN
 if ($_REQUEST['action'] == 'commit') {
-	// If submit requested, do config save
-	commit_plugin_config_changes('auth_basic', $cfg);
-	print_commit_complete('auth_basic');
+    // If submit requested, do config save
+    commit_plugin_config_changes('auth_basic', $cfg);
+    print_commit_complete('auth_basic');
 } else {
-	generate_config_page('auth_basic', $cfg);
+    generate_config_page('auth_basic', $cfg);
 }
-

--- a/auth_basic/install.php
+++ b/auth_basic/install.php
@@ -1,37 +1,41 @@
 <?php
-if (!defined('NGCMS')) die ('HAL');
-function plugin_auth_basic_install($action) {
 
-	global $lang;
-	if ($action != 'autoapply')
-		loadPluginLang('auth_basic', 'config', '', '', ':');
-	$db_update = array(
-		array(
-			'table'  => 'users_sessions',
-			'action' => 'cmodify',
-			'key'    => 'KEY `userUpdate` (`userID`, `authcookie`), KEY `users_auth` (`authcookie`)',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'userID', 'type' => 'int(10)', 'params' => 'NOT NULL'),
-				array('action' => 'cmodify', 'name' => 'ip', 'type' => 'varchar(15)', 'params' => 'NOT NULL default "0"'),
-				array('action' => 'cmodify', 'name' => 'last', 'type' => 'int(10)', 'params' => 'NOT NULL default "0"'),
-				array('action' => 'cmodify', 'name' => 'authcookie', 'type' => 'varchar(50)', 'params' => 'default NULL'),
-			)
-		),
-	);
-	// Apply requested action
-	switch ($action) {
-		case 'confirm':
-			generate_install_page('auth_basic', $lang['auth_basic:description']);
-			break;
-		case 'autoapply':
-		case 'apply':
-			if (fixdb_plugin_install('auth_basic', $db_update, 'install', ($action == 'autoapply') ? true : false)) {
-				plugin_mark_installed('auth_basic');
-			} else {
-				return false;
-			}
-			break;
-	}
+if (!defined('NGCMS')) {
+    die('HAL');
+}
+function plugin_auth_basic_install($action)
+{
+    global $lang;
+    if ($action != 'autoapply') {
+        loadPluginLang('auth_basic', 'config', '', '', ':');
+    }
+    $db_update = [
+        [
+            'table'  => 'users_sessions',
+            'action' => 'cmodify',
+            'key'    => 'KEY `userUpdate` (`userID`, `authcookie`), KEY `users_auth` (`authcookie`)',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'userID', 'type' => 'int(10)', 'params' => 'NOT NULL'],
+                ['action' => 'cmodify', 'name' => 'ip', 'type' => 'varchar(15)', 'params' => 'NOT NULL default "0"'],
+                ['action' => 'cmodify', 'name' => 'last', 'type' => 'int(10)', 'params' => 'NOT NULL default "0"'],
+                ['action' => 'cmodify', 'name' => 'authcookie', 'type' => 'varchar(50)', 'params' => 'default NULL'],
+            ],
+        ],
+    ];
+    // Apply requested action
+    switch ($action) {
+        case 'confirm':
+            generate_install_page('auth_basic', $lang['auth_basic:description']);
+            break;
+        case 'autoapply':
+        case 'apply':
+            if (fixdb_plugin_install('auth_basic', $db_update, 'install', ($action == 'autoapply') ? true : false)) {
+                plugin_mark_installed('auth_basic');
+            } else {
+                return false;
+            }
+            break;
+    }
 
-	return true;
+    return true;
 }

--- a/autokeys/autokeys.php
+++ b/autokeys/autokeys.php
@@ -1,49 +1,52 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 // Load library
-include_once(root . "/plugins/autokeys/lib/class.php");
+include_once root.'/plugins/autokeys/lib/class.php';
 
 // News filtering class
-class autoKeysNewsFilter extends NewsFilter {
+class autoKeysNewsFilter extends NewsFilter
+{
+    public function addNews(&$tvars, &$SQL)
+    {
+        if ($_POST['autokeys_generate'] == 1) {
+            $SQL['keywords'] = akeysGetKeys(['content' => $SQL['content'], 'title' => $SQL['title']]);
+        }
 
-	function addNews(&$tvars, &$SQL) {
+        return 1;
+    }
 
-		if ($_POST['autokeys_generate'] == 1) {
-			$SQL['keywords'] = akeysGetKeys(array('content' => $SQL['content'], 'title' => $SQL['title']));
-		}
+    public function editNews($newsID, $SQLold, &$SQLnew, &$tvars)
+    {
+        if ($_POST['autokeys_generate'] == 1) {
+            $SQLnew['keywords'] = akeysGetKeys(['content' => $SQLnew['content'], 'title' => $SQLnew['title']]);
+        }
 
-		return 1;
-	}
+        return 1;
+    }
 
-	function editNews($newsID, $SQLold, &$SQLnew, &$tvars) {
+    public function editNewsForm($newsID, $SQLold, &$tvars)
+    {
+        global $twig;
+        $tpath = locatePluginTemplates(['editnews'], 'autokeys', pluginGetVariable('autokeys', 'localsource'));
+        $xt = $twig->loadTemplate($tpath['editnews'].'/editnews.tpl');
+        $tvars['plugin']['autokeys'] = $xt->render(['flags' => ['checked' => pluginGetVariable('autokeys', 'activate_edit')]]);
 
-		if ($_POST['autokeys_generate'] == 1) {
-			$SQLnew['keywords'] = akeysGetKeys(array('content' => $SQLnew['content'], 'title' => $SQLnew['title']));
-		}
+        return 1;
+    }
 
-		return 1;
-	}
+    public function addNewsForm(&$tvars)
+    {
+        global $twig;
+        $tpath = locatePluginTemplates(['addnews'], 'autokeys', pluginGetVariable('autokeys', 'localsource'));
+        $xt = $twig->loadTemplate($tpath['addnews'].'/addnews.tpl');
+        $tvars['plugin']['autokeys'] = $xt->render(['flags' => ['checked' => pluginGetVariable('autokeys', 'activate_add')]]);
 
-	function editNewsForm($newsID, $SQLold, &$tvars) {
-
-		global $twig;
-		$tpath = locatePluginTemplates(array('editnews'), 'autokeys', pluginGetVariable('autokeys', 'localsource'));
-		$xt = $twig->loadTemplate($tpath['editnews'] . '/editnews.tpl');
-		$tvars['plugin']['autokeys'] = $xt->render(array('flags' => array('checked' => pluginGetVariable('autokeys', 'activate_edit'))));
-
-		return 1;
-	}
-
-	function addNewsForm(&$tvars) {
-
-		global $twig;
-		$tpath = locatePluginTemplates(array('addnews'), 'autokeys', pluginGetVariable('autokeys', 'localsource'));
-		$xt = $twig->loadTemplate($tpath['addnews'] . '/addnews.tpl');
-		$tvars['plugin']['autokeys'] = $xt->render(array('flags' => array('checked' => pluginGetVariable('autokeys', 'activate_add'))));
-
-		return 1;
-	}
+        return 1;
+    }
 }
 
-register_filter('news', 'autokeys', new autoKeysNewsFilter);
+register_filter('news', 'autokeys', new autoKeysNewsFilter());

--- a/autokeys/config.php
+++ b/autokeys/config.php
@@ -1,25 +1,26 @@
 <?php
+
 if (!defined('NGCMS')) {
-	die("Don't you figure you're so cool?");
+    die("Don't you figure you're so cool?");
 }
 plugins_load_config();
-$cfg = array();
-array_push($cfg, array('name' => 'activate_add', 'title' => 'Автоматическое создание при добавлении новости<br/><small><b>Да</b> - ключевые слова будут автоматически создаваться при добавлении новости', 'type' => 'select', values => array(0 => $lang['noa'], 1 => $lang['yesa']), value => pluginGetVariable('autokeys', 'activate_add')));
-array_push($cfg, array('name' => 'activate_edit', 'title' => 'Автоматическое пересоздание при изменении новости<br/><small><b>Да</b> - ключевые слова будут автоматически пересоздаваться при изменении новости', 'type' => 'select', values => array(0 => $lang['noa'], 1 => $lang['yesa']), value => pluginGetVariable('autokeys', 'activate_edit')));
-array_push($cfg, array('name' => 'length', 'title' => 'Минимальная длина слова', 'descr' => '(хороший вариант 5)', 'type' => 'input', 'html_flags' => 'style="width: 200px;"', 'value' => pluginGetVariable('autokeys', 'length')));
-array_push($cfg, array('name' => 'sub', 'title' => 'Максимальная длина слова', 'descr' => 'По умолчанию не ограничено', 'type' => 'input', 'html_flags' => 'style="width: 200px;"', 'value' => pluginGetVariable('autokeys', 'sub')));
-array_push($cfg, array('name' => 'occur', 'title' => 'Минимальное число повторений слова', 'descr' => '(хороший вариант 2)', 'type' => 'input', 'html_flags' => 'style="width: 200px;"', 'value' => pluginGetVariable('autokeys', 'occur')));
-array_push($cfg, array('name' => 'block_y', 'title' => '<b>Нежелательные слова</b>', 'descr' => 'включение/выключение опции', 'type' => 'select', values => array(0 => $lang['noa'], 1 => $lang['yesa']), value => pluginGetVariable('autokeys', 'block_y')));
-array_push($cfg, array('name' => 'block', 'title' => 'Список нежелательных слов<br><br><i>На каждой строке вводится по одноу слову. Слова из этого списка не будут попадать в keywords.</i>', 'type' => 'text', 'html_flags' => 'rows=8 cols=60', 'value' => pluginGetVariable('autokeys', 'block')));
-array_push($cfg, array('name' => 'good_y', 'title' => '<b>Желаемые слова</b>', 'descr' => 'включение/выключение опции', 'type' => 'select', values => array(0 => $lang['noa'], 1 => $lang['yesa']), value => pluginGetVariable('autokeys', 'good_y')));
-array_push($cfg, array('name' => 'good', 'title' => 'Список желаемых слов<br><br><i>На каждой строке вводится по одноу слову. Слова из этого всегда будут попадать в keywords.</i>', 'type' => 'text', 'html_flags' => 'rows=8 cols=60', 'value' => pluginGetVariable('autokeys', 'good')));
-array_push($cfg, array('name' => 'add_title', 'title' => 'Учитывать заголовок', 'descr' => 'Добавления заголовка новости к тексту новости для генерации ключевых слов<br />значение от 0 до бесконечности: <br />0 - не добавлять, 1 - добавлять, 2 - добавить два раза', 'type' => 'input', 'html_flags' => 'style="width: 200px;"', 'value' => pluginGetVariable('autokeys', 'add_title')));
-array_push($cfg, array('name' => 'sum', 'title' => 'Длина ключевых слов', 'descr' => 'Длина всех ключевых слов генерируемых плагином (По умолчанию <=245 симолов)', 'type' => 'input', 'html_flags' => 'style="width: 200px;"', 'value' => pluginGetVariable('autokeys', 'sum')));
-array_push($cfg, array('name' => 'count', 'title' => 'Количество ключевых слов', 'descr' => 'Количество ключевых слов генерируемых плагином (По умолчанию неограниченное количество)', 'type' => 'input', 'html_flags' => 'style="width: 200px;"', 'value' => pluginGetVariable('autokeys', 'count')));
-array_push($cfg, array('name' => 'good_b', 'title' => '<b>Усиление слов</b>', 'descr' => 'Усиление слов в теге [b]', 'type' => 'select', values => array(0 => $lang['noa'], 1 => $lang['yesa']), value => pluginGetVariable('autokeys', 'good_b')));
+$cfg = [];
+array_push($cfg, ['name' => 'activate_add', 'title' => 'Автоматическое создание при добавлении новости<br/><small><b>Да</b> - ключевые слова будут автоматически создаваться при добавлении новости', 'type' => 'select', values => [0 => $lang['noa'], 1 => $lang['yesa']], value => pluginGetVariable('autokeys', 'activate_add')]);
+array_push($cfg, ['name' => 'activate_edit', 'title' => 'Автоматическое пересоздание при изменении новости<br/><small><b>Да</b> - ключевые слова будут автоматически пересоздаваться при изменении новости', 'type' => 'select', values => [0 => $lang['noa'], 1 => $lang['yesa']], value => pluginGetVariable('autokeys', 'activate_edit')]);
+array_push($cfg, ['name' => 'length', 'title' => 'Минимальная длина слова', 'descr' => '(хороший вариант 5)', 'type' => 'input', 'html_flags' => 'style="width: 200px;"', 'value' => pluginGetVariable('autokeys', 'length')]);
+array_push($cfg, ['name' => 'sub', 'title' => 'Максимальная длина слова', 'descr' => 'По умолчанию не ограничено', 'type' => 'input', 'html_flags' => 'style="width: 200px;"', 'value' => pluginGetVariable('autokeys', 'sub')]);
+array_push($cfg, ['name' => 'occur', 'title' => 'Минимальное число повторений слова', 'descr' => '(хороший вариант 2)', 'type' => 'input', 'html_flags' => 'style="width: 200px;"', 'value' => pluginGetVariable('autokeys', 'occur')]);
+array_push($cfg, ['name' => 'block_y', 'title' => '<b>Нежелательные слова</b>', 'descr' => 'включение/выключение опции', 'type' => 'select', values => [0 => $lang['noa'], 1 => $lang['yesa']], value => pluginGetVariable('autokeys', 'block_y')]);
+array_push($cfg, ['name' => 'block', 'title' => 'Список нежелательных слов<br><br><i>На каждой строке вводится по одноу слову. Слова из этого списка не будут попадать в keywords.</i>', 'type' => 'text', 'html_flags' => 'rows=8 cols=60', 'value' => pluginGetVariable('autokeys', 'block')]);
+array_push($cfg, ['name' => 'good_y', 'title' => '<b>Желаемые слова</b>', 'descr' => 'включение/выключение опции', 'type' => 'select', values => [0 => $lang['noa'], 1 => $lang['yesa']], value => pluginGetVariable('autokeys', 'good_y')]);
+array_push($cfg, ['name' => 'good', 'title' => 'Список желаемых слов<br><br><i>На каждой строке вводится по одноу слову. Слова из этого всегда будут попадать в keywords.</i>', 'type' => 'text', 'html_flags' => 'rows=8 cols=60', 'value' => pluginGetVariable('autokeys', 'good')]);
+array_push($cfg, ['name' => 'add_title', 'title' => 'Учитывать заголовок', 'descr' => 'Добавления заголовка новости к тексту новости для генерации ключевых слов<br />значение от 0 до бесконечности: <br />0 - не добавлять, 1 - добавлять, 2 - добавить два раза', 'type' => 'input', 'html_flags' => 'style="width: 200px;"', 'value' => pluginGetVariable('autokeys', 'add_title')]);
+array_push($cfg, ['name' => 'sum', 'title' => 'Длина ключевых слов', 'descr' => 'Длина всех ключевых слов генерируемых плагином (По умолчанию <=245 симолов)', 'type' => 'input', 'html_flags' => 'style="width: 200px;"', 'value' => pluginGetVariable('autokeys', 'sum')]);
+array_push($cfg, ['name' => 'count', 'title' => 'Количество ключевых слов', 'descr' => 'Количество ключевых слов генерируемых плагином (По умолчанию неограниченное количество)', 'type' => 'input', 'html_flags' => 'style="width: 200px;"', 'value' => pluginGetVariable('autokeys', 'count')]);
+array_push($cfg, ['name' => 'good_b', 'title' => '<b>Усиление слов</b>', 'descr' => 'Усиление слов в теге [b]', 'type' => 'select', values => [0 => $lang['noa'], 1 => $lang['yesa']], value => pluginGetVariable('autokeys', 'good_b')]);
 if ($_REQUEST['action'] == 'commit') {
-	commit_plugin_config_changes('autokeys', $cfg);
-	print_commit_complete($plugin);
+    commit_plugin_config_changes('autokeys', $cfg);
+    print_commit_complete($plugin);
 } else {
-	generate_config_page('autokeys', $cfg);
+    generate_config_page('autokeys', $cfg);
 }

--- a/autokeys/lib/class.php
+++ b/autokeys/lib/class.php
@@ -1,134 +1,134 @@
 <?php
 
-class autokeyword {
+class autokeyword
+{
+    public $contents;
+    public $encoding;
+    public $keywords;
+    public $wordLengthMin;
+    public $wordOccuredMin;
+    public $wordLengthMax;
+    public $wordGoodArray;
+    public $wordBlockArray;
+    public $wordMaxCount;
+    public $wordB;
+    public $wordAddTitle;
+    public $wordTitle;
 
-	var $contents;
-	var $encoding;
-	var $keywords;
-	var $wordLengthMin;
-	var $wordOccuredMin;
-	var $wordLengthMax;
-	var $wordGoodArray;
-	var $wordBlockArray;
-	var $wordMaxCount;
-	var $wordB;
-	var $wordAddTitle;
-	var $wordTitle;
+    public function autokeyword($params, $encoding)
+    {
+        $this->wordGoodArray = [];
+        $this->wordBlockArray = [];
+        $this->encoding = $encoding;
+        $this->wordLengthMin = $params['min_word_length'];
+        $this->wordLengthMax = $params['max_word_length'];
+        $this->wordMaxCount = $params['word_count'];
+        if ($params['good_b']) {
+            $this->wordB = 1;
+        }
+        if ($params['add_title'] > 0) {
+            $this->wordAddTitle = $params['add_title'];
+            $this->wordTitle = $params['title'];
+            for ($i = 0; $i < $this->wordAddTitle; $i++) {
+                $content .= $this->wordTitle.' ';
+            }
+            $params['content'] = $content.' '.$params['content'];
+        }
+        if ($params['good_array'] && $params['good_word'] == true) {
+            $this->wordGoodArray = explode("\r\n", $params['good_array']);
+        }
+        if ($params['block_array'] && $params['block_word'] == true) {
+            $this->wordBlockArray = explode("\r\n", $params['block_array']);
+        }
+        $this->contents = $this->replace_chars($params['content']);
+    }
 
-	function autokeyword($params, $encoding) {
+    public function replace_chars($content)
+    {
+        $content = strtolower($content);
+        $content = strip_tags($content);
+        if ($this->wordB == 1) {
+            $content = preg_replace('![b](.*)[/b]!si', '$1 $1', $content);
+        }
+        $punctuations = [
+            ',', ')', '(', '.', "'", '"',
+            '<', '>', ';', '!', '?', '/', '-',
+            '_', '[', ']', ':', '+', '=', '#',
+            '$', '&quot;', '&copy;', '&gt;', '&lt;',
+            chr(10), chr(13), chr(9),
+        ];
+        $punctuations = array_merge($this->wordBlockArray, $punctuations);
+        $content = str_replace($punctuations, ' ', $content);
+        $content = preg_replace('/ {2,}/si', ' ', $content);
 
-		$this->wordGoodArray = array();
-		$this->wordBlockArray = array();
-		$this->encoding = $encoding;
-		$this->wordLengthMin = $params['min_word_length'];
-		$this->wordLengthMax = $params['max_word_length'];
-		$this->wordMaxCount = $params['word_count'];
-		if ($params['good_b']) {
-			$this->wordB = 1;
-		}
-		if ($params['add_title'] > 0) {
-			$this->wordAddTitle = $params['add_title'];
-			$this->wordTitle = $params['title'];
-			for ($i = 0; $i < $this->wordAddTitle; $i++) {
-				$content .= $this->wordTitle . ' ';
-			}
-			$params['content'] = $content . ' ' . $params['content'];
-		}
-		if ($params['good_array'] && $params['good_word'] == true) {
-			$this->wordGoodArray = explode("\r\n", $params['good_array']);
-		}
-		if ($params['block_array'] && $params['block_word'] == true) {
-			$this->wordBlockArray = explode("\r\n", $params['block_array']);
-		}
-		$this->contents = $this->replace_chars($params['content']);
-	}
+        return $content;
+    }
 
-	function replace_chars($content) {
+    public function parse_words()
+    {
+        $common = ['aaaaaaa', 'aaaaaaa'];
+        $s = explode(' ', $this->contents);
+        $k = [];
+        foreach ($s as $key => $val) {
+            if (strlen(trim($val)) >= $this->wordLengthMin && strlen(trim($val)) <= $this->wordLengthMax && !in_array(trim($val), $common) && !is_numeric(trim($val))) {
+                $k[] = trim($val);
+            }
+        }
+        $k = array_count_values($k);
+        $occur_filtered = $this->occure_filter($k, $this->wordOccuredMin);
+        arsort($occur_filtered);
+        $occur_filtered = array_flip($this->wordGoodArray) + $occur_filtered;
+        array_splice($occur_filtered, $this->wordMaxCount);
+        $imploded = $this->implode(', ', $occur_filtered);
+        unset($k);
+        unset($s);
 
-		$content = strtolower($content);
-		$content = strip_tags($content);
-		if ($this->wordB == 1) {
-			$content = preg_replace('![b](.*)[/b]!si', '$1 $1', $content);
-		}
-		$punctuations = array(
-			',', ')', '(', '.', "'", '"',
-			'<', '>', ';', '!', '?', '/', '-',
-			'_', '[', ']', ':', '+', '=', '#',
-			'$', '&quot;', '&copy;', '&gt;', '&lt;',
-			chr(10), chr(13), chr(9)
-		);
-		$punctuations = array_merge($this->wordBlockArray, $punctuations);
-		$content = str_replace($punctuations, " ", $content);
-		$content = preg_replace('/ {2,}/si', " ", $content);
+        return $imploded;
+    }
 
-		return $content;
-	}
+    public function occure_filter($array_count_values, $min_occur)
+    {
+        $occur_filtered = [];
+        foreach ($array_count_values as $word => $occured) {
+            if ($occured >= $min_occur) {
+                $occur_filtered[$word] = $occured;
+            }
+        }
 
-	function parse_words() {
+        return $occur_filtered;
+    }
 
-		$common = array("aaaaaaa", "aaaaaaa");
-		$s = explode(" ", $this->contents);
-		$k = array();
-		foreach ($s as $key => $val) {
-			if (strlen(trim($val)) >= $this->wordLengthMin && strlen(trim($val)) <= $this->wordLengthMax && !in_array(trim($val), $common) && !is_numeric(trim($val))) {
-				$k[] = trim($val);
-			}
-		}
-		$k = array_count_values($k);
-		$occur_filtered = $this->occure_filter($k, $this->wordOccuredMin);
-		arsort($occur_filtered);
-		$occur_filtered = array_flip($this->wordGoodArray) + $occur_filtered;
-		array_splice($occur_filtered, $this->wordMaxCount);
-		$imploded = $this->implode(", ", $occur_filtered);
-		unset($k);
-		unset($s);
+    public function implode($gule, $array)
+    {
+        $c = '';
+        foreach ($array as $key => $val) {
+            @$c .= $key.$gule;
+        }
 
-		return $imploded;
-	}
-
-	function occure_filter($array_count_values, $min_occur) {
-
-		$occur_filtered = array();
-		foreach ($array_count_values as $word => $occured) {
-			if ($occured >= $min_occur) {
-				$occur_filtered[$word] = $occured;
-			}
-		}
-
-		return $occur_filtered;
-	}
-
-	function implode($gule, $array) {
-
-		$c = "";
-		foreach ($array as $key => $val) {
-			@$c .= $key . $gule;
-		}
-
-		return $c;
-	}
+        return $c;
+    }
 }
 
-function akeysGetKeys($params) {
+function akeysGetKeys($params)
+{
+    $cfg = [
+        'content'         => $params['content'].' this is content',
+        'title'           => $params['title'],
+        'min_word_length' => (intval(pluginGetVariable('autokeys', 'length'))) ? intval(pluginGetVariable('autokeys', 'length')) : 5,
+        'max_word_length' => (intval(pluginGetVariable('autokeys', 'sub'))) ? intval(pluginGetVariable('autokeys', 'sub')) : 100,
+        'min_word_occur'  => (intval(pluginGetVariable('autokeys', 'occur'))) ? intval(pluginGetVariable('autokeys', 'occur')) : 2,
+        'word_sum'        => (intval(pluginGetVariable('autokeys', 'sum'))) ? intval(pluginGetVariable('autokeys', 'sum')) : 245,
+        'block_word'      => pluginGetVariable('autokeys', 'block_y') ? pluginGetVariable('autokeys', 'block_y') : false,
+        'block_array'     => pluginGetVariable('autokeys', 'block'),
+        'good_word'       => pluginGetVariable('autokeys', 'good_y') ? pluginGetVariable('autokeys', 'good_y') : false,
+        'good_array'      => pluginGetVariable('autokeys', 'good'),
+        'add_title'       => (intval(pluginGetVariable('autokeys', 'add_title'))) ? intval(pluginGetVariable('autokeys', 'add_title')) : 0,
+        'word_count'      => (intval(pluginGetVariable('autokeys', 'count'))) ? intval(pluginGetVariable('autokeys', 'count')) : 245,
+        'good_b'          => pluginGetVariable('autokeys', 'good_b') ? pluginGetVariable('autokeys', 'good_b') : false,
+    ];
+    $keyword = new autokeyword($cfg, 'windows-1251');
+    $words = substr($keyword->parse_words(), 0, $cfg['word_sum']);
+    $words = substr($words, 0, strrpos($words, ', '));
 
-	$cfg = array(
-		'content'         => $params['content'] . ' this is content',
-		'title'           => $params['title'],
-		'min_word_length' => (intval(pluginGetVariable('autokeys', 'length'))) ? intval(pluginGetVariable('autokeys', 'length')) : 5,
-		'max_word_length' => (intval(pluginGetVariable('autokeys', 'sub'))) ? intval(pluginGetVariable('autokeys', 'sub')) : 100,
-		'min_word_occur'  => (intval(pluginGetVariable('autokeys', 'occur'))) ? intval(pluginGetVariable('autokeys', 'occur')) : 2,
-		'word_sum'        => (intval(pluginGetVariable('autokeys', 'sum'))) ? intval(pluginGetVariable('autokeys', 'sum')) : 245,
-		'block_word'      => pluginGetVariable('autokeys', 'block_y') ? pluginGetVariable('autokeys', 'block_y') : false,
-		'block_array'     => pluginGetVariable('autokeys', 'block'),
-		'good_word'       => pluginGetVariable('autokeys', 'good_y') ? pluginGetVariable('autokeys', 'good_y') : false,
-		'good_array'      => pluginGetVariable('autokeys', 'good'),
-		'add_title'       => (intval(pluginGetVariable('autokeys', 'add_title'))) ? intval(pluginGetVariable('autokeys', 'add_title')) : 0,
-		'word_count'      => (intval(pluginGetVariable('autokeys', 'count'))) ? intval(pluginGetVariable('autokeys', 'count')) : 245,
-		'good_b'          => pluginGetVariable('autokeys', 'good_b') ? pluginGetVariable('autokeys', 'good_b') : false,
-	);
-	$keyword = new autokeyword($cfg, "windows-1251");
-	$words = substr($keyword->parse_words(), 0, $cfg['word_sum']);
-	$words = substr($words, 0, strrpos($words, ', '));
-
-	return $words;
+    return $words;
 }

--- a/autokeys/lib/librpc.php
+++ b/autokeys/lib/librpc.php
@@ -1,27 +1,30 @@
 <?php
+
 //
 // Online Auto-Keys generator
 //
-function akeysGenerate($params) {
+function akeysGenerate($params)
+{
+    global $userROW, $DSlist, $mysql, $twig;
+    // Load library
+    include_once root.'/plugins/autokeys/lib/class.php';
+    // Only registered users can use suggest
+    if (!is_array($userROW)) {
+        return ['status' => 0, 'errorCode' => 1, 'errorText' => 'Permission denied'];
+    }
+    // Check if suggest module is enabled
+    if (pluginGetVariable('tags', 'suggestHelper')) {
+        return ['status' => 0, 'errorCode' => 2, 'errorText' => 'Suggest helper is not enabled'];
+    }
+    // Check if article is specified
+    if ($params == '') {
+        return ['status' => 1, 'errorCode' => 0, 'data' => [$params, []]];
+    }
+    // Generate keywords
+    $words = akeysGetKeys(['title' => $params['title'], 'content' => $params['content']]);
 
-	global $userROW, $DSlist, $mysql, $twig;
-	// Load library
-	include_once(root . "/plugins/autokeys/lib/class.php");
-	// Only registered users can use suggest
-	if (!is_array($userROW))
-		return array('status' => 0, 'errorCode' => 1, 'errorText' => 'Permission denied');
-	// Check if suggest module is enabled
-	if (pluginGetVariable('tags', 'suggestHelper')) {
-		return array('status' => 0, 'errorCode' => 2, 'errorText' => 'Suggest helper is not enabled');
-	}
-	// Check if article is specified
-	if ($params == '')
-		return array('status' => 1, 'errorCode' => 0, 'data' => array($params, array()));
-	// Generate keywords
-	$words = akeysGetKeys(array('title' => $params['title'], 'content' => $params['content']));
-
-	// Return output
-	return array('status' => 1, 'errorCode' => 0, 'data' => $words);
+    // Return output
+    return ['status' => 1, 'errorCode' => 0, 'data' => $words];
 }
 
 rpcRegisterFunction('plugin.autokeys.generate', 'akeysGenerate');

--- a/breadcrumbs/breadcrumbs.php
+++ b/breadcrumbs/breadcrumbs.php
@@ -20,220 +20,225 @@
  * Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA  02111-1307, USA.
  *
  */
-if (!defined('NGCMS')) die ('Galaxy in danger');
+if (!defined('NGCMS')) {
+    die('Galaxy in danger');
+}
 add_act('index', 'breadcrumbs');
 LoadPluginLang('breadcrumbs', 'main', '', 'bc', ':');
-function breadcrumbs() {
-
-	global $lang, $catz, $catmap, $template, $CurrentHandler, $config,
-		   $SYSTEM_FLAGS, $tpl, $systemAccessURL, $twig;
-	$tpath = locatePluginTemplates(
-		array('breadcrumbs'), 'breadcrumbs',
-		pluginGetVariable('breadcrumbs', 'template_source')
-	);
-	$location = array();
-	$location_last = '';
-	# processing 404 page
-	if ($SYSTEM_FLAGS['info']['title']['group'] == $lang['404.title']) {
-		$link = str_replace(
-			array(
-				'{home_url}',
-				'{home_title}'
-			),
-			array(
-				$config['home_url'],
-				$lang['bc:mainpage']
-			),
-			$lang['bc:page_404']
-		);
-		$location[] = array(
-			'url'   => $config['home_url'],
-			'title' => $lang['bc:mainpage'],
-			'link'  => $link,
-		);
-		$location_last = $lang['404.title'];
-	} else {
-		if ($CurrentHandler) {
-			$params = $CurrentHandler['params'];
-			$pluginName = $CurrentHandler['pluginName'];
-		}
-		# generate main page with or without link
-		$main_page = ($systemAccessURL != '/'
-			? str_replace(
-				array(
-					'{home_url}',
-					'{home_title}'
-				),
-				array(
-					$config['home_url'],
-					$lang['bc:mainpage']
-				),
-				$lang['bc:page_404']
-			)
-			: $lang['bc:mainpage']
-		);
-		$location[] = array(
-			'url'   => ($systemAccessURL != '/') ? $config['home_url'] : '',
-			'title' => ($systemAccessURL != '/') ? $lang['bc:mainpage'] : $lang['bc:mainpage'],
-			'link'  => $main_page,
-		);
-		$location_last = $main_page;
-		# if category
-		if ($CurrentHandler['handlerName'] == 'by.category') {
-			$location_last = GetCategories($catz[$params['category']]['id'], true);
-			# show full path [if requested]
-			if ($catz[$params['category']]['parent'] != 0 && !pluginGetVariable('breadcrumbs', 'block_full_path')) {
-				$id = $catz[$params['category']]['parent'];
-				do {
-					$row = $catz[$catmap[$id]];
-					$location_tmp[] = [
-						'url' => generateLink('news', 'by.category', [
-							'category' => $row['alt'],
-							'catid' => $row['id'],
-						]),
-						'title' => $row['name'],
-						'link' => GetCategories($id),
-					];
-					$id = $row['parent'];
-				} while ($id != 0);
-				$location = array_merge($location, array_reverse($location_tmp));
-			}
-		} # news by date
-		elseif ($params['year']) {
-			# if we have only year then $year = plain text, if we have month then $year = link
-			$year = (!$params['month'])
-				? $params['year']
-				: str_replace(
-					array(
-						'{year_url}',
-						'{year}'
-					),
-					array(
-						generateLink('news', 'by.year', array('year' => $params['year'])),
-						$params['year']
-					),
-					$lang['bc:by.year']
-				);
-			$month_p = LangDate("F", mktime(0, 0, 0, $params['month'], 7, 0));
-			# if we have only year and month then $month = plain text, if we have day then $month = link
-			$month = (!$params['day'])
-				? $month_p
-				: str_replace(
-					array(
-						'{month_url}',
-						'{month_p}'
-					),
-					array(
-						generateLink('news', 'by.month', array('year' => $params['year'], 'month' => $params['month'])),
-						$month_p
-					),
-					$lang['bc:by.month']
-				);
-			$day = $params['day'];
-			$location_last = $year;
-			if ($params['month']) {
-				$location[] = array(
-					'url'   => (!$params['month']) ? '' : generateLink('news', 'by.year', array('year' => $params['year'])),
-					'title' => (!$params['month']) ? $params['year'] : $params['year'],
-					'link'  => $year,
-				);
-				$location_last = $month;
-			}
-			if ($params['day']) {
-				$location[] = array(
-					'url'   => (!$params['day']) ? '' : generateLink('news', 'by.month', array('year' => $params['year'], 'month' => $params['month'])),
-					'title' => (!$params['day']) ? $month_p : $month_p,
-					'link'  => $month,
-				);
-				$location_last = $day;
-			}
-			# plugin, static, etc.
-		} elseif ($pluginName != 'news') {
-			if ($pluginName == "static") $location_last = $SYSTEM_FLAGS['info']['title']['item'];
-			elseif (($pluginName == 'uprofile' && $CurrentHandler['handlerName'] == 'edit') || $pluginName == 'search')
-				$location_last = $SYSTEM_FLAGS['info']['title']['group'];
-			elseif ($pluginName == 'uprofile' && $CurrentHandler['handlerName'] == 'show')
-				$location_last = $SYSTEM_FLAGS['info']['title']['group'] . ' ' . $SYSTEM_FLAGS['info']['title']['item'];
-			elseif ($pluginName == 'core' && (in_array($CurrentHandler['handlerName'], array('registration', 'lostpassword', 'login'))))
-				$location_last = $SYSTEM_FLAGS['info']['title']['group'];
-			elseif ($params['plugin'] || $pluginName) {
-				# if plugin provide put some info
-				if ($SYSTEM_FLAGS['info']['breadcrumbs']) {
-					# plugin name becomes link
-					$count = count($SYSTEM_FLAGS['info']['breadcrumbs']) - 1;
-					# all items except last become links
-					for ($i = 0; $i < $count; $i++) {
-						$link = str_replace(
-							array(
-								'{plugin_url}',
-								'{plugin}'
-							),
-							array(
-								$SYSTEM_FLAGS['info']['breadcrumbs'][$i]['link'],
-								$SYSTEM_FLAGS['info']['breadcrumbs'][$i]['text']
-							),
-							$lang['bc:plugin']
-						);
-						$location[] = array(
-							'url'   => $SYSTEM_FLAGS['info']['breadcrumbs'][$i]['link'],
-							'title' => $SYSTEM_FLAGS['info']['breadcrumbs'][$i]['text'],
-							'link'  => $link,
-						);
-					}
-					# last item becomes plain text
-					$location_last = $SYSTEM_FLAGS['info']['breadcrumbs'][$i]['text'];
-				} else {
-					$location_last = $SYSTEM_FLAGS['info']['title']['group'] != $lang['loc_plugin']
-					    ? $SYSTEM_FLAGS['info']['title']['group']
-					    : $params['plugin'];
-				}
-			}
-			# full news
-		} elseif ($CurrentHandler['pluginName'] == 'news' && $CurrentHandler['handlerName'] == 'news') {
-			$catids = $SYSTEM_FLAGS['news']['db.categories'];
-			$location_last = $SYSTEM_FLAGS['info']['title']['item'];
-			if (count($catids) != 1 || pluginGetVariable('breadcrumbs', 'block_full_path')) {
-				if ($CurrentHandler['params']['category'] != 'none') {
-					foreach ($catids as $cid) {
-						foreach ($catz as $cc) {
-							if ($cc['id'] == $cid) {
-								$location[] = array(
-									'url'   => generateLink('news', 'by.category', array('category' => $cc['alt'], 'catid' => $cc['id'])),
-									'title' => $cc['name'],
-									'link'  => GetCategories($cc['id'], false),
-								);
-							}
-						}
-					}
-				}
-			} else {
-				$id = $catz[$params['category']]['parent'];
-				$location_tmp[] = array(
-					'url'   => generateLink('news', 'by.category', array('category' => $catz[$params['category']]['alt'], 'catid' => $catz[$params['category']]['id'])),
-					'title' => $catz[$params['category']]['name'],
-					'link'  => GetCategories($catz[$params['category']]['id'], false),
-				);
-				while ($id != 0) {
-					foreach ($catz as $cc) {
-						if ($cc['id'] == $id) {
-							$location_tmp[] = array(
-								'url'   => generateLink('news', 'by.category', array('category' => $cc['alt'], 'catid' => $cc['id'])),
-								'title' => $cc['name'],
-								'link'  => GetCategories($cc['id'], false),
-							);
-							$id = $catz[$cc['alt']]['parent'];
-						}
-					}
-				}
-				$location = array_merge($location, array_reverse($location_tmp));
-			}
-		}
-	}
-	$tVars = array(
-		'location'      => $location,
-		'location_last' => $location_last,
-		'separator'     => $separator
-	);
-	$xt = $twig->loadTemplate($tpath['breadcrumbs'] . 'breadcrumbs.tpl');
-	$template['vars']['breadcrumbs'] = $xt->render($tVars);
+function breadcrumbs()
+{
+    global $lang, $catz, $catmap, $template, $CurrentHandler, $config,
+           $SYSTEM_FLAGS, $tpl, $systemAccessURL, $twig;
+    $tpath = locatePluginTemplates(
+        ['breadcrumbs'],
+        'breadcrumbs',
+        pluginGetVariable('breadcrumbs', 'template_source')
+    );
+    $location = [];
+    $location_last = '';
+    // processing 404 page
+    if ($SYSTEM_FLAGS['info']['title']['group'] == $lang['404.title']) {
+        $link = str_replace(
+            [
+                '{home_url}',
+                '{home_title}',
+            ],
+            [
+                $config['home_url'],
+                $lang['bc:mainpage'],
+            ],
+            $lang['bc:page_404']
+        );
+        $location[] = [
+            'url'   => $config['home_url'],
+            'title' => $lang['bc:mainpage'],
+            'link'  => $link,
+        ];
+        $location_last = $lang['404.title'];
+    } else {
+        if ($CurrentHandler) {
+            $params = $CurrentHandler['params'];
+            $pluginName = $CurrentHandler['pluginName'];
+        }
+        // generate main page with or without link
+        $main_page = (
+            $systemAccessURL != '/'
+            ? str_replace(
+                [
+                    '{home_url}',
+                    '{home_title}',
+                ],
+                [
+                    $config['home_url'],
+                    $lang['bc:mainpage'],
+                ],
+                $lang['bc:page_404']
+            )
+            : $lang['bc:mainpage']
+        );
+        $location[] = [
+            'url'   => ($systemAccessURL != '/') ? $config['home_url'] : '',
+            'title' => ($systemAccessURL != '/') ? $lang['bc:mainpage'] : $lang['bc:mainpage'],
+            'link'  => $main_page,
+        ];
+        $location_last = $main_page;
+        // if category
+        if ($CurrentHandler['handlerName'] == 'by.category') {
+            $location_last = GetCategories($catz[$params['category']]['id'], true);
+            // show full path [if requested]
+            if ($catz[$params['category']]['parent'] != 0 && !pluginGetVariable('breadcrumbs', 'block_full_path')) {
+                $id = $catz[$params['category']]['parent'];
+                do {
+                    $row = $catz[$catmap[$id]];
+                    $location_tmp[] = [
+                        'url' => generateLink('news', 'by.category', [
+                            'category' => $row['alt'],
+                            'catid'    => $row['id'],
+                        ]),
+                        'title' => $row['name'],
+                        'link'  => GetCategories($id),
+                    ];
+                    $id = $row['parent'];
+                } while ($id != 0);
+                $location = array_merge($location, array_reverse($location_tmp));
+            }
+        } // news by date
+        elseif ($params['year']) {
+            // if we have only year then $year = plain text, if we have month then $year = link
+            $year = (!$params['month'])
+                ? $params['year']
+                : str_replace(
+                    [
+                        '{year_url}',
+                        '{year}',
+                    ],
+                    [
+                        generateLink('news', 'by.year', ['year' => $params['year']]),
+                        $params['year'],
+                    ],
+                    $lang['bc:by.year']
+                );
+            $month_p = LangDate('F', mktime(0, 0, 0, $params['month'], 7, 0));
+            // if we have only year and month then $month = plain text, if we have day then $month = link
+            $month = (!$params['day'])
+                ? $month_p
+                : str_replace(
+                    [
+                        '{month_url}',
+                        '{month_p}',
+                    ],
+                    [
+                        generateLink('news', 'by.month', ['year' => $params['year'], 'month' => $params['month']]),
+                        $month_p,
+                    ],
+                    $lang['bc:by.month']
+                );
+            $day = $params['day'];
+            $location_last = $year;
+            if ($params['month']) {
+                $location[] = [
+                    'url'   => (!$params['month']) ? '' : generateLink('news', 'by.year', ['year' => $params['year']]),
+                    'title' => (!$params['month']) ? $params['year'] : $params['year'],
+                    'link'  => $year,
+                ];
+                $location_last = $month;
+            }
+            if ($params['day']) {
+                $location[] = [
+                    'url'   => (!$params['day']) ? '' : generateLink('news', 'by.month', ['year' => $params['year'], 'month' => $params['month']]),
+                    'title' => (!$params['day']) ? $month_p : $month_p,
+                    'link'  => $month,
+                ];
+                $location_last = $day;
+            }
+            // plugin, static, etc.
+        } elseif ($pluginName != 'news') {
+            if ($pluginName == 'static') {
+                $location_last = $SYSTEM_FLAGS['info']['title']['item'];
+            } elseif (($pluginName == 'uprofile' && $CurrentHandler['handlerName'] == 'edit') || $pluginName == 'search') {
+                $location_last = $SYSTEM_FLAGS['info']['title']['group'];
+            } elseif ($pluginName == 'uprofile' && $CurrentHandler['handlerName'] == 'show') {
+                $location_last = $SYSTEM_FLAGS['info']['title']['group'].' '.$SYSTEM_FLAGS['info']['title']['item'];
+            } elseif ($pluginName == 'core' && (in_array($CurrentHandler['handlerName'], ['registration', 'lostpassword', 'login']))) {
+                $location_last = $SYSTEM_FLAGS['info']['title']['group'];
+            } elseif ($params['plugin'] || $pluginName) {
+                // if plugin provide put some info
+                if ($SYSTEM_FLAGS['info']['breadcrumbs']) {
+                    // plugin name becomes link
+                    $count = count($SYSTEM_FLAGS['info']['breadcrumbs']) - 1;
+                    // all items except last become links
+                    for ($i = 0; $i < $count; $i++) {
+                        $link = str_replace(
+                            [
+                                '{plugin_url}',
+                                '{plugin}',
+                            ],
+                            [
+                                $SYSTEM_FLAGS['info']['breadcrumbs'][$i]['link'],
+                                $SYSTEM_FLAGS['info']['breadcrumbs'][$i]['text'],
+                            ],
+                            $lang['bc:plugin']
+                        );
+                        $location[] = [
+                            'url'   => $SYSTEM_FLAGS['info']['breadcrumbs'][$i]['link'],
+                            'title' => $SYSTEM_FLAGS['info']['breadcrumbs'][$i]['text'],
+                            'link'  => $link,
+                        ];
+                    }
+                    // last item becomes plain text
+                    $location_last = $SYSTEM_FLAGS['info']['breadcrumbs'][$i]['text'];
+                } else {
+                    $location_last = $SYSTEM_FLAGS['info']['title']['group'] != $lang['loc_plugin']
+                        ? $SYSTEM_FLAGS['info']['title']['group']
+                        : $params['plugin'];
+                }
+            }
+            // full news
+        } elseif ($CurrentHandler['pluginName'] == 'news' && $CurrentHandler['handlerName'] == 'news') {
+            $catids = $SYSTEM_FLAGS['news']['db.categories'];
+            $location_last = $SYSTEM_FLAGS['info']['title']['item'];
+            if (count($catids) != 1 || pluginGetVariable('breadcrumbs', 'block_full_path')) {
+                if ($CurrentHandler['params']['category'] != 'none') {
+                    foreach ($catids as $cid) {
+                        foreach ($catz as $cc) {
+                            if ($cc['id'] == $cid) {
+                                $location[] = [
+                                    'url'   => generateLink('news', 'by.category', ['category' => $cc['alt'], 'catid' => $cc['id']]),
+                                    'title' => $cc['name'],
+                                    'link'  => GetCategories($cc['id'], false),
+                                ];
+                            }
+                        }
+                    }
+                }
+            } else {
+                $id = $catz[$params['category']]['parent'];
+                $location_tmp[] = [
+                    'url'   => generateLink('news', 'by.category', ['category' => $catz[$params['category']]['alt'], 'catid' => $catz[$params['category']]['id']]),
+                    'title' => $catz[$params['category']]['name'],
+                    'link'  => GetCategories($catz[$params['category']]['id'], false),
+                ];
+                while ($id != 0) {
+                    foreach ($catz as $cc) {
+                        if ($cc['id'] == $id) {
+                            $location_tmp[] = [
+                                'url'   => generateLink('news', 'by.category', ['category' => $cc['alt'], 'catid' => $cc['id']]),
+                                'title' => $cc['name'],
+                                'link'  => GetCategories($cc['id'], false),
+                            ];
+                            $id = $catz[$cc['alt']]['parent'];
+                        }
+                    }
+                }
+                $location = array_merge($location, array_reverse($location_tmp));
+            }
+        }
+    }
+    $tVars = [
+        'location'      => $location,
+        'location_last' => $location_last,
+        'separator'     => $separator,
+    ];
+    $xt = $twig->loadTemplate($tpath['breadcrumbs'].'breadcrumbs.tpl');
+    $template['vars']['breadcrumbs'] = $xt->render($tVars);
 }

--- a/breadcrumbs/config.php
+++ b/breadcrumbs/config.php
@@ -7,31 +7,31 @@
  */
 pluginsLoadConfig();
 LoadPluginLang('breadcrumbs', 'config', '', 'bc', ':');
-$cfg = array();
-array_push($cfg, array('descr' => $lang['bc:description']));
-array_push($cfg, array(
-	'name'   => 'block_full_path',
-	'title'  => $lang['bc:block_full_path'],
-	'type'   => 'select',
-	'values' => array(1 => $lang['yesa'], 0 => $lang['noa']),
-	'value'  => pluginGetVariable($plugin, 'block_full_path')
-));
-$cfgX = array();
-array_push($cfgX, array(
-	'name'   => 'template_source',
-	'title'  => $lang['bc:template_source_title'],
-	'type'   => 'select',
-	'values' => array('0' => $lang['bc:template_source_site'], '1' => $lang['bc:template_source_plugin']),
-	'value'  => intval(pluginGetVariable($plugin, 'template_source'))
-));
-array_push($cfg, array(
-	'mode'    => 'group',
-	'title'   => $lang['bc:template_source'],
-	'entries' => $cfgX
-));
+$cfg = [];
+array_push($cfg, ['descr' => $lang['bc:description']]);
+array_push($cfg, [
+    'name'   => 'block_full_path',
+    'title'  => $lang['bc:block_full_path'],
+    'type'   => 'select',
+    'values' => [1 => $lang['yesa'], 0 => $lang['noa']],
+    'value'  => pluginGetVariable($plugin, 'block_full_path'),
+]);
+$cfgX = [];
+array_push($cfgX, [
+    'name'   => 'template_source',
+    'title'  => $lang['bc:template_source_title'],
+    'type'   => 'select',
+    'values' => ['0' => $lang['bc:template_source_site'], '1' => $lang['bc:template_source_plugin']],
+    'value'  => intval(pluginGetVariable($plugin, 'template_source')),
+]);
+array_push($cfg, [
+    'mode'    => 'group',
+    'title'   => $lang['bc:template_source'],
+    'entries' => $cfgX,
+]);
 if ($_REQUEST['action'] == 'commit') {
-	commit_plugin_config_changes($plugin, $cfg);
-	print_commit_complete($plugin);
+    commit_plugin_config_changes($plugin, $cfg);
+    print_commit_complete($plugin);
 } else {
-	generate_config_page($plugin, $cfg);
+    generate_config_page($plugin, $cfg);
 }

--- a/calendar/calendar.php
+++ b/calendar/calendar.php
@@ -1,7 +1,9 @@
 <?php
-// Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
 
+// Protect against hack attempts
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 
 function plugin_calendar()
 {
@@ -9,12 +11,13 @@ function plugin_calendar()
 
     // Determine MONTH and YEAR for current show process
     if (($CurrentHandler['pluginName'] == 'news') &&
-        (in_array($CurrentHandler['handlerName'], array('by.day', 'by.month', 'by.year')))
+        (in_array($CurrentHandler['handlerName'], ['by.day', 'by.month', 'by.year']))
     ) {
         $year = isset($CurrentHandler['params']['year']) ? $CurrentHandler['params']['year'] : $_REQUEST['year'];
         $month = isset($CurrentHandler['params']['month']) ? $CurrentHandler['params']['month'] : $_REQUEST['month'];
-        if (($month < 1) || ($month > 12))
+        if (($month < 1) || ($month > 12)) {
             $month = 1;
+        }
         if (($year < 1970) || ($year > 2100)) {
             $tm = localtime();
             $year = $tm[5];
@@ -24,17 +27,17 @@ function plugin_calendar()
         $month = date('m', $lt);
         $year = date('Y', $lt);
     }
-    $template['vars']['plugin_calendar'] = plug_calgen($month, $year, false, array(), pluginGetVariable('calendar', 'cache') ? pluginGetVariable('calendar', 'cacheExpire') : 0);
+    $template['vars']['plugin_calendar'] = plug_calgen($month, $year, false, [], pluginGetVariable('calendar', 'cache') ? pluginGetVariable('calendar', 'cacheExpire') : 0);
 }
 
-function plug_calgen($month, $year, $overrideTemplateName = false, $categoryList = array(), $cacheExpire = 0, $flagAJAX = false)
+function plug_calgen($month, $year, $overrideTemplateName = false, $categoryList = [], $cacheExpire = 0, $flagAJAX = false)
 {
     global $config, $lang, $mysql, $tpl, $template, $langMonths, $twig, $twigLoader;
 
     // Add leading zeroes to month (if needed)
     $month = sprintf('%02s', $month);
     // Generate cache file name [ we should take into account SWITCHER plugin ]
-    $cacheFileName = md5('calendar' . $config['theme'] . '|' . join(",", $categoryList) . $overrideTemplateName . $config['default_lang'] . $year . $month) . '.txt';
+    $cacheFileName = md5('calendar'.$config['theme'].'|'.implode(',', $categoryList).$overrideTemplateName.$config['default_lang'].$year.$month).'.txt';
     if ($cacheExpire > 0) {
         $cacheData = cacheRetrieveFile($cacheFileName, $cacheExpire, 'calendar');
         if ($cacheData != false) {
@@ -47,18 +50,19 @@ function plug_calgen($month, $year, $overrideTemplateName = false, $categoryList
 
     // Разные запросы в зависимости от указания категорий
     if (!is_array($categoryList)) {
-        $categoryList = intval($categoryList) ? array(intval($categoryList)) : array();
+        $categoryList = intval($categoryList) ? [intval($categoryList)] : [];
     }
 
     if (!count($categoryList)) {
-        $sql = "SELECT day(from_unixtime(postdate)) as day, to_days(from_unixtime(postdate)) as to_days, count(id) as count FROM " . prefix . "_news WHERE approve = '1' AND postdate >= unix_timestamp('" . $year . "-" . $month . "-01 00:00:00') AND postdate < unix_timestamp(date_add('" . $year . "-" . $month . "-01 00:00:00', interval 1 month)) group by to_days, day";
+        $sql = 'SELECT day(from_unixtime(postdate)) as day, to_days(from_unixtime(postdate)) as to_days, count(id) as count FROM '.prefix."_news WHERE approve = '1' AND postdate >= unix_timestamp('".$year.'-'.$month."-01 00:00:00') AND postdate < unix_timestamp(date_add('".$year.'-'.$month."-01 00:00:00', interval 1 month)) group by to_days, day";
     } else {
-        $sqlList = array();
+        $sqlList = [];
         foreach ($categoryList as $c) {
-            if (intval($c) > 0)
-                $sqlList [] = intval($c);
+            if (intval($c) > 0) {
+                $sqlList[] = intval($c);
+            }
         }
-        $sql = "SELECT day(dt) as day, to_days(dt) as to_days, count(newsID) as count FROM " . prefix . "_news_map WHERE categoryID in (" . join(",", $sqlList) . ") AND (dt >= '" . $year . "-" . $month . "-01 00:00:00') AND dt < (date_add('" . $year . "-" . $month . "-01 00:00:00', interval 1 month)) group by to_days, day";
+        $sql = 'SELECT day(dt) as day, to_days(dt) as to_days, count(newsID) as count FROM '.prefix.'_news_map WHERE categoryID in ('.implode(',', $sqlList).") AND (dt >= '".$year.'-'.$month."-01 00:00:00') AND dt < (date_add('".$year.'-'.$month."-01 00:00:00', interval 1 month)) group by to_days, day";
     }
 
     foreach ($mysql->select($sql) as $row) {
@@ -66,38 +70,38 @@ function plug_calgen($month, $year, $overrideTemplateName = false, $categoryList
     }
 
     // Determine paths for all template files
-    $tpath = locatePluginTemplates(array('entries', 'calendar'), 'calendar', pluginGetVariable('calendar', 'localsource'));
+    $tpath = locatePluginTemplates(['entries', 'calendar'], 'calendar', pluginGetVariable('calendar', 'localsource'));
     $dt = mktime(0, 0, 0, $month, 1, $year);
     $prevdt = mktime(0, 0, 0, $month - 1, 1, $year);
     $nextdt = mktime(0, 0, 0, $month + 1, 1, $year);
-    $days = date("t", $dt);
-    $offset = (date("w", $dt)) ? date("w", $dt) - 1 : 6;
+    $days = date('t', $dt);
+    $offset = (date('w', $dt)) ? date('w', $dt) - 1 : 6;
     $weeks = ceil(($days + $offset) / 7);
     $result = '';
 
     // Determine current date [ needed to set different class for current day ]
     $localTime = localtime();
     $flagCurrentMonth = ((($localTime[4] + 1) == $month) && (($localTime[5] + 1900) == $year)) ? 1 : 0;
-    $tVars = array('weeks' => array());
+    $tVars = ['weeks' => []];
 
     for ($i = 0; $i < $weeks; $i++) {
-        $tDays = array();
+        $tDays = [];
         unset($tvars);
         for ($j = 1; $j <= 7; $j++) {
             $dayno = ($i * 7 + $j) - $offset;
             if (($dayno > 0) && ($dayno <= $days)) {
                 $day_link = checkLinkAvailable('news', 'by.day') ?
-                    generateLink('news', 'by.day', array('year' => $year, 'month' => $month, 'day' => sprintf('%02u', $dayno))) :
-                    generateLink('core', 'plugin', array('plugin' => 'news', 'handler' => 'by.day'), array('year' => $year, 'month' => $month, 'day' => $dayno));
-                $tDays[$j] = array(
-                    'dayNo' => $dayno,
+                    generateLink('news', 'by.day', ['year' => $year, 'month' => $month, 'day' => sprintf('%02u', $dayno)]) :
+                    generateLink('core', 'plugin', ['plugin' => 'news', 'handler' => 'by.day'], ['year' => $year, 'month' => $month, 'day' => $dayno]);
+                $tDays[$j] = [
+                    'dayNo'     => $dayno,
                     'countNews' => isset($counters[$dayno]) ? $counters[$dayno] : 0,
-                    'link' => $day_link,
-                    'className' => $lang['calendar_class_' . (($flagCurrentMonth && ($localTime[3] == $dayno)) ? 'today_' : '') . 'week' . (($j < 6) ? 'day' : 'end')],
-                    'isToday' => ($localTime[3] == $dayno) ? true : false,
+                    'link'      => $day_link,
+                    'className' => $lang['calendar_class_'.(($flagCurrentMonth && ($localTime[3] == $dayno)) ? 'today_' : '').'week'.(($j < 6) ? 'day' : 'end')],
+                    'isToday'   => ($localTime[3] == $dayno) ? true : false,
                     'isWeekDay' => ($j < 6) ? true : false,
                     'isWeekEnd' => ($j == 7) ? true : false,
-                );
+                ];
             }
         }
         $tVars['weeks'][$i + 1] = $tDays;
@@ -105,43 +109,43 @@ function plug_calgen($month, $year, $overrideTemplateName = false, $categoryList
     unset($tvars);
 
     $month_link = checkLinkAvailable('news', 'by.month') ?
-        generateLink('news', 'by.month', array('year' => $year, 'month' => $month)) :
-        generateLink('core', 'plugin', array('plugin' => 'news', 'handler' => 'by.month'), array('year' => $year, 'month' => $month));
+        generateLink('news', 'by.month', ['year' => $year, 'month' => $month]) :
+        generateLink('core', 'plugin', ['plugin' => 'news', 'handler' => 'by.month'], ['year' => $year, 'month' => $month]);
 
     $prev_cd = localtime($prevdt, true);
 
     $prev_link = checkLinkAvailable('news', 'by.month') ?
-        generateLink('news', 'by.month', array('year' => ($prev_cd['tm_year'] + 1900), 'month' => sprintf('%02u', ($prev_cd['tm_mon'] + 1)))) :
-        generateLink('core', 'plugin', array('plugin' => 'news', 'handler' => 'by.month'), array('year' => ($prev_cd['tm_year'] + 1900), 'month' => sprintf('%02u', ($prev_cd['tm_mon'] + 1))));
+        generateLink('news', 'by.month', ['year' => ($prev_cd['tm_year'] + 1900), 'month' => sprintf('%02u', ($prev_cd['tm_mon'] + 1))]) :
+        generateLink('core', 'plugin', ['plugin' => 'news', 'handler' => 'by.month'], ['year' => ($prev_cd['tm_year'] + 1900), 'month' => sprintf('%02u', ($prev_cd['tm_mon'] + 1))]);
 
     $next_cd = localtime($nextdt, true);
 
     $next_link = checkLinkAvailable('news', 'by.month') ?
-        generateLink('news', 'by.month', array('year' => ($next_cd['tm_year'] + 1900), 'month' => sprintf('%02u', ($next_cd['tm_mon'] + 1)))) :
-        generateLink('core', 'plugin', array('plugin' => 'news', 'handler' => 'by.month'), array('year' => ($next_cd['tm_year'] + 1900), 'month' => sprintf('%02u', ($next_cd['tm_mon'] + 1))));
+        generateLink('news', 'by.month', ['year' => ($next_cd['tm_year'] + 1900), 'month' => sprintf('%02u', ($next_cd['tm_mon'] + 1))]) :
+        generateLink('core', 'plugin', ['plugin' => 'news', 'handler' => 'by.month'], ['year' => ($next_cd['tm_year'] + 1900), 'month' => sprintf('%02u', ($next_cd['tm_mon'] + 1))]);
 
-    $tVars['currentMonth'] = array(
+    $tVars['currentMonth'] = [
         'name' => $langMonths[$month - 1],
         'link' => $month_link,
-    );
+    ];
 
-    $tVars['currentEntry'] = array(
-        'month' => $month,
-        'year' => $year,
-        'template' => $overrideTemplateName,
-        'categories' => join(",", $categoryList),
-    );
+    $tVars['currentEntry'] = [
+        'month'      => $month,
+        'year'       => $year,
+        'template'   => $overrideTemplateName,
+        'categories' => implode(',', $categoryList),
+    ];
 
     // If cache is activated - calculate MIN and MAX dates for news
     if ($cacheExpire > 0) {
         //
-        $mmx = $mysql->record("select (select postdate from " . prefix . "_news use key(news_postdate) where mainpage=1 order by postdate limit 1) as min, (select postdate from " . prefix . "_news use key(news_postdate) where approve=1 order by postdate desc limit 1) as max", 1);
+        $mmx = $mysql->record('select (select postdate from '.prefix.'_news use key(news_postdate) where mainpage=1 order by postdate limit 1) as min, (select postdate from '.prefix.'_news use key(news_postdate) where approve=1 order by postdate desc limit 1) as max', 1);
 
         // Prev link
         if ($prevdt < $mmx['min']) {
             // Lock
         } else {
-            $tVars['prevMonth'] = array('link' => $prev_link);
+            $tVars['prevMonth'] = ['link' => $prev_link];
             $tVars['flags']['havePrevMonth'] = true;
         }
 
@@ -149,51 +153,52 @@ function plug_calgen($month, $year, $overrideTemplateName = false, $categoryList
         if ($nextdt > $mmx['max']) {
             // Lock
         } else {
-            $tVars['nextMonth'] = array('link' => $next_link);
+            $tVars['nextMonth'] = ['link' => $next_link];
             $tVars['flags']['haveNextMonth'] = true;
         }
     } else {
-        $tVars['prevMonth'] = array('link' => $prev_link);
-        $tVars['nextMonth'] = array('link' => $next_link);
+        $tVars['prevMonth'] = ['link' => $prev_link];
+        $tVars['nextMonth'] = ['link' => $next_link];
         $tVars['flags']['havePrevMonth'] = true;
         $tVars['flags']['haveNextMonth'] = true;
     }
-    foreach (explode(",", $lang['short_weekdays']) as $k => $v) {
-        $lang['weekday_' . $k] = $v;
+    foreach (explode(',', $lang['short_weekdays']) as $k => $v) {
+        $lang['weekday_'.$k] = $v;
         $tVars['weekdays'][$k ? ($k) : 7] = $v;
     }
     // Prepare conversion table
-    $conversionConfig = array(
-        '{entries}' => '{% for week in weeks %}{% include localPath(0) ~ "entries.tpl" %}{% endfor %}',
+    $conversionConfig = [
+        '{entries}'      => '{% for week in weeks %}{% include localPath(0) ~ "entries.tpl" %}{% endfor %}',
         '{current_link}' => '<a href="{{ currentMonth.link }}">{{ currentMonth.name }}</a>',
-        '{tpl_url}' => '{{ tpl_url }}',
-    );
-    $conversionConfigRegex = array(
+        '{tpl_url}'      => '{{ tpl_url }}',
+    ];
+    $conversionConfigRegex = [
         '#\[prev_link\](.+?)\[/prev_link\]#is' => '{% if (flags.havePrevMonth) %}<a href="{{ prevMonth.link }}">$1</a>{% endif %}',
         '#\[next_link\](.+?)\[/next_link\]#is' => '{% if (flags.haveNextMonth) %}<a href="{{ nextMonth.link }}">$1</a>{% endif %}',
-    );
-    $conversionConfigE = array();
+    ];
+    $conversionConfigE = [];
 
     for ($i = 0; $i < 7; $i++) {
-        $conversionConfig['{l_weekday_' . $i . '}'] = '{{ weekdays[' . $i . '] }}';
+        $conversionConfig['{l_weekday_'.$i.'}'] = '{{ weekdays['.$i.'] }}';
     }
 
     for ($i = 1; $i <= 7; $i++) {
-        $conversionConfigE['{cl' . $i . '}'] = '{{ week[' . $i . '].className }}';
-        $conversionConfigE['{d' . $i . '}'] = '{% if (week[' . $i . '].countNews>0) %}<a href="{{ week[' . $i . '].link }}">{{ week[' . $i . '].dayNo}}</a>{% else %}{{ week[' . $i . '].dayNo }}{% endif %}';
+        $conversionConfigE['{cl'.$i.'}'] = '{{ week['.$i.'].className }}';
+        $conversionConfigE['{d'.$i.'}'] = '{% if (week['.$i.'].countNews>0) %}<a href="{{ week['.$i.'].link }}">{{ week['.$i.'].dayNo}}</a>{% else %}{{ week['.$i.'].dayNo }}{% endif %}';
     }
 
-    $twigLoader->setConversion($tpath['calendar'] . 'calendar.tpl', $conversionConfig, $conversionConfigRegex);
-    $twigLoader->setConversion($tpath['entries'] . 'entries.tpl', $conversionConfigE);
+    $twigLoader->setConversion($tpath['calendar'].'calendar.tpl', $conversionConfig, $conversionConfigRegex);
+    $twigLoader->setConversion($tpath['entries'].'entries.tpl', $conversionConfigE);
 
     // AJAX flag
     $tVars['flags']['ajax'] = $flagAJAX ? 1 : 0;
 
     // Предзагрузка шаблона entries [ чтобы отработал setConversion ] при его наличии
-    if (isset($tpath['entries']))
-        $twig->loadTemplate($tpath['entries'] . 'entries.tpl');
+    if (isset($tpath['entries'])) {
+        $twig->loadTemplate($tpath['entries'].'entries.tpl');
+    }
 
-    $xt = $twig->loadTemplate($tpath['calendar'] . 'calendar.tpl');
+    $xt = $twig->loadTemplate($tpath['calendar'].'calendar.tpl');
     $output = $xt->render($tVars);
     if ($cacheExpire > 0) {
         cacheStoreFile($cacheFileName, $output, 'calendar');
@@ -228,12 +233,13 @@ function plugin_calendar_showTwig($params)
     } else {
         // Month/year is not set. Try to check current month/year from URL
         if (($CurrentHandler['pluginName'] == 'news') &&
-            (in_array($CurrentHandler['handlerName'], array('by.day', 'by.month', 'by.year')))
+            (in_array($CurrentHandler['handlerName'], ['by.day', 'by.month', 'by.year']))
         ) {
             $year = isset($CurrentHandler['params']['year']) ? $CurrentHandler['params']['year'] : $_REQUEST['year'];
             $month = isset($CurrentHandler['params']['month']) ? $CurrentHandler['params']['month'] : $_REQUEST['month'];
-            if (($month < 1) || ($month > 12))
+            if (($month < 1) || ($month > 12)) {
                 $month = 1;
+            }
             if (($year < 1970) || ($year > 2100)) {
                 $tm = localtime();
                 $year = $tm[5];
@@ -261,7 +267,7 @@ function plugin_calendar_showTwig($params)
         $year--;
     }
 
-    $categoryList = array();
+    $categoryList = [];
     if (!empty($params['category'])) {
         $categoryList = explode(',', $params['category']);
     }
@@ -271,11 +277,10 @@ function plugin_calendar_showTwig($params)
 
 function calendar_rpc_manage($params)
 {
-
     $params['flagAJAX'] = true;
-    return array('status' => 1, 'errorCode' => 0, 'data' => plugin_calendar_showTwig($params));
-}
 
+    return ['status' => 1, 'errorCode' => 0, 'data' => plugin_calendar_showTwig($params)];
+}
 
 // Check execution mode
 if (!pluginGetVariable('calendar', 'mode')) {

--- a/calendar/config.php
+++ b/calendar/config.php
@@ -1,31 +1,33 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
 // Preload config file
 plugins_load_config();
 // Fill configuration parameters
-$cfg = array();
-$cfgX = array();
-array_push($cfg, array('descr' => 'Плагин отображает "календарь" - отображает данные о новостях по выбранному месяцу подсвечивая дни когда были размещены новостиПри клике на день будут отображаться новости за этот день'));
-$cfgX = array();
-array_push($cfgX, array('name' => 'mode', 'title' => "В каком режиме генерируется вывод плагина<br /><small><b>Автоматически</b> - при включении плагина автоматически генерируется блок {plugin_comments}<br /><b>TWIG</b> - вывод плагина генерируется только через TWIG функцию <b>callPlugin()</b></small>", 'type' => 'select', 'values' => array('0' => 'Автоматически', '1' => 'TWIG'), 'value' => intval(pluginGetVariable($plugin, 'mode'))));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Режим запуска</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'localsource', 'title' => "Выберите каталог из которого плагин будет брать шаблоны для отображения<br /><small><b>Шаблон сайта</b> - плагин будет пытаться взять шаблоны из общего шаблона сайта; в случае недоступности - шаблоны будут взяты из собственного каталога плагина<br /><b>Плагин</b> - шаблоны будут браться из собственного каталога плагина</small>", 'type' => 'select', 'values' => array('0' => 'Шаблон сайта', '1' => 'Плагин'), 'value' => intval(pluginGetVariable($plugin, 'localsource'))));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки отображения</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'cache', 'title' => "Использовать кеширование данных<br /><small><b>Да</b> - кеширование используется<br /><b>Нет</b> - кеширование не используется</small>", 'type' => 'select', 'values' => array('1' => 'Да', '0' => 'Нет'), 'value' => intval(pluginGetVariable($plugin, 'cache'))));
-array_push($cfgX, array('name' => 'cacheExpire', 'title' => "Период обновления кеша<br /><small>(через сколько секунд происходит обновление кеша. Значение по умолчанию: <b>60</b>)</small>", 'type' => 'input', 'value' => intval(pluginGetVariable($plugin, 'cacheExpire')) ? pluginGetVariable($plugin, 'cacheExpire') : '60'));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки кеширования</b>', 'entries' => $cfgX));
-// RUN 
+$cfg = [];
+$cfgX = [];
+array_push($cfg, ['descr' => 'Плагин отображает "календарь" - отображает данные о новостях по выбранному месяцу подсвечивая дни когда были размещены новостиПри клике на день будут отображаться новости за этот день']);
+$cfgX = [];
+array_push($cfgX, ['name' => 'mode', 'title' => 'В каком режиме генерируется вывод плагина<br /><small><b>Автоматически</b> - при включении плагина автоматически генерируется блок {plugin_comments}<br /><b>TWIG</b> - вывод плагина генерируется только через TWIG функцию <b>callPlugin()</b></small>', 'type' => 'select', 'values' => ['0' => 'Автоматически', '1' => 'TWIG'], 'value' => intval(pluginGetVariable($plugin, 'mode'))]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Режим запуска</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'localsource', 'title' => 'Выберите каталог из которого плагин будет брать шаблоны для отображения<br /><small><b>Шаблон сайта</b> - плагин будет пытаться взять шаблоны из общего шаблона сайта; в случае недоступности - шаблоны будут взяты из собственного каталога плагина<br /><b>Плагин</b> - шаблоны будут браться из собственного каталога плагина</small>', 'type' => 'select', 'values' => ['0' => 'Шаблон сайта', '1' => 'Плагин'], 'value' => intval(pluginGetVariable($plugin, 'localsource'))]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки отображения</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'cache', 'title' => 'Использовать кеширование данных<br /><small><b>Да</b> - кеширование используется<br /><b>Нет</b> - кеширование не используется</small>', 'type' => 'select', 'values' => ['1' => 'Да', '0' => 'Нет'], 'value' => intval(pluginGetVariable($plugin, 'cache'))]);
+array_push($cfgX, ['name' => 'cacheExpire', 'title' => 'Период обновления кеша<br /><small>(через сколько секунд происходит обновление кеша. Значение по умолчанию: <b>60</b>)</small>', 'type' => 'input', 'value' => intval(pluginGetVariable($plugin, 'cacheExpire')) ? pluginGetVariable($plugin, 'cacheExpire') : '60']);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки кеширования</b>', 'entries' => $cfgX]);
+// RUN
 if ($_REQUEST['action'] == 'commit') {
-	// If submit requested, do config save
-	commit_plugin_config_changes($plugin, $cfg);
-	print_commit_complete($plugin);
+    // If submit requested, do config save
+    commit_plugin_config_changes($plugin, $cfg);
+    print_commit_complete($plugin);
 } else {
-	generate_config_page($plugin, $cfg);
+    generate_config_page($plugin, $cfg);
 }
-?>

--- a/clear_config/config.php
+++ b/clear_config/config.php
@@ -1,145 +1,175 @@
 <?php
-if (!defined('NGCMS')) exit('HAL');
+
+if (!defined('NGCMS')) {
+    exit('HAL');
+}
 $lang = LoadLang('users', 'admin');
 LoadPluginLang('clear_config', 'config', '', 'с_с', ':');
 switch ($_REQUEST['action']) {
-	case 'delete':
-		delete();
-		break;
-	default:
-		showlist();
+    case 'delete':
+        delete();
+        break;
+    default:
+        showlist();
 }
-function showlist() {
-
-	global $tpl, $PLUGINS, $lang;
-	plugins_load_config();
-	$ULIB = new urlLibrary();
-	$ULIB->loadConfig();
-	$plug = array();
-	$conf = array();
-	if (isset($PLUGINS['active']['active']) && is_array($PLUGINS['active']['active'])) {
-		foreach ($PLUGINS['active']['active'] as $key => $row) {
-			$plug[] = $key;
-			$conf[$key][] = 'active';
-		}
-	}
-	if (isset($PLUGINS['active']['actions']) && is_array($PLUGINS['active']['actions'])) {
-		foreach ($PLUGINS['active']['actions'] as $key => $row) {
-			if (!is_array($row)) continue;
-			foreach ($row as $kkey => $rrow) {
-				if (!in_array($kkey, $plug)) $plug[] = $kkey;
-				if (!in_array('actions', $conf[$kkey])) $conf[$kkey][] = 'actions';
-			}
-		}
-	}
-	if (isset($PLUGINS['active']['installed']) && is_array($PLUGINS['active']['installed'])) {
-		foreach ($PLUGINS['active']['installed'] as $key => $row) {
-			if (!in_array($key, $plug)) $plug[] = $key;
-			$conf[$key][] = 'installed';
-		}
-	}
-	if (isset($PLUGINS['active']['libs']) && is_array($PLUGINS['active']['libs'])) {
-		foreach ($PLUGINS['active']['libs'] as $key => $row) {
-			if (!in_array($key, $plug)) $plug[] = $key;
-			$conf[$key][] = 'libs';
-		}
-	}
-	if (isset($PLUGINS['config']) && is_array($PLUGINS['config'])) {
-		foreach ($PLUGINS['config'] as $key => $row) {
-			if (!in_array($key, $plug)) $plug[] = $key;
-			$conf[$key][] = 'config';
-		}
-	}
-	if (isset($ULIB->CMD) && is_array($ULIB->CMD)) {
-		foreach ($ULIB->CMD as $key => $row) {
-			if ($key != 'core' && $key != 'static' && $key != 'search' && $key != 'news' && !in_array($key, $plug)) $plug[] = $key;
-			$conf[$key][] = 'urlcmd';
-		}
-	}
-	$tpath = locatePluginTemplates(array('conf.list', 'conf.list.row'), 'clear_config');
-	$output = '';
-	sort($plug);
-	foreach ($plug as $key => $row) {
-		$pvars['vars']['id'] = $row;
-		$pvars['vars']['conf'] = '';
-		foreach ($conf[$row] as $kkey => $rrow) {
-			$pvars['vars']['conf'] .=
-				'<a href="/engine/admin.php?mod=extra-config&plugin=clear_config&action=delete&id=' . $row .
-				'&conf=' . $rrow .
-				'" title="' . $lang['с_с:' . $rrow] .
-				'" onclick="return confirm(\'' . sprintf($lang['с_с:confirm'], $lang['с_с:' . $rrow], $row) . '\');" ' .
-				'><img src="/engine/plugins/clear_config/tpl/images/' . $rrow . '.png" /></a>&#160;';
-		}
-		$tpl->template('conf.list.row', $tpath['conf.list.row']);
-		$tpl->vars('conf.list.row', $pvars);
-		$output .= $tpl->show('conf.list.row');
-	}
-	$tvars['vars']['entries'] = $output;
-	$tpl->template('conf.list', $tpath['conf.list']);
-	$tpl->vars('conf.list', $tvars);
-	print $tpl->show('conf.list');
+function showlist()
+{
+    global $tpl, $PLUGINS, $lang;
+    plugins_load_config();
+    $ULIB = new urlLibrary();
+    $ULIB->loadConfig();
+    $plug = [];
+    $conf = [];
+    if (isset($PLUGINS['active']['active']) && is_array($PLUGINS['active']['active'])) {
+        foreach ($PLUGINS['active']['active'] as $key => $row) {
+            $plug[] = $key;
+            $conf[$key][] = 'active';
+        }
+    }
+    if (isset($PLUGINS['active']['actions']) && is_array($PLUGINS['active']['actions'])) {
+        foreach ($PLUGINS['active']['actions'] as $key => $row) {
+            if (!is_array($row)) {
+                continue;
+            }
+            foreach ($row as $kkey => $rrow) {
+                if (!in_array($kkey, $plug)) {
+                    $plug[] = $kkey;
+                }
+                if (!in_array('actions', $conf[$kkey])) {
+                    $conf[$kkey][] = 'actions';
+                }
+            }
+        }
+    }
+    if (isset($PLUGINS['active']['installed']) && is_array($PLUGINS['active']['installed'])) {
+        foreach ($PLUGINS['active']['installed'] as $key => $row) {
+            if (!in_array($key, $plug)) {
+                $plug[] = $key;
+            }
+            $conf[$key][] = 'installed';
+        }
+    }
+    if (isset($PLUGINS['active']['libs']) && is_array($PLUGINS['active']['libs'])) {
+        foreach ($PLUGINS['active']['libs'] as $key => $row) {
+            if (!in_array($key, $plug)) {
+                $plug[] = $key;
+            }
+            $conf[$key][] = 'libs';
+        }
+    }
+    if (isset($PLUGINS['config']) && is_array($PLUGINS['config'])) {
+        foreach ($PLUGINS['config'] as $key => $row) {
+            if (!in_array($key, $plug)) {
+                $plug[] = $key;
+            }
+            $conf[$key][] = 'config';
+        }
+    }
+    if (isset($ULIB->CMD) && is_array($ULIB->CMD)) {
+        foreach ($ULIB->CMD as $key => $row) {
+            if ($key != 'core' && $key != 'static' && $key != 'search' && $key != 'news' && !in_array($key, $plug)) {
+                $plug[] = $key;
+            }
+            $conf[$key][] = 'urlcmd';
+        }
+    }
+    $tpath = locatePluginTemplates(['conf.list', 'conf.list.row'], 'clear_config');
+    $output = '';
+    sort($plug);
+    foreach ($plug as $key => $row) {
+        $pvars['vars']['id'] = $row;
+        $pvars['vars']['conf'] = '';
+        foreach ($conf[$row] as $kkey => $rrow) {
+            $pvars['vars']['conf'] .=
+                '<a href="/engine/admin.php?mod=extra-config&plugin=clear_config&action=delete&id='.$row.
+                '&conf='.$rrow.
+                '" title="'.$lang['с_с:'.$rrow].
+                '" onclick="return confirm(\''.sprintf($lang['с_с:confirm'], $lang['с_с:'.$rrow], $row).'\');" '.
+                '><img src="/engine/plugins/clear_config/tpl/images/'.$rrow.'.png" /></a>&#160;';
+        }
+        $tpl->template('conf.list.row', $tpath['conf.list.row']);
+        $tpl->vars('conf.list.row', $pvars);
+        $output .= $tpl->show('conf.list.row');
+    }
+    $tvars['vars']['entries'] = $output;
+    $tpl->template('conf.list', $tpath['conf.list']);
+    $tpl->vars('conf.list', $tvars);
+    echo $tpl->show('conf.list');
 }
 
-function delete() {
+function delete()
+{
+    global $PLUGINS, $lang;
+    if (!isset($_REQUEST['id']) || !isset($_REQUEST['conf'])) {
+        msg(['type' => 'info', 'info' => $lang['с_с:error']]);
+        showlist();
 
-	global $PLUGINS, $lang;
-	if (!isset($_REQUEST['id']) || !isset($_REQUEST['conf'])) {
-		msg(array('type' => 'info', 'info' => $lang['с_с:error']));
-		showlist();
-
-		return false;
-	}
-	$id = secure_html(convert($_REQUEST['id']));
-	$conf = secure_html(convert($_REQUEST['conf']));
-	switch ($conf) {
-		case 'active':
-			if (isset($PLUGINS['active']['active'][$id])) {
-				unset($PLUGINS['active']['active'][$id]);
-				msg(array('type' => 'info', 'info' => sprintf($lang['с_с:del_ok'], 'active', $id)));
-			} else msg(array('type' => 'info', 'info' => sprintf($lang['с_с:del_er'], 'active', $id)));
-			break;
-		case 'actions':
-			$if_delete = false;
-			if (isset($PLUGINS['active']['actions']) && is_array($PLUGINS['active']['actions'])) {
-				foreach ($PLUGINS['active']['actions'] as $key => $row) {
-					if (isset($PLUGINS['active']['actions'][$key][$id])) {
-						unset($PLUGINS['active']['actions'][$key][$id]);
-						$if_delete = true;
-					}
-				}
-			}
-			if ($if_delete) msg(array('type' => 'info', 'info' => sprintf($lang['с_с:del_ok'], 'actions', $id)));
-			else msg(array('type' => 'info', 'info' => sprintf($lang['с_с:del_er'], 'actions', $id)));
-			break;
-		case 'installed':
-			if (isset($PLUGINS['active']['installed'][$id])) {
-				unset($PLUGINS['active']['installed'][$id]);
-				msg(array('type' => 'info', 'info' => sprintf($lang['с_с:del_ok'], 'installed', $id)));
-			} else msg(array('type' => 'info', 'info' => sprintf($lang['с_с:del_er'], 'installed', $id)));
-			break;
-		case 'libs':
-			if (isset($PLUGINS['active']['libs'][$id])) {
-				unset($PLUGINS['active']['libs'][$id]);
-				msg(array('type' => 'info', 'info' => sprintf($lang['с_с:del_ok'], 'libs', $id)));
-			} else msg(array('type' => 'info', 'info' => sprintf($lang['с_с:del_er'], 'libs', $id)));
-			break;
-		case 'config':
-			if (isset($PLUGINS['config'][$id])) {
-				unset($PLUGINS['config'][$id]);
-				msg(array('type' => 'info', 'info' => sprintf($lang['с_с:del_ok'], 'config', $id)));
-			} else msg(array('type' => 'info', 'info' => sprintf($lang['с_с:del_er'], 'config', $id)));
-			break;
-		case 'urlcmd':
-			$ULIB = new urlLibrary();
-			$ULIB->loadConfig();
-			if (isset($ULIB->CMD[$id])) {
-				unset($ULIB->CMD[$id]);
-				msg(array('type' => 'info', 'info' => sprintf($lang['с_с:del_ok'], 'urlcmd', $id)));
-			} else msg(array('type' => 'info', 'info' => sprintf($lang['с_с:del_er'], 'urlcmd', $id)));
-			$ULIB->saveConfig();
-			break;
-	}
-	pluginsSaveConfig();
-	savePluginsActiveList();
-	showlist();
+        return false;
+    }
+    $id = secure_html(convert($_REQUEST['id']));
+    $conf = secure_html(convert($_REQUEST['conf']));
+    switch ($conf) {
+        case 'active':
+            if (isset($PLUGINS['active']['active'][$id])) {
+                unset($PLUGINS['active']['active'][$id]);
+                msg(['type' => 'info', 'info' => sprintf($lang['с_с:del_ok'], 'active', $id)]);
+            } else {
+                msg(['type' => 'info', 'info' => sprintf($lang['с_с:del_er'], 'active', $id)]);
+            }
+            break;
+        case 'actions':
+            $if_delete = false;
+            if (isset($PLUGINS['active']['actions']) && is_array($PLUGINS['active']['actions'])) {
+                foreach ($PLUGINS['active']['actions'] as $key => $row) {
+                    if (isset($PLUGINS['active']['actions'][$key][$id])) {
+                        unset($PLUGINS['active']['actions'][$key][$id]);
+                        $if_delete = true;
+                    }
+                }
+            }
+            if ($if_delete) {
+                msg(['type' => 'info', 'info' => sprintf($lang['с_с:del_ok'], 'actions', $id)]);
+            } else {
+                msg(['type' => 'info', 'info' => sprintf($lang['с_с:del_er'], 'actions', $id)]);
+            }
+            break;
+        case 'installed':
+            if (isset($PLUGINS['active']['installed'][$id])) {
+                unset($PLUGINS['active']['installed'][$id]);
+                msg(['type' => 'info', 'info' => sprintf($lang['с_с:del_ok'], 'installed', $id)]);
+            } else {
+                msg(['type' => 'info', 'info' => sprintf($lang['с_с:del_er'], 'installed', $id)]);
+            }
+            break;
+        case 'libs':
+            if (isset($PLUGINS['active']['libs'][$id])) {
+                unset($PLUGINS['active']['libs'][$id]);
+                msg(['type' => 'info', 'info' => sprintf($lang['с_с:del_ok'], 'libs', $id)]);
+            } else {
+                msg(['type' => 'info', 'info' => sprintf($lang['с_с:del_er'], 'libs', $id)]);
+            }
+            break;
+        case 'config':
+            if (isset($PLUGINS['config'][$id])) {
+                unset($PLUGINS['config'][$id]);
+                msg(['type' => 'info', 'info' => sprintf($lang['с_с:del_ok'], 'config', $id)]);
+            } else {
+                msg(['type' => 'info', 'info' => sprintf($lang['с_с:del_er'], 'config', $id)]);
+            }
+            break;
+        case 'urlcmd':
+            $ULIB = new urlLibrary();
+            $ULIB->loadConfig();
+            if (isset($ULIB->CMD[$id])) {
+                unset($ULIB->CMD[$id]);
+                msg(['type' => 'info', 'info' => sprintf($lang['с_с:del_ok'], 'urlcmd', $id)]);
+            } else {
+                msg(['type' => 'info', 'info' => sprintf($lang['с_с:del_er'], 'urlcmd', $id)]);
+            }
+            $ULIB->saveConfig();
+            break;
+    }
+    pluginsSaveConfig();
+    savePluginsActiveList();
+    showlist();
 }

--- a/comments/comments.php
+++ b/comments/comments.php
@@ -1,446 +1,455 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
-$lang = LoadLang("comments", "site");
+if (!defined('NGCMS')) {
+    die('HAL');
+}
+$lang = LoadLang('comments', 'site');
 
-class CommentsNewsFilter extends NewsFilter {
+class CommentsNewsFilter extends NewsFilter
+{
+    public function addNewsForm(&$tvars)
+    {
+        global $lang;
+        loadPluginLang('comments', 'config', '', '', ':');
+        for ($ix = 0; $ix <= 2; $ix++) {
+            $tvars['plugin']['comments']['acom:'.$ix] = (pluginGetVariable('comments', 'default_news') == $ix) ? 'selected="selected"' : '';
+        }
+    }
 
-	function addNewsForm(&$tvars) {
+    public function addNews(&$tvars, &$SQL)
+    {
+        $SQL['allow_com'] = intval($_REQUEST['allow_com']);
 
-		global $lang;
-		loadPluginLang('comments', 'config', '', '', ':');
-		for ($ix = 0; $ix <= 2; $ix++) {
-			$tvars['plugin']['comments']['acom:' . $ix] = (pluginGetVariable('comments', 'default_news') == $ix) ? 'selected="selected"' : '';
-		}
-	}
+        return 1;
+    }
 
-	function addNews(&$tvars, &$SQL) {
+    public function editNewsForm($newsID, $SQLnews, &$tvars)
+    {
+        global $lang, $mysql, $config, $parse, $tpl, $PHP_SELF;
+        loadPluginLang('comments', 'config', '', '', ':');
+        // List comments
+        $comments = '';
+        $tpl->template('comments', tpl_actions.'news');
+        foreach ($mysql->select('select * from '.prefix."_comments where post='".$newsID."' order by id") as $crow) {
+            $text = $crow['text'];
+            if ($config['blocks_for_reg']) {
+                $text = $parse->userblocks($text);
+            }
+            if ($config['use_bbcodes']) {
+                $text = $parse->bbcodes($text);
+            }
+            if ($config['use_htmlformatter']) {
+                $text = $parse->htmlformatter($text);
+            }
+            if ($config['use_smilies']) {
+                $text = $parse->smilies($text);
+            }
+            $txvars['vars'] = [
+                'php_self'   => $PHP_SELF,
+                'com_author' => $crow['author'],
+                'com_post'   => $crow['post'],
+                'com_url'    => ($crow['url']) ? $crow['url'] : $PHP_SELF.'?mod=users&action=edituser&id='.$crow['author_id'],
+                'com_id'     => $crow['id'],
+                'com_ip'     => $crow['ip'],
+                'com_time'   => LangDate(pluginGetVariable('comments', 'timestamp'), $crow['postdate']),
+                'com_part'   => $text,
+            ];
+            if ($crow['reg']) {
+                $txvars['vars']['[userlink]'] = '';
+                $txvars['vars']['[/userlink]'] = '';
+            } else {
+                $txvars['regx']["'\\[userlink\\].*?\\[/userlink\\]'si"] = $crow['author'];
+            }
+            $tpl->vars('comments', $txvars);
+            $comments .= $tpl->show('comments');
+        }
+        $tvars['plugin']['comments']['list'] = $comments;
+        $tvars['plugin']['comments']['count'] = $SQLnews['com'] ? $SQLnews['com'] : $lang['noa'];
+        for ($ix = 0; $ix <= 2; $ix++) {
+            $tvars['plugin']['comments']['acom:'.$ix] = ($SQLnews['allow_com'] == $ix) ? 'selected="selected"' : '';
+        }
+    }
 
-		$SQL['allow_com'] = intval($_REQUEST['allow_com']);
+    public function editNews($newsID, $SQLold, &$SQLnew, &$tvars)
+    {
+        $SQLnew['allow_com'] = intval($_REQUEST['allow_com']);
 
-		return 1;
-	}
+        return 1;
+    }
 
-	function editNewsForm($newsID, $SQLnews, &$tvars) {
+    public function showNews($newsID, $SQLnews, &$tvars, $callingParams = [])
+    {
+        global $catmap, $catz, $config, $userROW, $template, $lang, $tpl;
+        // Determine if comments are allowed in  this specific news
+        $allowCom = $SQLnews['allow_com'];
+        if ($allowCom == 2) {
+            // `Use default` - check master category
+            $masterCat = intval(array_shift(explode(',', $SQLnews['catid'])));
+            if ($masterCat && isset($catmap[$masterCat])) {
+                $allowCom = intval($catz[$catmap[$masterCat]]['allow_com']);
+            }
+            // If we still have 2 (no master category or master category also have 'default' - fetch plugin's config
+            if ($allowCom == 2) {
+                $allowCom = pluginGetVariable('comments', 'global_default');
+            }
+        }
+        // Fill variables within news template
+        $tvars['vars']['comments-num'] = $SQLnews['com'];
+        $tvars['vars']['comnum'] = $SQLnews['com'];
+        $tvars['regx']['[\[comheader\](.*)\[/comheader\]]'] = ($SQLnews['com']) ? '$1' : '';
+        // Blocks [comments] .. [/comments] and [nocomments] .. [/nocomments]
+        $tvars['regx']['[\[comments\](.*)\[/comments\]]'] = ($SQLnews['com']) ? '$1' : '';
+        $tvars['regx']['[\[nocomments\](.*)\[/nocomments\]]'] = ($SQLnews['com']) ? '' : '$1';
+        // Check if we need to add comments block:
+        //	* style == full
+        //  * emulate == false
+        //  * plugin == not set
+        if (!(($callingParams['style'] == 'full') && (!$callingParams['emulate']) && (!isset($callingParams['plugin'])))) {
+            // No, we don't need to show comments
+            $tvars['vars']['plugin_comments'] = '';
 
-		global $lang, $mysql, $config, $parse, $tpl, $PHP_SELF;
-		loadPluginLang('comments', 'config', '', '', ':');
-		// List comments
-		$comments = '';
-		$tpl->template('comments', tpl_actions . 'news');
-		foreach ($mysql->select("select * from " . prefix . "_comments where post='" . $newsID . "' order by id") as $crow) {
-			$text = $crow['text'];
-			if ($config['blocks_for_reg']) {
-				$text = $parse->userblocks($text);
-			}
-			if ($config['use_bbcodes']) {
-				$text = $parse->bbcodes($text);
-			}
-			if ($config['use_htmlformatter']) {
-				$text = $parse->htmlformatter($text);
-			}
-			if ($config['use_smilies']) {
-				$text = $parse->smilies($text);
-			}
-			$txvars['vars'] = array(
-				'php_self'   => $PHP_SELF,
-				'com_author' => $crow['author'],
-				'com_post'   => $crow['post'],
-				'com_url'    => ($crow['url']) ? $crow['url'] : $PHP_SELF . '?mod=users&action=edituser&id=' . $crow['author_id'],
-				'com_id'     => $crow['id'],
-				'com_ip'     => $crow['ip'],
-				'com_time'   => LangDate(pluginGetVariable('comments', 'timestamp'), $crow['postdate']),
-				'com_part'   => $text
-			);
-			if ($crow['reg']) {
-				$txvars['vars']['[userlink]'] = '';
-				$txvars['vars']['[/userlink]'] = '';
-			} else {
-				$txvars['regx']["'\\[userlink\\].*?\\[/userlink\\]'si"] = $crow['author'];
-			}
-			$tpl->vars('comments', $txvars);
-			$comments .= $tpl->show('comments');
-		}
-		$tvars['plugin']['comments']['list'] = $comments;
-		$tvars['plugin']['comments']['count'] = $SQLnews['com'] ? $SQLnews['com'] : $lang['noa'];
-		for ($ix = 0; $ix <= 2; $ix++) {
-			$tvars['plugin']['comments']['acom:' . $ix] = ($SQLnews['allow_com'] == $ix) ? 'selected="selected"' : '';
-		}
-	}
-
-	function editNews($newsID, $SQLold, &$SQLnew, &$tvars) {
-
-		$SQLnew['allow_com'] = intval($_REQUEST['allow_com']);
-
-		return 1;
-	}
-
-	function showNews($newsID, $SQLnews, &$tvars, $callingParams = array()) {
-
-		global $catmap, $catz, $config, $userROW, $template, $lang, $tpl;
-		// Determine if comments are allowed in  this specific news
-		$allowCom = $SQLnews['allow_com'];
-		if ($allowCom == 2) {
-			// `Use default` - check master category
-			$masterCat = intval(array_shift(explode(',', $SQLnews['catid'])));
-			if ($masterCat && isset($catmap[$masterCat])) {
-				$allowCom = intval($catz[$catmap[$masterCat]]['allow_com']);
-			}
-			// If we still have 2 (no master category or master category also have 'default' - fetch plugin's config
-			if ($allowCom == 2) {
-				$allowCom = pluginGetVariable('comments', 'global_default');
-			}
-		}
-		// Fill variables within news template
-		$tvars['vars']['comments-num'] = $SQLnews['com'];
-		$tvars['vars']['comnum'] = $SQLnews['com'];
-		$tvars['regx']['[\[comheader\](.*)\[/comheader\]]'] = ($SQLnews['com']) ? '$1' : '';
-		// Blocks [comments] .. [/comments] and [nocomments] .. [/nocomments]
-		$tvars['regx']['[\[comments\](.*)\[/comments\]]'] = ($SQLnews['com']) ? '$1' : '';
-		$tvars['regx']['[\[nocomments\](.*)\[/nocomments\]]'] = ($SQLnews['com']) ? '' : '$1';
-		// Check if we need to add comments block:
-		//	* style == full
-		//  * emulate == false
-		//  * plugin == not set
-		if (!(($callingParams['style'] == 'full') && (!$callingParams['emulate']) && (!isset($callingParams['plugin'])))) {
-			// No, we don't need to show comments
-			$tvars['vars']['plugin_comments'] = '';
-
-			return 1;
-		}
-		// ******************************************** //
-		// Yeah, let's show comments here
-		// ******************************************** //
-		// Prepare params for call
-		$callingCommentsParams = array('outprint' => true, 'total' => $SQLnews['com']);
-		// Set default template path
-		$templatePath = tpl_site . 'plugins/comments';
-		$fcat = array_shift(explode(",", $SQLnews['catid']));
-		// Check if there is a custom mapping
-		if ($fcat && $catmap[$fcat] && ($ctname = $catz[$catmap[$fcat]]['tpl'])) {
-			// Check if directory exists
-			if (is_dir(tpl_site . 'ncustom/' . $ctname)) {
-				$callingCommentsParams['overrideTemplatePath'] = tpl_site . 'ncustom/' . $ctname;
-				$templatePath = tpl_site . 'ncustom/' . $ctname;
-			}
-		}
-		include_once(root . "/plugins/comments/inc/comments.show.php");
-		// Check if we need pagination
-		$flagMoreComments = false;
-		$skipCommShow = false;
-		if (pluginGetVariable('comments', 'multipage')) {
-			$multi_mcount = intval(pluginGetVariable('comments', 'multi_mcount'));
-			// If we have comments more than for one page - activate pagination
-			if (($multi_mcount >= 0) && ($SQLnews['com'] > $multi_mcount)) {
-				$callingCommentsParams['limitCount'] = $multi_mcount;
-				$flagMoreComments = true;
-				if (!$multi_mcount)
-					$skipCommShow = true;
-			}
-		}
-		$tcvars = array();
-		// Show comments [ if not skipped ]
-		$tcvars['vars']['entries'] = $skipCommShow ? '' : comments_show($newsID, 0, 0, $callingCommentsParams);
-		// If multipage is used and we have more comments - show
-		if ($flagMoreComments) {
-			$link = checkLinkAvailable('comments', 'show') ?
-				generateLink('comments', 'show', array('news_id' => $newsID)) :
-				generateLink('core', 'plugin', array('plugin' => 'comments', 'handler' => 'show'), array('news_id' => $newsID));
-			$tcvars['vars']['more_comments'] = str_replace(array('{link}', '{count}'), array($link, $SQLnews['com']), $lang['comments:link.more']);
-			$tcvars['regx']['#\[more_comments\](.*?)\[\/more_comments\]#is'] = '$1';
-		} else {
-			$tcvars['vars']['more_comments'] = '';
-			$tcvars['regx']['#\[more_comments\](.*?)\[\/more_comments\]#is'] = '';
-		}
-		// Show form for adding comments
-		if ($allowCom && (!pluginGetVariable('comments', 'regonly') || is_array($userROW))) {
-			$tcvars['vars']['form'] = comments_showform($newsID, $callingCommentsParams);
-			$tcvars['regx']['#\[regonly\](.*?)\[\/regonly\]#is'] = '';
-			$tcvars['regx']['#\[commforbidden\](.*?)\[\/commforbidden\]#is'] = '';
-		} else {
-			$tcvars['vars']['form'] = '';
-			$tcvars['regx']['#\[regonly\](.*?)\[\/regonly\]#is'] = $allowCom ? '$1' : '';
-			$tcvars['regx']['#\[commforbidden\](.*?)\[\/commforbidden\]#is'] = $allowCom ? '' : '$1';
-		}
-		$tcvars['regx']['#\[comheader\](.*)\[/comheader\]#is'] = ($SQLnews['com']) ? '$1' : '';
-		$tpl->template('comments.internal', $templatePath);
-		$tpl->vars('comments.internal', $tcvars);
-		$tvars['vars']['plugin_comments'] = $tpl->show('comments.internal');
-	}
+            return 1;
+        }
+        // ******************************************** //
+        // Yeah, let's show comments here
+        // ******************************************** //
+        // Prepare params for call
+        $callingCommentsParams = ['outprint' => true, 'total' => $SQLnews['com']];
+        // Set default template path
+        $templatePath = tpl_site.'plugins/comments';
+        $fcat = array_shift(explode(',', $SQLnews['catid']));
+        // Check if there is a custom mapping
+        if ($fcat && $catmap[$fcat] && ($ctname = $catz[$catmap[$fcat]]['tpl'])) {
+            // Check if directory exists
+            if (is_dir(tpl_site.'ncustom/'.$ctname)) {
+                $callingCommentsParams['overrideTemplatePath'] = tpl_site.'ncustom/'.$ctname;
+                $templatePath = tpl_site.'ncustom/'.$ctname;
+            }
+        }
+        include_once root.'/plugins/comments/inc/comments.show.php';
+        // Check if we need pagination
+        $flagMoreComments = false;
+        $skipCommShow = false;
+        if (pluginGetVariable('comments', 'multipage')) {
+            $multi_mcount = intval(pluginGetVariable('comments', 'multi_mcount'));
+            // If we have comments more than for one page - activate pagination
+            if (($multi_mcount >= 0) && ($SQLnews['com'] > $multi_mcount)) {
+                $callingCommentsParams['limitCount'] = $multi_mcount;
+                $flagMoreComments = true;
+                if (!$multi_mcount) {
+                    $skipCommShow = true;
+                }
+            }
+        }
+        $tcvars = [];
+        // Show comments [ if not skipped ]
+        $tcvars['vars']['entries'] = $skipCommShow ? '' : comments_show($newsID, 0, 0, $callingCommentsParams);
+        // If multipage is used and we have more comments - show
+        if ($flagMoreComments) {
+            $link = checkLinkAvailable('comments', 'show') ?
+                generateLink('comments', 'show', ['news_id' => $newsID]) :
+                generateLink('core', 'plugin', ['plugin' => 'comments', 'handler' => 'show'], ['news_id' => $newsID]);
+            $tcvars['vars']['more_comments'] = str_replace(['{link}', '{count}'], [$link, $SQLnews['com']], $lang['comments:link.more']);
+            $tcvars['regx']['#\[more_comments\](.*?)\[\/more_comments\]#is'] = '$1';
+        } else {
+            $tcvars['vars']['more_comments'] = '';
+            $tcvars['regx']['#\[more_comments\](.*?)\[\/more_comments\]#is'] = '';
+        }
+        // Show form for adding comments
+        if ($allowCom && (!pluginGetVariable('comments', 'regonly') || is_array($userROW))) {
+            $tcvars['vars']['form'] = comments_showform($newsID, $callingCommentsParams);
+            $tcvars['regx']['#\[regonly\](.*?)\[\/regonly\]#is'] = '';
+            $tcvars['regx']['#\[commforbidden\](.*?)\[\/commforbidden\]#is'] = '';
+        } else {
+            $tcvars['vars']['form'] = '';
+            $tcvars['regx']['#\[regonly\](.*?)\[\/regonly\]#is'] = $allowCom ? '$1' : '';
+            $tcvars['regx']['#\[commforbidden\](.*?)\[\/commforbidden\]#is'] = $allowCom ? '' : '$1';
+        }
+        $tcvars['regx']['#\[comheader\](.*)\[/comheader\]#is'] = ($SQLnews['com']) ? '$1' : '';
+        $tpl->template('comments.internal', $templatePath);
+        $tpl->vars('comments.internal', $tcvars);
+        $tvars['vars']['plugin_comments'] = $tpl->show('comments.internal');
+    }
 }
 
-class CommentsFilterAdminCategories extends FilterAdminCategories {
+class CommentsFilterAdminCategories extends FilterAdminCategories
+{
+    public function addCategory(&$tvars, &$SQL)
+    {
+        $SQL['allow_com'] = intval($_REQUEST['allow_com']);
 
-	function addCategory(&$tvars, &$SQL) {
+        return 1;
+    }
 
-		$SQL['allow_com'] = intval($_REQUEST['allow_com']);
+    public function addCategoryForm(&$tvars)
+    {
+        global $lang;
+        loadPluginLang('comments', 'config', '', '', ':');
+        $allowCom = pluginGetVariable('comments', 'default_categories');
+        $ms = '<select name="allow_com">';
+        $cv = ['0' => 'запретить', '1' => 'разрешить', '2' => 'по умолчанию'];
+        for ($i = 0; $i < 3; $i++) {
+            $ms .= '<option value="'.$i.'"'.(($allowCom == $i) ? ' selected="selected"' : '').'>'.$cv[$i].'</option>';
+        }
+        $tvars['extend'] .= '<tr><td width="70%" class="contentEntry1">'.$lang['comments:categories.comments'].'<br/><small>'.$lang['comments:categories.comments#desc'].'</small></td><td width="30%" class="contentEntry2">'.$ms.'</td></tr>';
 
-		return 1;
-	}
+        return 1;
+    }
 
-	function addCategoryForm(&$tvars) {
+    public function editCategoryForm($categoryID, $SQL, &$tvars)
+    {
+        global $lang;
+        loadPluginLang('comments', 'config', '', '', ':');
+        if (!isset($SQL['allow_com'])) {
+            $SQL['allow_com'] = pluginGetVariable('comments', 'default_categories');
+        }
+        $ms = '<select name="allow_com">';
+        $cv = ['0' => 'запретить', '1' => 'разрешить', '2' => 'по умолчанию'];
+        for ($i = 0; $i < 3; $i++) {
+            $ms .= '<option value="'.$i.'"'.(($SQL['allow_com'] == $i) ? ' selected="selected"' : '').'>'.$cv[$i].'</option>';
+        }
+        $tvars['extend'] .= '<tr><td width="70%" class="contentEntry1">'.$lang['comments:categories.comments'].'<br/><small>'.$lang['comments:categories.comments#desc'].'</small></td><td width="30%" class="contentEntry2">'.$ms.'</td></tr>';
 
-		global $lang;
-		loadPluginLang('comments', 'config', '', '', ':');
-		$allowCom = pluginGetVariable('comments', 'default_categories');
-		$ms = '<select name="allow_com">';
-		$cv = array('0' => 'запретить', '1' => 'разрешить', '2' => 'по умолчанию');
-		for ($i = 0; $i < 3; $i++) {
-			$ms .= '<option value="' . $i . '"' . (($allowCom == $i) ? ' selected="selected"' : '') . '>' . $cv[$i] . '</option>';
-		}
-		$tvars['extend'] .= '<tr><td width="70%" class="contentEntry1">' . $lang['comments:categories.comments'] . '<br/><small>' . $lang['comments:categories.comments#desc'] . '</small></td><td width="30%" class="contentEntry2">' . $ms . '</td></tr>';
+        return 1;
+    }
 
-		return 1;
-	}
+    public function editCategory($categoryID, $SQL, &$SQLnew, &$tvars)
+    {
+        $SQLnew['allow_com'] = intval($_REQUEST['allow_com']);
 
-	function editCategoryForm($categoryID, $SQL, &$tvars) {
-
-		global $lang;
-		loadPluginLang('comments', 'config', '', '', ':');
-		if (!isset($SQL['allow_com'])) {
-			$SQL['allow_com'] = pluginGetVariable('comments', 'default_categories');
-		}
-		$ms = '<select name="allow_com">';
-		$cv = array('0' => 'запретить', '1' => 'разрешить', '2' => 'по умолчанию');
-		for ($i = 0; $i < 3; $i++) {
-			$ms .= '<option value="' . $i . '"' . (($SQL['allow_com'] == $i) ? ' selected="selected"' : '') . '>' . $cv[$i] . '</option>';
-		}
-		$tvars['extend'] .= '<tr><td width="70%" class="contentEntry1">' . $lang['comments:categories.comments'] . '<br/><small>' . $lang['comments:categories.comments#desc'] . '</small></td><td width="30%" class="contentEntry2">' . $ms . '</td></tr>';
-
-		return 1;
-	}
-
-	function editCategory($categoryID, $SQL, &$SQLnew, &$tvars) {
-
-		$SQLnew['allow_com'] = intval($_REQUEST['allow_com']);
-
-		return 1;
-	}
+        return 1;
+    }
 }
 
-function plugin_comments_add() {
+function plugin_comments_add()
+{
+    global $config, $catz, $catmap, $tpl, $template, $lang, $SUPRESS_TEMPLATE_SHOW;
+    $SUPRESS_TEMPLATE_SHOW = 1;
+    // Connect library
+    include_once root.'/plugins/comments/inc/comments.show.php';
+    include_once root.'/plugins/comments/inc/comments.add.php';
+    // Call comments_add() to ADD COMMENT
+    if (is_array($addResult = comments_add())) {
+        // Ok.
+        // Check if AJAX mode is turned OFF
+        if (!$_REQUEST['ajax']) {
+            // We should JUMP to this new comment
+            // Make FULL news link
+            $nlink = newsGenerateLink($addResult[0]);
+            // Make redirect to full news
+            @header('Location: '.$nlink);
 
-	global $config, $catz, $catmap, $tpl, $template, $lang, $SUPRESS_TEMPLATE_SHOW;
-	$SUPRESS_TEMPLATE_SHOW = 1;
-	// Connect library
-	include_once(root . "/plugins/comments/inc/comments.show.php");
-	include_once(root . "/plugins/comments/inc/comments.add.php");
-	// Call comments_add() to ADD COMMENT
-	if (is_array($addResult = comments_add())) {
-		// Ok.
-		// Check if AJAX mode is turned OFF
-		if (!$_REQUEST['ajax']) {
-			// We should JUMP to this new comment
-			// Make FULL news link
-			$nlink = newsGenerateLink($addResult[0]);
-			// Make redirect to full news
-			@header("Location: " . $nlink);
+            return 1;
+        }
+        // AJAX MODE.
+        // Let's print (ONLY) new comment
+        $SQLnews = $addResult[0];
+        $commentId = $addResult[1];
+        // Check if we need to override news template
+        $callingCommentsParams = ['outprint' => true];
+        // Set default template path
+        $templatePath = tpl_dir.$config['theme'];
+        // Find first category
+        $fcat = array_shift(explode(',', $SQLnews['catid']));
+        // Check if there is a custom mapping
+        if ($fcat && $catmap[$fcat] && ($ctname = $catz[$catmap[$fcat]]['tpl'])) {
+            // Check if directory exists
+            if (is_dir($templatePath.'/ncustom/'.$ctname)) {
+                $callingCommentsParams['overrideTemplatePath'] = $templatePath.'/ncustom/'.$ctname;
+            }
+        }
+        $output = [
+            'status' => 1,
+            'rev'    => intval(pluginGetVariable('comments', 'backorder')),
+            'data'   => iconv('Windows-1251', 'UTF-8', comments_show($SQLnews['id'], $commentId, $SQLnews['com'] + 1, $callingCommentsParams)),
+        ];
+        echo json_encode($output);
+        $template['vars']['mainblock'] = '';
 
-			return 1;
-		}
-		// AJAX MODE.
-		// Let's print (ONLY) new comment
-		$SQLnews = $addResult[0];
-		$commentId = $addResult[1];
-		// Check if we need to override news template
-		$callingCommentsParams = array('outprint' => true);
-		// Set default template path
-		$templatePath = tpl_dir . $config['theme'];
-		// Find first category
-		$fcat = array_shift(explode(",", $SQLnews['catid']));
-		// Check if there is a custom mapping
-		if ($fcat && $catmap[$fcat] && ($ctname = $catz[$catmap[$fcat]]['tpl'])) {
-			// Check if directory exists
-			if (is_dir($templatePath . '/ncustom/' . $ctname))
-				$callingCommentsParams['overrideTemplatePath'] = $templatePath . '/ncustom/' . $ctname;
-		}
-		$output = array(
-			'status' => 1,
-			'rev'    => intval(pluginGetVariable('comments', 'backorder')),
-			'data'   => iconv('Windows-1251', 'UTF-8', comments_show($SQLnews['id'], $commentId, $SQLnews['com'] + 1, $callingCommentsParams))
-		);
-		print json_encode($output);
-		$template['vars']['mainblock'] = '';
-
-		return 1;
-	} else {
-		// Some errors.
-		if ($_REQUEST['ajax']) {
-			// AJAX MODE
-			// Set default template path [from site template / comments plugin subdirectory]
-			$templatePath = tpl_site . 'plugins/comments';
-			$tpl->template('comments.error', $templatePath);
-			$tpl->vars('comments.error', array('vars' => array('content' => $template['vars']['mainblock'])));
-			$output = array(
-				'status' => 0,
-				'data'   => iconv('Windows-1251', 'UTF-8', $tpl->show('comments.error'))
-			);
-			print json_encode($output);
-			$template['vars']['mainblock'] = '';
-		} else {
-			// NON-AJAX MODE
-			$tavars = array(
-				'vars' => array(
-					'title'    => $lang['comments:err.redir.title'],
-					'message'  => $template['vars']['mainblock'],
-					'link'     => secure_html(($_REQUEST['referer']) ? $_REQUEST['referer'] : '/'),
-					'linktext' => $lang['comments:err.redir.url'],
-				)
-			);
-			$tpl->template('redirect', tpl_site);
-			$tpl->vars('redirect', $tavars);
-			$template['vars']['mainblock'] = $tpl->show('redirect');
-		}
-	}
+        return 1;
+    } else {
+        // Some errors.
+        if ($_REQUEST['ajax']) {
+            // AJAX MODE
+            // Set default template path [from site template / comments plugin subdirectory]
+            $templatePath = tpl_site.'plugins/comments';
+            $tpl->template('comments.error', $templatePath);
+            $tpl->vars('comments.error', ['vars' => ['content' => $template['vars']['mainblock']]]);
+            $output = [
+                'status' => 0,
+                'data'   => iconv('Windows-1251', 'UTF-8', $tpl->show('comments.error')),
+            ];
+            echo json_encode($output);
+            $template['vars']['mainblock'] = '';
+        } else {
+            // NON-AJAX MODE
+            $tavars = [
+                'vars' => [
+                    'title'    => $lang['comments:err.redir.title'],
+                    'message'  => $template['vars']['mainblock'],
+                    'link'     => secure_html(($_REQUEST['referer']) ? $_REQUEST['referer'] : '/'),
+                    'linktext' => $lang['comments:err.redir.url'],
+                ],
+            ];
+            $tpl->template('redirect', tpl_site);
+            $tpl->vars('redirect', $tavars);
+            $template['vars']['mainblock'] = $tpl->show('redirect');
+        }
+    }
 }
 
 // Show dedicated page for comments
-function plugin_comments_show() {
+function plugin_comments_show()
+{
+    global $config, $catz, $mysql, $catmap, $tpl, $template, $lang, $SUPRESS_TEMPLATE_SHOW, $userROW, $TemplateCache, $SYSTEM_FLAGS;
+    // Load lang file, that is required for [hide]..[/hide] block
+    $lang = LoadLang('news', 'site');
+    $SYSTEM_FLAGS['info']['title']['group'] = $lang['comments:header.title'];
+    include_once root.'/plugins/comments/inc/comments.show.php';
+    // Try to fetch news
+    $newsID = intval($_REQUEST['news_id']);
+    if (!$newsID || !is_array($newsRow = $mysql->record('select * from '.prefix.'_news where id = '.$newsID))) {
+        error404();
 
-	global $config, $catz, $mysql, $catmap, $tpl, $template, $lang, $SUPRESS_TEMPLATE_SHOW, $userROW, $TemplateCache, $SYSTEM_FLAGS;
-	// Load lang file, that is required for [hide]..[/hide] block
-	$lang = LoadLang('news', 'site');
-	$SYSTEM_FLAGS['info']['title']['group'] = $lang['comments:header.title'];
-	include_once(root . "/plugins/comments/inc/comments.show.php");
-	// Try to fetch news
-	$newsID = intval($_REQUEST['news_id']);
-	if (!$newsID || !is_array($newsRow = $mysql->record("select * from " . prefix . "_news where id = " . $newsID))) {
-		error404();
-
-		return;
-	}
-	$SYSTEM_FLAGS['info']['title']['item'] = $newsRow['title'];
-	// Prepare params for call
-	// AJAX is turned off by default
-	$callingCommentsParams = array('noajax' => 1, 'outprint' => true);
-	// Set default template path [from site template / comments plugin subdirectory]
-	$templatePath = tpl_site . 'plugins/comments';
-	$fcat = array_shift(explode(",", $newsRow['catid']));
-	// Check if there is a custom mapping
-	if ($fcat && $catmap[$fcat] && ($ctname = $catz[$catmap[$fcat]]['tpl'])) {
-		// Check if directory exists
-		if (is_dir(tpl_site . 'ncustom/' . $ctname))
-			$callingCommentsParams['overrideTemplatePath'] = tpl_site . 'ncustom/' . $ctname;
-		$templatePath = tpl_site . 'ncustom/' . $ctname;
-	}
-	// Check if we need pagination
-	$page = 0;
-	$pageCount = 0;
-	// If we have comments more than for one page - activate pagination
-	$multi_scount = intval(pluginGetVariable('comments', 'multi_scount'));
-	if (($multi_scount > 0) && ($newsRow['com'] > $multi_scount)) {
-		// Page count
-		$pageCount = ceil($newsRow['com'] / $multi_scount);
-		// Check if user wants to access not first page
-		$page = intval($_REQUEST['page']);
-		if ($page < 1) $page = 1;
-		$callingCommentsParams['limitCount'] = intval(pluginGetVariable('comments', 'multi_scount'));
-		$callingCommentsParams['limitStart'] = ($page - 1) * intval(pluginGetVariable('comments', 'multi_scount'));
-	}
-	// Pass total number of comments
-	$callingCommentsParams['total'] = $newsRow['com'];
-	// Show comments
-	$tcvars = array();
-	$tcvars['vars']['entries'] = comments_show($newsID, 0, 0, $callingCommentsParams);
-	if ($pageCount > 1) {
-		$paginationParams = checkLinkAvailable('comments', 'show') ?
-			array('pluginName' => 'comments', 'pluginHandler' => 'show', 'params' => array('news_id' => $newsID), 'xparams' => array(), 'paginator' => array('page', 0, false)) :
-			array('pluginName' => 'core', 'pluginHandler' => 'plugin', 'params' => array('plugin' => 'comments', 'handler' => 'show'), 'xparams' => array('news_id' => $newsID), 'paginator' => array('page', 1, false));
-		templateLoadVariables(true);
-		$navigations = $TemplateCache['site']['#variables']['navigation'];
-		$tcvars['vars']['more_comments'] = generatePagination($page, 1, $pageCount, 10, $paginationParams, $navigations, true);
-		$tcvars['regx']['#\[more_comments\](.*?)\[\/more_comments\]#is'] = '$1';
-	} else {
-		$tcvars['vars']['more_comments'] = '';
-		$tcvars['regx']['#\[more_comments\](.*?)\[\/more_comments\]#is'] = '';
-	}
-	// Enable AJAX in case if we are on last page
-	if ($page == $pageCount)
-		$callingCommentsParams['noajax'] = 0;
-	$allowCom = $newsRow['allow_com'];
-	// Show form for adding comments
-	if ($newsRow['allow_com'] && (!pluginGetVariable('comments', 'regonly') || is_array($userROW))) {
-		$tcvars['vars']['form'] = comments_showform($newsID, $callingCommentsParams);
-		$tcvars['regx']['#\[regonly\](.*?)\[\/regonly\]#is'] = '';
-		$tcvars['regx']['#\[commforbidden\](.*?)\[\/commforbidden\]#is'] = '';
-	} else {
-		$tcvars['vars']['form'] = '';
-		$tcvars['regx']['#\[regonly\](.*?)\[\/regonly\]#is'] = $allowCom ? '$1' : '';
-		$tcvars['regx']['#\[commforbidden\](.*?)\[\/commforbidden\]#is'] = $allowCom ? '' : '$1';
-	}
-	// Show header file
-	$tcvars['vars']['link'] = newsGenerateLink($newsRow);
-	$tcvars['vars']['title'] = secure_html($newsRow['title']);
-	$tcvars['regx']['[\[comheader\](.*)\[/comheader\]]'] = ($newsRow['com']) ? '$1' : '';
-	$tpl->template('comments.external', $templatePath);
-	$tpl->vars('comments.external', $tcvars);
-	$template['vars']['mainblock'] .= $tpl->show('comments.external');
+        return;
+    }
+    $SYSTEM_FLAGS['info']['title']['item'] = $newsRow['title'];
+    // Prepare params for call
+    // AJAX is turned off by default
+    $callingCommentsParams = ['noajax' => 1, 'outprint' => true];
+    // Set default template path [from site template / comments plugin subdirectory]
+    $templatePath = tpl_site.'plugins/comments';
+    $fcat = array_shift(explode(',', $newsRow['catid']));
+    // Check if there is a custom mapping
+    if ($fcat && $catmap[$fcat] && ($ctname = $catz[$catmap[$fcat]]['tpl'])) {
+        // Check if directory exists
+        if (is_dir(tpl_site.'ncustom/'.$ctname)) {
+            $callingCommentsParams['overrideTemplatePath'] = tpl_site.'ncustom/'.$ctname;
+        }
+        $templatePath = tpl_site.'ncustom/'.$ctname;
+    }
+    // Check if we need pagination
+    $page = 0;
+    $pageCount = 0;
+    // If we have comments more than for one page - activate pagination
+    $multi_scount = intval(pluginGetVariable('comments', 'multi_scount'));
+    if (($multi_scount > 0) && ($newsRow['com'] > $multi_scount)) {
+        // Page count
+        $pageCount = ceil($newsRow['com'] / $multi_scount);
+        // Check if user wants to access not first page
+        $page = intval($_REQUEST['page']);
+        if ($page < 1) {
+            $page = 1;
+        }
+        $callingCommentsParams['limitCount'] = intval(pluginGetVariable('comments', 'multi_scount'));
+        $callingCommentsParams['limitStart'] = ($page - 1) * intval(pluginGetVariable('comments', 'multi_scount'));
+    }
+    // Pass total number of comments
+    $callingCommentsParams['total'] = $newsRow['com'];
+    // Show comments
+    $tcvars = [];
+    $tcvars['vars']['entries'] = comments_show($newsID, 0, 0, $callingCommentsParams);
+    if ($pageCount > 1) {
+        $paginationParams = checkLinkAvailable('comments', 'show') ?
+            ['pluginName' => 'comments', 'pluginHandler' => 'show', 'params' => ['news_id' => $newsID], 'xparams' => [], 'paginator' => ['page', 0, false]] :
+            ['pluginName' => 'core', 'pluginHandler' => 'plugin', 'params' => ['plugin' => 'comments', 'handler' => 'show'], 'xparams' => ['news_id' => $newsID], 'paginator' => ['page', 1, false]];
+        templateLoadVariables(true);
+        $navigations = $TemplateCache['site']['#variables']['navigation'];
+        $tcvars['vars']['more_comments'] = generatePagination($page, 1, $pageCount, 10, $paginationParams, $navigations, true);
+        $tcvars['regx']['#\[more_comments\](.*?)\[\/more_comments\]#is'] = '$1';
+    } else {
+        $tcvars['vars']['more_comments'] = '';
+        $tcvars['regx']['#\[more_comments\](.*?)\[\/more_comments\]#is'] = '';
+    }
+    // Enable AJAX in case if we are on last page
+    if ($page == $pageCount) {
+        $callingCommentsParams['noajax'] = 0;
+    }
+    $allowCom = $newsRow['allow_com'];
+    // Show form for adding comments
+    if ($newsRow['allow_com'] && (!pluginGetVariable('comments', 'regonly') || is_array($userROW))) {
+        $tcvars['vars']['form'] = comments_showform($newsID, $callingCommentsParams);
+        $tcvars['regx']['#\[regonly\](.*?)\[\/regonly\]#is'] = '';
+        $tcvars['regx']['#\[commforbidden\](.*?)\[\/commforbidden\]#is'] = '';
+    } else {
+        $tcvars['vars']['form'] = '';
+        $tcvars['regx']['#\[regonly\](.*?)\[\/regonly\]#is'] = $allowCom ? '$1' : '';
+        $tcvars['regx']['#\[commforbidden\](.*?)\[\/commforbidden\]#is'] = $allowCom ? '' : '$1';
+    }
+    // Show header file
+    $tcvars['vars']['link'] = newsGenerateLink($newsRow);
+    $tcvars['vars']['title'] = secure_html($newsRow['title']);
+    $tcvars['regx']['[\[comheader\](.*)\[/comheader\]]'] = ($newsRow['com']) ? '$1' : '';
+    $tpl->template('comments.external', $templatePath);
+    $tpl->vars('comments.external', $tcvars);
+    $template['vars']['mainblock'] .= $tpl->show('comments.external');
 }
 
 // Delete comment
-function plugin_comments_delete() {
-
-	global $mysql, $config, $userROW, $lang, $tpl, $template, $SUPRESS_MAINBLOCK_SHOW, $SUPRESS_TEMPLATE_SHOW;
-	$output = array();
-	$params = array();
-	// First: check if user have enough permissions
-	if (!is_array($userROW) || ($userROW['status'] > 2) || ($_GET['uT'] != genUToken(intval($_REQUEST['id'])))) {
-		// Not allowed
-		$output['status'] = 0;
-		$output['data'] = $lang['perm.denied'];
-	} else {
-		// Second: check if this comment exists
-		$comid = intval($_REQUEST['id']);
-		if (($comid) && ($row = $mysql->record("select * from " . prefix . "_comments where id=" . db_squote($comid)))) {
-			$mysql->query("delete from " . prefix . "_comments where id=" . db_squote($comid));
-			$mysql->query("update " . uprefix . "_users set com=com-1 where id=" . db_squote($row['author_id']));
-			$mysql->query("update " . prefix . "_news set com=com-1 where id=" . db_squote($row['post']));
-			$output['status'] = 1;
-			$output['data'] = $lang['comments:deleted.text'];
-			$params['newsid'] = $row['post'];
-		} else {
-			$output['status'] = 0;
-			$output['data'] = $lang['comments:err.nocomment'];
-		}
-	}
-	$SUPRESS_TEMPLATE_SHOW = 1;
-	// Check if we run AJAX request
-	if ($_REQUEST['ajax']) {
-		$output['data'] = iconv('Windows-1251', 'UTF-8', $output['data']);
-		$template['vars']['mainblock'] = json_encode($output);
-	} else {
-		// NON-AJAX mode
-		// Fetch news record
-		if ($nrow = $mysql->record("select * from " . prefix . "_news where id = " . db_squote($params['newsid']))) {
-			$url = newsGenerateLink($nrow);
-		} else {
-			$url = $config['home_url'];
-		}
-		$tavars = array(
-			'vars' => array(
-				'message' => $output['data'],
-				'link'    => $url,
-			)
-		);
-		// If ok - redirect to news
-		if ($output['status']) {
-			$tavars['vars']['title'] = $lang['comments:deleted.title'];
-			$tavars['vars']['linktext'] = $lang['comments:deleted.url'];
-		} else {
-			// Print error messag
-			// NON-AJAX MODE
-			$tavars['vars']['title'] = $lang['comments:err.redir.title'];
-			$tavars['vars']['linktext'] = $lang['comments:err.redir.url'];
-		}
-		$tpl->template('redirect', tpl_site);
-		$tpl->vars('redirect', $tavars);
-		$template['vars']['mainblock'] = $tpl->show('redirect');
-	}
+function plugin_comments_delete()
+{
+    global $mysql, $config, $userROW, $lang, $tpl, $template, $SUPRESS_MAINBLOCK_SHOW, $SUPRESS_TEMPLATE_SHOW;
+    $output = [];
+    $params = [];
+    // First: check if user have enough permissions
+    if (!is_array($userROW) || ($userROW['status'] > 2) || ($_GET['uT'] != genUToken(intval($_REQUEST['id'])))) {
+        // Not allowed
+        $output['status'] = 0;
+        $output['data'] = $lang['perm.denied'];
+    } else {
+        // Second: check if this comment exists
+        $comid = intval($_REQUEST['id']);
+        if (($comid) && ($row = $mysql->record('select * from '.prefix.'_comments where id='.db_squote($comid)))) {
+            $mysql->query('delete from '.prefix.'_comments where id='.db_squote($comid));
+            $mysql->query('update '.uprefix.'_users set com=com-1 where id='.db_squote($row['author_id']));
+            $mysql->query('update '.prefix.'_news set com=com-1 where id='.db_squote($row['post']));
+            $output['status'] = 1;
+            $output['data'] = $lang['comments:deleted.text'];
+            $params['newsid'] = $row['post'];
+        } else {
+            $output['status'] = 0;
+            $output['data'] = $lang['comments:err.nocomment'];
+        }
+    }
+    $SUPRESS_TEMPLATE_SHOW = 1;
+    // Check if we run AJAX request
+    if ($_REQUEST['ajax']) {
+        $output['data'] = iconv('Windows-1251', 'UTF-8', $output['data']);
+        $template['vars']['mainblock'] = json_encode($output);
+    } else {
+        // NON-AJAX mode
+        // Fetch news record
+        if ($nrow = $mysql->record('select * from '.prefix.'_news where id = '.db_squote($params['newsid']))) {
+            $url = newsGenerateLink($nrow);
+        } else {
+            $url = $config['home_url'];
+        }
+        $tavars = [
+            'vars' => [
+                'message' => $output['data'],
+                'link'    => $url,
+            ],
+        ];
+        // If ok - redirect to news
+        if ($output['status']) {
+            $tavars['vars']['title'] = $lang['comments:deleted.title'];
+            $tavars['vars']['linktext'] = $lang['comments:deleted.url'];
+        } else {
+            // Print error messag
+            // NON-AJAX MODE
+            $tavars['vars']['title'] = $lang['comments:err.redir.title'];
+            $tavars['vars']['linktext'] = $lang['comments:err.redir.url'];
+        }
+        $tpl->template('redirect', tpl_site);
+        $tpl->vars('redirect', $tavars);
+        $template['vars']['mainblock'] = $tpl->show('redirect');
+    }
 }
 
 loadPluginLang('comments', 'main', '', '', ':');
-register_filter('news', 'comments', new CommentsNewsFilter);
-register_admin_filter('categories', 'comments', new CommentsFilterAdminCategories);
+register_filter('news', 'comments', new CommentsNewsFilter());
+register_admin_filter('categories', 'comments', new CommentsFilterAdminCategories());
 register_plugin_page('comments', 'add', 'plugin_comments_add', 0);
 register_plugin_page('comments', 'show', 'plugin_comments_show', 0);
 register_plugin_page('comments', 'delete', 'plugin_comments_delete', 0);

--- a/comments/config.php
+++ b/comments/config.php
@@ -1,55 +1,58 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
 // Preload config file
 plugins_load_config();
 // Set default values if values are not set [for new variables]
-$pluginDefaults = array(
-	'global_default'     => 1,
-	'default_news'       => 2,
-	'default_categories' => 2,
-);
+$pluginDefaults = [
+    'global_default'     => 1,
+    'default_news'       => 2,
+    'default_categories' => 2,
+];
 foreach ($pluginDefaults as $k => $v) {
-	if (pluginGetVariable('comments', $k) == null)
-		pluginSetVariable('comments', $k, $v);
+    if (pluginGetVariable('comments', $k) == null) {
+        pluginSetVariable('comments', $k, $v);
+    }
 }
 // Fill configuration parameters
-$cfg = array();
-$cfgX = array();
-array_push($cfg, array('descr' => 'Плагин реализует базовый функционал работы с комментариями.<br/><font color="red"><b>Обратите внимание:</b> плагин для своей работы использует файлы-шаблоны из <u>основного шаблона сайта</u></font>.'));
-$cfgX = array();
-array_push($cfgX, array('name' => 'regonly', 'title' => "Комментарии только для зарегистрированных", 'descr' => '<b>Да</b> - комментарии могут оставлять только зарегистрированные пользователи<br/><b>Нет</b> - комментарии может оставить любой посетитель', 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(pluginGetVariable($plugin, 'regonly'))));
-array_push($cfgX, array('name' => 'guest_edup_lock', 'title' => "Запретить гостям использовать <b>email</b>'ы зарегистрированных пользователей", 'descr' => '<b>Да</b> - гости не смогут в качестве email адреса указывать адрес уже зарегистрированных пользоваталей<br/><b>Нет</b> - гость может использовать любой валидный email адрес', 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(pluginGetVariable($plugin, 'guest_edup_lock'))));
-array_push($cfgX, array('name' => 'backorder', 'title' => "Очередность отображения комментариев", 'descr' => "<b>Прямая</b> - отображение в порядке добавления<br/><b>Обратная</b> - самые новые показываются первыми", 'type' => 'select', 'values' => array('0' => 'Прямая', '1' => 'Обратная'), 'value' => intval(pluginGetVariable($plugin, 'backorder'))));
-array_push($cfgX, array('name' => 'maxlen', 'title' => "Максимальный размер", 'descr' => "Укажите максимальное кол-во символов для комментариев (например: <b>200</b>; <b>0</b> - не ограничивать)", 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'maxlen')));
-array_push($cfgX, array('name' => 'maxwlen', 'title' => "Автоурезание слов в комментариях", 'descr' => "В случае превышения заданного числа, в слово будет автоматически будет добавляться пробел (например: <b>50</b>)", 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'maxwlen')));
-array_push($cfgX, array('name' => 'multi', 'title' => "Разрешить множественные комментарии", 'descr' => "<b>Да</b> - пользователь может оставлять последовательно несколько комментариев<br/><b>Нет</b> - пользователю запрещено размещать последовательно несколько комментариев (необходимо дождаться комментария другого пользователя)", 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(pluginGetVariable($plugin, 'multi'))));
-array_push($cfgX, array('name' => 'author_multi', 'title' => "Разрешить множественные комментарии <u>для автора</u>", 'descr' => "<b>Да</b> - автор может оставлять последовательно несколько комментариев<br/><b>Нет</b> - автору запрещено размещать последовательно несколько комментариев", 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(pluginGetVariable($plugin, 'author_multi'))));
-array_push($cfgX, array('name' => 'timestamp', 'title' => "Формат отображения даты/времени", 'descr' => "Помощь по работе функции: <a href=\"http://php.net/date/\" target=\"_blank\">php.net/date</a><br/>Значение по умолчанию: <b>j.m.Y - H:i</b>", 'type' => 'input', 'value' => pluginGetVariable($plugin, 'timestamp')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Общие настройки</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'global_default', 'title' => "По умолчанию комментарии", 'descr' => '<b>разрешены</b> - будут разрешены в новости если они явно не запрещены<br/><b>запрещены</b> - будут запрещены новости если они явно не разрешены', 'type' => 'select', 'values' => array('0' => 'запрещены', '1' => 'разрешены'), 'value' => intval(pluginGetVariable($plugin, 'global_default'))));
-array_push($cfgX, array('name' => 'default_news', 'title' => "Значение доступности при добавлении новостей", 'descr' => 'При добавлении новостей по умолчанию будет устанавливаться:<br/><b>запретить</b> - комментарии будут запрещены<br/><b>разрешить</b> - комментарии будут разрешены<br/><b>по умолчанию</b> - флаг разрешения/запрета комментариев будет браться из настроек главной категории новости', 'type' => 'select', 'values' => array('0' => 'запрещены', '1' => 'разрешены', '2' => 'по умолчанию'), 'value' => intval(pluginGetVariable($plugin, 'default_news'))));
-array_push($cfgX, array('name' => 'default_categories', 'title' => "Значение доступности при добавлении категорий", 'descr' => 'При добавлении категорий по умолчанию будет устанавливаться:<br/><b>запретить</b> - по умолчанию комментарии в новостях этой категории запрещены<br/><b>разрешить</b> - по умолчанию комментарии в этой категории будут разрешены<br/><b>по умолчанию</b> - флаг разрешения/запрета комментариев будет браться из параметра "по умолчанию комментарии"', 'type' => 'select', 'values' => array('0' => 'запрещены', '1' => 'разрешены', '2' => 'по умолчанию'), 'value' => intval(pluginGetVariable($plugin, 'default_categories'))));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки по умолчанию</b>', 'entries' => $cfgX, 'toggle' => true, 'toggle.mode' => 'hide'));
-$cfgX = array();
-array_push($cfgX, array('name' => 'multipage', 'title' => "Использовать многостраничное отображение", 'descr' => '<b>Да</b> - на странице новости будет отображаться только часть комментариев, остальные будут доступны на отдельной страничке<br/><b>Нет</b> - все комментарии будут отображаться на странице новости', 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(pluginGetVariable($plugin, 'multipage'))));
-array_push($cfgX, array('name' => 'multi_mcount', 'title' => "Кол-во комментариев на странице новости", 'descr' => "Укажите кол-во комментариев, отображаемых на странице новости<br/>(<b>0</b> - не отображать ни одного комментария)", 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'multi_mcount')));
-array_push($cfgX, array('name' => 'multi_scount', 'title' => "Кол-во комментариев на странице с комментариями", 'descr' => "Укажите кол-во комментариев, отображаемых на каждой странице с комментариями<br/>(<b>0</b> - отображать все на одной странице)", 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'multi_scount')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Многостраничное отображение</b>', 'entries' => $cfgX, 'toggle' => true, 'toggle.mode' => 'hide'));
-$cfgX = array();
-array_push($cfgX, array('name' => 'inform_author', 'title' => "Оповещать автора новости по email о новом комментарии", 'descr' => "<b>Да</b> - при добавлении каждого комментария автор будет получать e-mail сообщение<br/><b>Нет</b> - автор не будет получать e-mail нотификаций", 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(pluginGetVariable($plugin, 'inform_author'))));
-array_push($cfgX, array('name' => 'inform_admin', 'title' => "Оповещать администратора о новом комментарии", 'descr' => "<b>Да</b> - при добавлении каждого комментария администратор будет получать e-mail сообщение<br/><b>Нет</b> - администратор(ы) не будет получать e-mail нотификаций", 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(pluginGetVariable($plugin, 'inform_admin'))));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки оповещений</b>', 'entries' => $cfgX, 'toggle' => true, 'toggle.mode' => 'hide'));
+$cfg = [];
+$cfgX = [];
+array_push($cfg, ['descr' => 'Плагин реализует базовый функционал работы с комментариями.<br/><font color="red"><b>Обратите внимание:</b> плагин для своей работы использует файлы-шаблоны из <u>основного шаблона сайта</u></font>.']);
+$cfgX = [];
+array_push($cfgX, ['name' => 'regonly', 'title' => 'Комментарии только для зарегистрированных', 'descr' => '<b>Да</b> - комментарии могут оставлять только зарегистрированные пользователи<br/><b>Нет</b> - комментарии может оставить любой посетитель', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(pluginGetVariable($plugin, 'regonly'))]);
+array_push($cfgX, ['name' => 'guest_edup_lock', 'title' => "Запретить гостям использовать <b>email</b>'ы зарегистрированных пользователей", 'descr' => '<b>Да</b> - гости не смогут в качестве email адреса указывать адрес уже зарегистрированных пользоваталей<br/><b>Нет</b> - гость может использовать любой валидный email адрес', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(pluginGetVariable($plugin, 'guest_edup_lock'))]);
+array_push($cfgX, ['name' => 'backorder', 'title' => 'Очередность отображения комментариев', 'descr' => '<b>Прямая</b> - отображение в порядке добавления<br/><b>Обратная</b> - самые новые показываются первыми', 'type' => 'select', 'values' => ['0' => 'Прямая', '1' => 'Обратная'], 'value' => intval(pluginGetVariable($plugin, 'backorder'))]);
+array_push($cfgX, ['name' => 'maxlen', 'title' => 'Максимальный размер', 'descr' => 'Укажите максимальное кол-во символов для комментариев (например: <b>200</b>; <b>0</b> - не ограничивать)', 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'maxlen')]);
+array_push($cfgX, ['name' => 'maxwlen', 'title' => 'Автоурезание слов в комментариях', 'descr' => 'В случае превышения заданного числа, в слово будет автоматически будет добавляться пробел (например: <b>50</b>)', 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'maxwlen')]);
+array_push($cfgX, ['name' => 'multi', 'title' => 'Разрешить множественные комментарии', 'descr' => '<b>Да</b> - пользователь может оставлять последовательно несколько комментариев<br/><b>Нет</b> - пользователю запрещено размещать последовательно несколько комментариев (необходимо дождаться комментария другого пользователя)', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(pluginGetVariable($plugin, 'multi'))]);
+array_push($cfgX, ['name' => 'author_multi', 'title' => 'Разрешить множественные комментарии <u>для автора</u>', 'descr' => '<b>Да</b> - автор может оставлять последовательно несколько комментариев<br/><b>Нет</b> - автору запрещено размещать последовательно несколько комментариев', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(pluginGetVariable($plugin, 'author_multi'))]);
+array_push($cfgX, ['name' => 'timestamp', 'title' => 'Формат отображения даты/времени', 'descr' => 'Помощь по работе функции: <a href="http://php.net/date/" target="_blank">php.net/date</a><br/>Значение по умолчанию: <b>j.m.Y - H:i</b>', 'type' => 'input', 'value' => pluginGetVariable($plugin, 'timestamp')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Общие настройки</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'global_default', 'title' => 'По умолчанию комментарии', 'descr' => '<b>разрешены</b> - будут разрешены в новости если они явно не запрещены<br/><b>запрещены</b> - будут запрещены новости если они явно не разрешены', 'type' => 'select', 'values' => ['0' => 'запрещены', '1' => 'разрешены'], 'value' => intval(pluginGetVariable($plugin, 'global_default'))]);
+array_push($cfgX, ['name' => 'default_news', 'title' => 'Значение доступности при добавлении новостей', 'descr' => 'При добавлении новостей по умолчанию будет устанавливаться:<br/><b>запретить</b> - комментарии будут запрещены<br/><b>разрешить</b> - комментарии будут разрешены<br/><b>по умолчанию</b> - флаг разрешения/запрета комментариев будет браться из настроек главной категории новости', 'type' => 'select', 'values' => ['0' => 'запрещены', '1' => 'разрешены', '2' => 'по умолчанию'], 'value' => intval(pluginGetVariable($plugin, 'default_news'))]);
+array_push($cfgX, ['name' => 'default_categories', 'title' => 'Значение доступности при добавлении категорий', 'descr' => 'При добавлении категорий по умолчанию будет устанавливаться:<br/><b>запретить</b> - по умолчанию комментарии в новостях этой категории запрещены<br/><b>разрешить</b> - по умолчанию комментарии в этой категории будут разрешены<br/><b>по умолчанию</b> - флаг разрешения/запрета комментариев будет браться из параметра "по умолчанию комментарии"', 'type' => 'select', 'values' => ['0' => 'запрещены', '1' => 'разрешены', '2' => 'по умолчанию'], 'value' => intval(pluginGetVariable($plugin, 'default_categories'))]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки по умолчанию</b>', 'entries' => $cfgX, 'toggle' => true, 'toggle.mode' => 'hide']);
+$cfgX = [];
+array_push($cfgX, ['name' => 'multipage', 'title' => 'Использовать многостраничное отображение', 'descr' => '<b>Да</b> - на странице новости будет отображаться только часть комментариев, остальные будут доступны на отдельной страничке<br/><b>Нет</b> - все комментарии будут отображаться на странице новости', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(pluginGetVariable($plugin, 'multipage'))]);
+array_push($cfgX, ['name' => 'multi_mcount', 'title' => 'Кол-во комментариев на странице новости', 'descr' => 'Укажите кол-во комментариев, отображаемых на странице новости<br/>(<b>0</b> - не отображать ни одного комментария)', 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'multi_mcount')]);
+array_push($cfgX, ['name' => 'multi_scount', 'title' => 'Кол-во комментариев на странице с комментариями', 'descr' => 'Укажите кол-во комментариев, отображаемых на каждой странице с комментариями<br/>(<b>0</b> - отображать все на одной странице)', 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'multi_scount')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Многостраничное отображение</b>', 'entries' => $cfgX, 'toggle' => true, 'toggle.mode' => 'hide']);
+$cfgX = [];
+array_push($cfgX, ['name' => 'inform_author', 'title' => 'Оповещать автора новости по email о новом комментарии', 'descr' => '<b>Да</b> - при добавлении каждого комментария автор будет получать e-mail сообщение<br/><b>Нет</b> - автор не будет получать e-mail нотификаций', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(pluginGetVariable($plugin, 'inform_author'))]);
+array_push($cfgX, ['name' => 'inform_admin', 'title' => 'Оповещать администратора о новом комментарии', 'descr' => '<b>Да</b> - при добавлении каждого комментария администратор будет получать e-mail сообщение<br/><b>Нет</b> - администратор(ы) не будет получать e-mail нотификаций', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(pluginGetVariable($plugin, 'inform_admin'))]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки оповещений</b>', 'entries' => $cfgX, 'toggle' => true, 'toggle.mode' => 'hide']);
 // RUN
 if ($_REQUEST['action'] == 'commit') {
-	// If submit requested, do config save
-	commit_plugin_config_changes($plugin, $cfg);
-	print_commit_complete($plugin);
+    // If submit requested, do config save
+    commit_plugin_config_changes($plugin, $cfg);
+    print_commit_complete($plugin);
 } else {
-	generate_config_page($plugin, $cfg);
+    generate_config_page($plugin, $cfg);
 }
-?>

--- a/comments/inc/comments.add.php
+++ b/comments/inc/comments.add.php
@@ -1,262 +1,270 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Params for filtering and processing
 //
-function comments_add() {
+function comments_add()
+{
+    global $mysql, $config, $AUTH_METHOD, $userROW, $ip, $lang, $parse, $catmap, $catz, $PFILTERS;
+    // Check membership
+    // If login/pass is entered (either logged or not)
+    if ($_POST['name'] && $_POST['password']) {
+        $auth = $AUTH_METHOD[$config['auth_module']];
+        $user = $auth->login(0, $_POST['name'], $_POST['password']);
+        if (!is_array($user)) {
+            msg(['type' => 'error', 'text' => $lang['comments:err.password']]);
 
-	global $mysql, $config, $AUTH_METHOD, $userROW, $ip, $lang, $parse, $catmap, $catz, $PFILTERS;
-	// Check membership
-	// If login/pass is entered (either logged or not)
-	if ($_POST['name'] && $_POST['password']) {
-		$auth = $AUTH_METHOD[$config['auth_module']];
-		$user = $auth->login(0, $_POST['name'], $_POST['password']);
-		if (!is_array($user)) {
-			msg(array("type" => "error", "text" => $lang['comments:err.password']));
+            return;
+        }
+    }
+    // Entered data have higher priority then login data
+    $memberRec = null;
+    if (is_array($user)) {
+        $SQL['author'] = $user['name'];
+        $SQL['author_id'] = $user['id'];
+        $SQL['mail'] = $user['mail'];
+        $is_member = 1;
+        $memberRec = $user;
+    } elseif (is_array($userROW)) {
+        $SQL['author'] = $userROW['name'];
+        $SQL['author_id'] = $userROW['id'];
+        $SQL['mail'] = $userROW['mail'];
+        $is_member = 1;
+        $memberRec = $userROW;
+    } else {
+        $SQL['author'] = secure_html(trim($_POST['name']));
+        $SQL['author_id'] = 0;
+        $SQL['mail'] = secure_html(trim($_POST['mail']));
+        $is_member = 0;
+    }
+    // CSRF protection variables
+    $sValue = '';
+    if (preg_match('#^(\d+)\#(.+)$#', $_POST['newsid'], $m)) {
+        $SQL['post'] = $m[1];
+        $sValue = $m[2];
+    }
+    if ($sValue != genUToken('comment.add.'.$SQL['post'])) {
+        msg(['type' => 'error', 'text' => $lang['comments:err.regonly']]);
 
-			return;
-		}
-	}
-	// Entered data have higher priority then login data
-	$memberRec = null;
-	if (is_array($user)) {
-		$SQL['author'] = $user['name'];
-		$SQL['author_id'] = $user['id'];
-		$SQL['mail'] = $user['mail'];
-		$is_member = 1;
-		$memberRec = $user;
-	} else if (is_array($userROW)) {
-		$SQL['author'] = $userROW['name'];
-		$SQL['author_id'] = $userROW['id'];
-		$SQL['mail'] = $userROW['mail'];
-		$is_member = 1;
-		$memberRec = $userROW;
-	} else {
-		$SQL['author'] = secure_html(trim($_POST['name']));
-		$SQL['author_id'] = 0;
-		$SQL['mail'] = secure_html(trim($_POST['mail']));
-		$is_member = 0;
-	}
-	// CSRF protection variables
-	$sValue = '';
-	if (preg_match('#^(\d+)\#(.+)$#', $_POST['newsid'], $m)) {
-		$SQL['post'] = $m[1];
-		$sValue = $m[2];
-	}
-	if ($sValue != genUToken('comment.add.' . $SQL['post'])) {
-		msg(array("type" => "error", "text" => $lang['comments:err.regonly']));
+        return;
+    }
+    $SQL['text'] = secure_html(trim($_POST['content']));
 
-		return;
-	}
-	$SQL['text'] = secure_html(trim($_POST['content']));
+    // If user is not logged, make some additional tests
+    if (!$is_member) {
+        // Check if unreg are allowed to make comments
+        if (pluginGetVariable('comments', 'regonly')) {
+            msg(['type' => 'error', 'text' => $lang['comments:err.regonly']]);
 
-	// If user is not logged, make some additional tests
-	if (!$is_member) {
-		// Check if unreg are allowed to make comments
-		if (pluginGetVariable('comments', 'regonly')) {
-			msg(array("type" => "error", "text" => $lang['comments:err.regonly']));
+            return;
+        }
+        // Check captcha for unregistered visitors
+        if ($config['use_captcha']) {
+            $vcode = $_POST['vcode'];
+            if ($vcode != $_SESSION['captcha']) {
+                msg(['type' => 'error', 'text' => $lang['comments:err.vcode']]);
 
-			return;
-		}
-		// Check captcha for unregistered visitors
-		if ($config['use_captcha']) {
-			$vcode = $_POST['vcode'];
-			if ($vcode != $_SESSION['captcha']) {
-				msg(array("type" => "error", "text" => $lang['comments:err.vcode']));
+                return;
+            }
+            // Update captcha
+            $_SESSION['captcha'] = rand(00000, 99999);
+        }
+        if (!$SQL['author']) {
+            msg(['type' => 'error', 'text' => $lang['comments:err.name']]);
 
-				return;
-			}
-			// Update captcha
-			$_SESSION['captcha'] = rand(00000, 99999);
-		}
-		if (!$SQL['author']) {
-			msg(array("type" => "error", "text" => $lang['comments:err.name']));
+            return;
+        }
+        if (!$SQL['mail']) {
+            msg(['type' => 'error', 'text' => $lang['comments:err.mail']]);
 
-			return;
-		}
-		if (!$SQL['mail']) {
-			msg(array("type" => "error", "text" => $lang['comments:err.mail']));
+            return;
+        }
+        // Check if author name use incorrect symbols. Check should be done only for unregs
+        if ((!$SQL['author_id']) && (preg_match("/[^(\w)|(\x7F-\xFF)|(\s)]/", $SQL['author']) || strlen($SQL['author']) > 60)) {
+            msg(['type' => 'error', 'text' => $lang['comments:err.badname']]);
 
-			return;
-		}
-		// Check if author name use incorrect symbols. Check should be done only for unregs
-		if ((!$SQL['author_id']) && (preg_match("/[^(\w)|(\x7F-\xFF)|(\s)]/", $SQL['author']) || strlen($SQL['author']) > 60)) {
-			msg(array("type" => "error", "text" => $lang['comments:err.badname']));
+            return;
+        }
+        if (strlen($SQL['mail']) > 70 || !preg_match("/^[\.A-z0-9_\-]+[@][A-z0-9_\-]+([.][A-z0-9_\-]+)+[A-z]{1,4}$/", $SQL['mail'])) {
+            msg(['type' => 'error', 'text' => $lang['comments:err.badmail']]);
 
-			return;
-		}
-		if (strlen($SQL['mail']) > 70 || !preg_match("/^[\.A-z0-9_\-]+[@][A-z0-9_\-]+([.][A-z0-9_\-]+)+[A-z]{1,4}$/", $SQL['mail'])) {
-			msg(array("type" => "error", "text" => $lang['comments:err.badmail']));
+            return;
+        }
+        // Check if guest wants to use email of already registered user
+        if (pluginGetVariable('comments', 'guest_edup_lock')) {
+            if (is_array($mysql->record('select * from '.uprefix.'_users where mail = '.db_squote($SQL['mail']).' limit 1'))) {
+                msg(['type' => 'error', 'text' => $lang['comments:err.edupmail']]);
 
-			return;
-		}
-		// Check if guest wants to use email of already registered user
-		if (pluginGetVariable('comments', 'guest_edup_lock')) {
-			if (is_array($mysql->record("select * from " . uprefix . "_users where mail = " . db_squote($SQL['mail']) . " limit 1"))) {
-				msg(array("type" => "error", "text" => $lang['comments:err.edupmail']));
+                return;
+            }
+        }
+    }
+    $maxlen = intval(pluginGetVariable('comments', 'maxlen'));
+    if (($maxlen) && (strlen($SQL['text']) > $maxlen || strlen($SQL['text']) < 2)) {
+        msg(['type' => 'error', 'text' => str_replace('{maxlen}', pluginGetVariable('comments', 'maxlen'), $lang['comments:err.badtext'])]);
 
-				return;
-			}
-		}
-	}
-	$maxlen = intval(pluginGetVariable('comments', 'maxlen'));
-	if (($maxlen) && (strlen($SQL['text']) > $maxlen || strlen($SQL['text']) < 2)) {
-		msg(array("type" => "error", "text" => str_replace('{maxlen}', pluginGetVariable('comments', 'maxlen'), $lang['comments:err.badtext'])));
+        return;
+    }
+    // Check for flood
+    if (checkFlood(0, $ip, 'comments', 'add', $is_member ? $memberRec : null, $is_member ? null : $SQL['author'])) {
+        msg(['type' => 'error', 'text' => str_replace('{timeout}', $config['flood_time'], $lang['comments:err.flood'])]);
 
-		return;
-	}
-	// Check for flood
-	if (checkFlood(0, $ip, 'comments', 'add', $is_member ? $memberRec : null, $is_member ? null : $SQL['author'])) {
-		msg(array("type" => "error", "text" => str_replace('{timeout}', $config['flood_time'], $lang['comments:err.flood'])));
+        return;
+    }
+    // Check for bans
+    if ($ban_mode = checkBanned($ip, 'comments', 'add', $is_member ? $memberRec : null, $is_member ? null : $SQL['author'])) {
+        // If hidden mode is active - say that news is not found
+        if ($ban_mode == 2) {
+            msg(['type' => 'error', 'text' => $lang['comments:err.notfound']]);
+        } else {
+            msg(['type' => 'error', 'text' => $lang['comments:err.ipban']]);
+        }
 
-		return;
-	}
-	// Check for bans
-	if ($ban_mode = checkBanned($ip, 'comments', 'add', $is_member ? $memberRec : null, $is_member ? null : $SQL['author'])) {
-		// If hidden mode is active - say that news is not found
-		if ($ban_mode == 2) {
-			msg(array("type" => "error", "text" => $lang['comments:err.notfound']));
-		} else {
-			msg(array("type" => "error", "text" => $lang['comments:err.ipban']));
-		}
+        return;
+    }
+    // Locate news
+    if ($news_row = $mysql->record('select * from '.prefix.'_news where id = '.db_squote($SQL['post']))) {
+        // Determine if comments are allowed in  this specific news
+        $allowCom = $news_row['allow_com'];
+        if ($allowCom == 2) {
+            // `Use default` - check master category
+            $masterCat = intval(array_shift(explode(',', $news_row['catid'])));
+            if ($masterCat && isset($catmap[$masterCat])) {
+                $allowCom = intval($catz[$catmap[$masterCat]]['allow_com']);
+            }
+            // If we still have 2 (no master category or master category also have 'default' - fetch plugin's config
+            if ($allowCom == 2) {
+                $allowCom = pluginGetVariable('comments', 'global_default');
+            }
+        }
+        if (!$allowCom) {
+            msg(['type' => 'error', 'text' => $lang['comments:err.forbidden']]);
 
-		return;
-	}
-	// Locate news
-	if ($news_row = $mysql->record("select * from " . prefix . "_news where id = " . db_squote($SQL['post']))) {
-		// Determine if comments are allowed in  this specific news
-		$allowCom = $news_row['allow_com'];
-		if ($allowCom == 2) {
-			// `Use default` - check master category
-			$masterCat = intval(array_shift(explode(',', $news_row['catid'])));
-			if ($masterCat && isset($catmap[$masterCat])) {
-				$allowCom = intval($catz[$catmap[$masterCat]]['allow_com']);
-			}
-			// If we still have 2 (no master category or master category also have 'default' - fetch plugin's config
-			if ($allowCom == 2) {
-				$allowCom = pluginGetVariable('comments', 'global_default');
-			}
-		}
-		if (!$allowCom) {
-			msg(array("type" => "error", "text" => $lang['comments:err.forbidden']));
+            return;
+        }
+    } else {
+        msg(['type' => 'error', 'text' => $lang['comments:err.notfound']]);
 
-			return;
-		}
-	} else {
-		msg(array("type" => "error", "text" => $lang['comments:err.notfound']));
+        return;
+    }
+    // Check for multiple comments block [!!! ADMINS CAN DO IT IN ANY CASE !!!]
+    $multiCheck = 0;
+    // Make tests only for non-admins
+    if (!is_array($userROW)) {
+        // Not logged
+        $multiCheck = !intval(pluginGetVariable('comments', 'multi'));
+    } else {
+        // Logged. Skip admins
+        if ($userROW['status'] != 1) {
+            // Check for author
+            $multiCheck = !intval(pluginGetVariable('comments', (($userROW['id'] == $news_row['author_id']) ? 'author_' : '').'multi'));
+        }
+    }
+    if ($multiCheck) {
+        // Locate last comment for this news
+        if (is_array($lpost = $mysql->record('select author_id, author, ip, mail from '.prefix.'_comments where post='.db_squote($SQL['post']).' order by id desc limit 1'))) {
+            // Check for post from the same user
+            if (is_array($userROW)) {
+                if ($userROW['id'] == $lpost['author_id']) {
+                    msg(['type' => 'error', 'text' => $lang['comments:err.multilock']]);
 
-		return;
-	}
-	// Check for multiple comments block [!!! ADMINS CAN DO IT IN ANY CASE !!!]
-	$multiCheck = 0;
-	// Make tests only for non-admins
-	if (!is_array($userROW)) {
-		// Not logged
-		$multiCheck = !intval(pluginGetVariable('comments', 'multi'));
-	} else {
-		// Logged. Skip admins
-		if ($userROW['status'] != 1) {
-			// Check for author
-			$multiCheck = !intval(pluginGetVariable('comments', (($userROW['id'] == $news_row['author_id']) ? 'author_' : '') . 'multi'));
-		}
-	}
-	if ($multiCheck) {
-		// Locate last comment for this news
-		if (is_array($lpost = $mysql->record("select author_id, author, ip, mail from " . prefix . "_comments where post=" . db_squote($SQL['post']) . " order by id desc limit 1"))) {
-			// Check for post from the same user
-			if (is_array($userROW)) {
-				if ($userROW['id'] == $lpost['author_id']) {
-					msg(array("type" => "error", "text" => $lang['comments:err.multilock']));
+                    return;
+                }
+            } else {
+                //print "Last post: ".$lpost['id']."<br>\n";
+                if (($lpost['author'] == $SQL['author']) || ($lpost['mail'] == $SQL['mail'])) {
+                    msg(['type' => 'error', 'text' => $lang['comments:err.multilock']]);
 
-					return;
-				}
-			} else {
-				//print "Last post: ".$lpost['id']."<br>\n";
-				if (($lpost['author'] == $SQL['author']) || ($lpost['mail'] == $SQL['mail'])) {
-					msg(array("type" => "error", "text" => $lang['comments:err.multilock']));
+                    return;
+                }
+            }
+        }
+    }
+    $SQL['postdate'] = time() + ($config['date_adjust'] * 60);
+    if (pluginGetVariable('comments', 'maxwlen') > 1) {
+        $SQL['text'] = preg_replace('/(\S{'.intval(pluginGetVariable('comments', 'maxwlen')).'})(?!\s)/', '$1 ', $SQL['text']);
+        if ((!$SQL['author_id']) && (strlen($SQL['author']) > pluginGetVariable('comments', 'maxwlen'))) {
+            $SQL['author'] = substr($SQL['author'], 0, pluginGetVariable('comments', 'maxwlen')).' ...';
+        }
+    }
+    $SQL['text'] = str_replace("\r\n", '<br />', $SQL['text']);
+    $SQL['ip'] = $ip;
+    $SQL['reg'] = ($is_member) ? '1' : '0';
+    // RUN interceptors
+    load_extras('comments:add');
+    if (is_array($PFILTERS['comments'])) {
+        foreach ($PFILTERS['comments'] as $k => $v) {
+            $pluginResult = $v->addComments($memberRec, $news_row, $tvars, $SQL);
+            if ((is_array($pluginResult) && ($pluginResult['result'])) || (!is_array($pluginResult) && $pluginResult)) {
+                continue;
+            }
+            msg(['type' => 'error', 'text' => str_replace(['{plugin}', '{errorText}'], [$k, (is_array($pluginResult) && isset($pluginResult['errorText']) ? $pluginResult['errorText'] : '')], $lang['comments:err.'.((is_array($pluginResult) && isset($pluginResult['errorText'])) ? 'e' : '').'pluginlock'])]);
 
-					return;
-				}
-			}
-		}
-	}
-	$SQL['postdate'] = time() + ($config['date_adjust'] * 60);
-	if (pluginGetVariable('comments', 'maxwlen') > 1) {
-		$SQL['text'] = preg_replace('/(\S{' . intval(pluginGetVariable('comments', 'maxwlen')) . '})(?!\s)/', '$1 ', $SQL['text']);
-		if ((!$SQL['author_id']) && (strlen($SQL['author']) > pluginGetVariable('comments', 'maxwlen'))) {
-			$SQL['author'] = substr($SQL['author'], 0, pluginGetVariable('comments', 'maxwlen')) . " ...";
-		}
-	}
-	$SQL['text'] = str_replace("\r\n", "<br />", $SQL['text']);
-	$SQL['ip'] = $ip;
-	$SQL['reg'] = ($is_member) ? '1' : '0';
-	// RUN interceptors
-	load_extras('comments:add');
-	if (is_array($PFILTERS['comments']))
-		foreach ($PFILTERS['comments'] as $k => $v) {
-			$pluginResult = $v->addComments($memberRec, $news_row, $tvars, $SQL);
-			if ((is_array($pluginResult) && ($pluginResult['result'])) || (!is_array($pluginResult) && $pluginResult))
-				continue;
-			msg(array("type" => "error", "text" => str_replace(array('{plugin}', '{errorText}'), array($k, (is_array($pluginResult) && isset($pluginResult['errorText']) ? $pluginResult['errorText'] : '')), $lang['comments:err.' . ((is_array($pluginResult) && isset($pluginResult['errorText'])) ? 'e' : '') . 'pluginlock'])));
+            return 0;
+        }
+    }
+    // Create comment
+    $vnames = [];
+    $vparams = [];
+    foreach ($SQL as $k => $v) {
+        $vnames[] = $k;
+        $vparams[] = db_squote($v);
+    }
+    $mysql->query('insert into '.prefix.'_comments ('.implode(',', $vnames).') values ('.implode(',', $vparams).')');
+    // Retrieve comment ID
+    $comment_id = $mysql->result('select LAST_INSERT_ID() as id');
+    // Update comment counter in news
+    $mysql->query('update '.prefix.'_news set com=com+1 where id='.db_squote($SQL['post']));
+    // Update counter for user
+    if ($SQL['author_id']) {
+        $mysql->query('update '.prefix.'_users set com=com+1 where id = '.db_squote($SQL['author_id']));
+    }
+    // Update flood protect database
+    checkFlood(1, $ip, 'comments', 'add', $is_member ? $memberRec : null, $is_member ? null : $SQL['author']);
+    // RUN interceptors
+    if (is_array($PFILTERS['comments'])) {
+        foreach ($PFILTERS['comments'] as $k => $v) {
+            $v->addCommentsNotify($memberRec, $news_row, $tvars, $SQL, $comment_id);
+        }
+    }
+    // Email informer
+    if (pluginGetVariable('comments', 'inform_author') || pluginGetVariable('comments', 'inform_admin')) {
+        $alink = ($SQL['author_id']) ? generatePluginLink('uprofile', 'show', ['name' => $SQL['author'], 'id' => $SQL['author_id']], [], false, true) : '';
+        $body = str_replace(
+            [
+                '{username}',
+                '[userlink]',
+                '[/userlink]',
+                '{comment}',
+                '{newslink}',
+                '{newstitle}',
+            ],
+            [
+                $SQL['author'],
+                ($SQL['author_id']) ? '<a href="'.$alink.'">' : '',
+                ($SQL['author_id']) ? '</a>' : '',
+                $parse->bbcodes($parse->smilies(secure_html($SQL['text']))),
+                newsGenerateLink($news_row, false, 0, true),
+                $news_row['title'],
+            ],
+            $lang['notice']
+        );
+        if (pluginGetVariable('comments', 'inform_author')) {
+            // Determine author's email
+            if (is_array($umail = $mysql->record('select * from '.uprefix.'_users where id = '.db_squote($news_row['author_id'])))) {
+                zzMail($umail['mail'], $lang['newcomment'], $body, 'html');
+            }
+        }
+        if (pluginGetVariable('comments', 'inform_admin')) {
+            zzMail($config['admin_mail'], $lang['newcomment'], $body, 'html');
+        }
+    }
+    @setcookie('com_username', urlencode($SQL['author']), 0, '/');
+    @setcookie('com_usermail', urlencode($SQL['mail']), 0, '/');
 
-			return 0;
-		}
-	// Create comment
-	$vnames = array();
-	$vparams = array();
-	foreach ($SQL as $k => $v) {
-		$vnames[] = $k;
-		$vparams[] = db_squote($v);
-	}
-	$mysql->query("insert into " . prefix . "_comments (" . implode(",", $vnames) . ") values (" . implode(",", $vparams) . ")");
-	// Retrieve comment ID
-	$comment_id = $mysql->result("select LAST_INSERT_ID() as id");
-	// Update comment counter in news
-	$mysql->query("update " . prefix . "_news set com=com+1 where id=" . db_squote($SQL['post']));
-	// Update counter for user
-	if ($SQL['author_id']) {
-		$mysql->query("update " . prefix . "_users set com=com+1 where id = " . db_squote($SQL['author_id']));
-	}
-	// Update flood protect database
-	checkFlood(1, $ip, 'comments', 'add', $is_member ? $memberRec : null, $is_member ? null : $SQL['author']);
-	// RUN interceptors
-	if (is_array($PFILTERS['comments']))
-		foreach ($PFILTERS['comments'] as $k => $v)
-			$v->addCommentsNotify($memberRec, $news_row, $tvars, $SQL, $comment_id);
-	// Email informer
-	if (pluginGetVariable('comments', 'inform_author') || pluginGetVariable('comments', 'inform_admin')) {
-		$alink = ($SQL['author_id']) ? generatePluginLink('uprofile', 'show', array('name' => $SQL['author'], 'id' => $SQL['author_id']), array(), false, true) : '';
-		$body = str_replace(
-			array(
-				'{username}',
-				'[userlink]',
-				'[/userlink]',
-				'{comment}',
-				'{newslink}',
-				'{newstitle}'
-			),
-			array(
-				$SQL['author'],
-				($SQL['author_id']) ? '<a href="' . $alink . '">' : '',
-				($SQL['author_id']) ? '</a>' : '',
-				$parse->bbcodes($parse->smilies(secure_html($SQL['text']))),
-				newsGenerateLink($news_row, false, 0, true),
-				$news_row['title'],
-			),
-			$lang['notice']
-		);
-		if (pluginGetVariable('comments', 'inform_author')) {
-			// Determine author's email
-			if (is_array($umail = $mysql->record("select * from " . uprefix . "_users where id = " . db_squote($news_row['author_id'])))) {
-				zzMail($umail['mail'], $lang['newcomment'], $body, 'html');
-			}
-		}
-		if (pluginGetVariable('comments', 'inform_admin'))
-			zzMail($config['admin_mail'], $lang['newcomment'], $body, 'html');
-	}
-	@setcookie("com_username", urlencode($SQL['author']), 0, '/');
-	@setcookie("com_usermail", urlencode($SQL['mail']), 0, '/');
-
-	return array($news_row, $comment_id);
+    return [$news_row, $comment_id];
 }

--- a/comments/inc/comments.lib.php
+++ b/comments/inc/comments.lib.php
@@ -1,52 +1,55 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 // ==================================================================
 // Comments actions interceptors
 // ==================================================================
-class FilterComments {
+class FilterComments
+{
+    // Form generator
+    public function addCommentsForm($newsID, &$tvars)
+    {
+        return 1;
+    }
 
-	// Form generator
-	function addCommentsForm($newsID, &$tvars) {
+    // Adding executor [ done BEFORE actual add and CAN block adding ]
+    // Returning values in simple mode:
+    // 0 - block adding comment
+    // 1 - allow adding comment
+    // Returning values in advanced mode:
+    // array(
+    //	'result' = 0 - block adding comments
+    //		 = 1 - allow adding comment
+    //	'errorText' = text message (that will be showed) in case if adding was blocked
+    // )
+    public function addComments($userRec, $newsRec, &$tvars, &$SQL)
+    {
+        return 1;
+    }
 
-		return 1;
-	}
+    // Adding notificator [ after successful adding ]
+    public function addCommentsNotify($userRec, $newsRec, &$tvars, $SQL, $commID)
+    {
+        return 1;
+    }
 
-	// Adding executor [ done BEFORE actual add and CAN block adding ]
-	// Returning values in simple mode:
-	// 0 - block adding comment
-	// 1 - allow adding comment
-	// Returning values in advanced mode:
-	// array(
-	//	'result' = 0 - block adding comments
-	//		 = 1 - allow adding comment
-	//	'errorText' = text message (that will be showed) in case if adding was blocked
-	// )
-	function addComments($userRec, $newsRec, &$tvars, &$SQL) {
+    // Show comments
+    public function showComments($newsID, $commRec, $comnum, &$tvars)
+    {
+        return 1;
+    }
 
-		return 1;
-	}
-
-	// Adding notificator [ after successful adding ]
-	function addCommentsNotify($userRec, $newsRec, &$tvars, $SQL, $commID) {
-
-		return 1;
-	}
-
-	// Show comments
-	function showComments($newsID, $commRec, $comnum, &$tvars) {
-
-		return 1;
-	}
-
-	// Show comments external table join initiator.
-	// Function should return specially formatted array:
-	// Each array antry is a name of table for joining [ currenly only `users` is supported ] with value of configuration sub array
-	// Sub array should contain configuration parameters:
-	//		fields - list of fields to join
-	// example: array ( 'users' => array ( 'fields' => array ( 'avatar' )))
-	function commentsJoinFilter() {
-
-		return array();
-	}
+    // Show comments external table join initiator.
+    // Function should return specially formatted array:
+    // Each array antry is a name of table for joining [ currenly only `users` is supported ] with value of configuration sub array
+    // Sub array should contain configuration parameters:
+    //		fields - list of fields to join
+    // example: array ( 'users' => array ( 'fields' => array ( 'avatar' )))
+    public function commentsJoinFilter()
+    {
+        return [];
+    }
 }

--- a/comments/inc/comments.show.php
+++ b/comments/inc/comments.show.php
@@ -1,4 +1,5 @@
 <?php
+
 //
 // Copyright (C) 2006-2011 Next Generation CMS (http://ngcms.ru/)
 // Name: comments.show.php
@@ -6,7 +7,9 @@
 // Author: Vitaly Ponomarev, Alexey Zinchenko
 //
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Show comments for a news
 // $newsID - [required] ID of the news for that comments should be showed
@@ -20,184 +23,188 @@ if (!defined('NGCMS')) die ('HAL');
 //		'limitCount' => number of comments to show (for pagination)
 //		'outprint'	 => flag: if set, output will be returned, elsewhere - will be added to mainblock
 //		'total'		=> total number of comments in this news
-function comments_show($newsID, $commID = 0, $commDisplayNum = 0, $callingParams = array()) {
+function comments_show($newsID, $commID = 0, $commDisplayNum = 0, $callingParams = [])
+{
+    global $mysql, $tpl, $template, $config, $userROW, $parse, $lang, $PFILTERS, $TemplateCache;
+    // Preload template configuration variables
+    templateLoadVariables();
+    // Use default <noavatar> file
+    // - Check if noavatar is defined on template level
+    $tplVars = $TemplateCache['site']['#variables'];
+    $noAvatarURL = (isset($tplVars['configuration']) && is_array($tplVars['configuration']) && isset($tplVars['configuration']['noAvatarImage']) && $tplVars['configuration']['noAvatarImage']) ? (tpl_url.'/'.$tplVars['configuration']['noAvatarImage']) : (avatars_url.'/noavatar.gif');
+    // -> desired template path
+    $templatePath = ($callingParams['overrideTemplatePath']) ? $callingParams['overrideTemplatePath'] : (tpl_site.'plugins/comments');
+    // -> desired template
+    if ($callingParams['overrideTemplateName']) {
+        $templateName = $callingParams['overrideTemplateName'];
+    } else {
+        $templateName = 'comments.show';
+    }
+    $tpl->template($templateName, $templatePath);
+    $joinFilter = [];
+    if ($config['use_avatars']) {
+        $joinFilter = ['users' => ['fields' => ['avatar']]];
+    }
+    // RUN interceptors
+    if (isset($PFILTERS['comments']) && is_array($PFILTERS['comments'])) {
+        foreach ($PFILTERS['comments'] as $k => $v) {
+            $xcfg = $v->commentsJoinFilter();
+            if (is_array($xcfg) && isset($xcfg['users']) && isset($xcfg['users']['fields']) && is_array($xcfg['users']['fields'])) {
+                $joinFilter['users']['fields'] = array_unique(array_merge($joinFilter['users']['fields'], $xcfg['users']['fields']));
+            }
+        }
+    }
+    //print "ARRAY CFG: <pre>".var_export($joinFilter, true)."</pre>";
+    function _cs_am($k)
+    {
+        return 'u.'.$k.' as `users_'.$k.'`';
+    }
 
-	global $mysql, $tpl, $template, $config, $userROW, $parse, $lang, $PFILTERS, $TemplateCache;
-	// Preload template configuration variables
-	templateLoadVariables();
-	// Use default <noavatar> file
-	// - Check if noavatar is defined on template level
-	$tplVars = $TemplateCache['site']['#variables'];
-	$noAvatarURL = (isset($tplVars['configuration']) && is_array($tplVars['configuration']) && isset($tplVars['configuration']['noAvatarImage']) && $tplVars['configuration']['noAvatarImage']) ? (tpl_url . "/" . $tplVars['configuration']['noAvatarImage']) : (avatars_url . "/noavatar.gif");
-	// -> desired template path
-	$templatePath = ($callingParams['overrideTemplatePath']) ? $callingParams['overrideTemplatePath'] : (tpl_site . 'plugins/comments');
-	// -> desired template
-	if ($callingParams['overrideTemplateName']) {
-		$templateName = $callingParams['overrideTemplateName'];
-	} else {
-		$templateName = 'comments.show';
-	}
-	$tpl->template($templateName, $templatePath);
-	$joinFilter = array();
-	if ($config['use_avatars']) {
-		$joinFilter = array('users' => array('fields' => array('avatar')));
-	}
-	// RUN interceptors
-	if (isset($PFILTERS['comments']) && is_array($PFILTERS['comments']))
-		foreach ($PFILTERS['comments'] as $k => $v) {
-			$xcfg = $v->commentsJoinFilter();
-			if (is_array($xcfg) && isset($xcfg['users']) && isset($xcfg['users']['fields']) && is_array($xcfg['users']['fields'])) {
-				$joinFilter['users']['fields'] = array_unique(array_merge($joinFilter['users']['fields'], $xcfg['users']['fields']));
-			}
-		}
-	//print "ARRAY CFG: <pre>".var_export($joinFilter, true)."</pre>";
-	function _cs_am($k) {
-
-		return 'u.' . $k . ' as `users_' . $k . '`';
-	}
-
-	if (isset($joinFilter['users']) && isset($joinFilter['users']['fields']) && is_array($joinFilter['users']['fields']) && (count($joinFilter['users']['fields']) > 0)) {
-		$sql = "select c.*, " .
-			join(", ", array_map('_cs_am', $joinFilter['users']['fields'])) .
-			' from ' . prefix . '_comments c' .
-			' left join ' . uprefix . '_users u on c.author_id = u.id where c.post=' . db_squote($newsID) . ($commID ? (" and c.id=" . db_squote($commID)) : '');
-	} else {
-		$sql = "select c.* from " . prefix . "_comments c WHERE c.post=" . db_squote($newsID) . ($commID ? (" and c.id=" . db_squote($commID)) : '');
-	}
-	$sql .= " order by c.id" . (pluginGetVariable('comments', 'backorder') ? ' desc' : '');
-	// Comments counter
-	$comnum = 0;
-	// Check if we need to use limits
-	$limitStart = isset($callingParams['limitStart']) ? intval($callingParams['limitStart']) : 0;
-	$limitCount = isset($callingParams['limitCount']) ? intval($callingParams['limitCount']) : 0;
-	if ($limitStart || $limitCount) {
-		$sql .= ' limit ' . $limitStart . ", " . $limitCount;
-		$comnum = $limitStart;
-	}
-	$timestamp = pluginGetVariable('comments', 'timestamp');
-	if (!$timestamp)
-		$timestamp = 'j.m.Y - H:i';
-	$output = '';
-	foreach ($mysql->select($sql) as $row) {
-		$comnum++;
-		$tvars['vars']['id'] = $row['id'];
-		$tvars['vars']['author'] = $row['author'];
-		$tvars['vars']['mail'] = $row['mail'];
-		$tvars['vars']['date'] = LangDate($timestamp, $row['postdate']);
-		if ($row['reg'] && getPluginStatusActive('uprofile')) {
-			$tvars['vars']['profile_link'] = checkLinkAvailable('uprofile', 'show') ?
-				generateLink('uprofile', 'show', array('name' => $row['author'], 'id' => $row['author_id'])) :
-				generateLink('core', 'plugin', array('plugin' => 'uprofile', 'handler' => 'show'), array('id' => $row['author_id']));
-			$tvars['regx']["'\[profile\](.*?)\[/profile\]'si"] = '$1';
-		} else {
-			$tvars['vars']['profile_link'] = '';
-			$tvars['regx']["'\[profile\](.*?)\[/profile\]'si"] = '';
-		}
-		// Add [hide] tag processing
-		$text = $row['text'];
-		if ($config['blocks_for_reg']) {
-			$text = $parse->userblocks($text);
-		}
-		if ($config['use_bbcodes']) {
-			$text = $parse->bbcodes($text);
-		}
-		if ($config['use_htmlformatter']) {
-			$text = $parse->htmlformatter($text);
-		}
-		if ($config['use_smilies']) {
-			$text = $parse->smilies($text);
-		}
-		/*
-		if (intval($config['com_wrap']) && (strlen($text) > $config['com_wrap'])) {
-			$tvars['vars']['comment-short']	=	substr($text, 0, $config['com_wrap']);
-			$tvars['vars']['comment-full']	=	substr($text, $config['com_wrap']);
-			$tvars['regx']["'\[comment_full\](.*?)\[/comment_full\]'si"] = '$1';
-		} else {
-		*/
-		$tvars['vars']['comment-short'] = $text;
-		$tvars['regx']["'\[comment_full\](.*?)\[/comment_full\]'si"] = '';
-		/* } */
-		if ($commID && $commDisplayNum) {
-			$tvars['vars']['comnum'] = $commDisplayNum;
-		} else {
-			if (pluginGetVariable('comments', 'backorder') && (intval($callingParams['total']) > 0)) {
-				$tvars['vars']['comnum'] = intval($callingParams['total']) - $comnum + 1;
-			} else {
-				$tvars['vars']['comnum'] = $comnum;
-			}
-		}
-		$tvars['vars']['alternating'] = ($comnum % 2) ? "comment_even" : "comment_odd";
-		if ($config['use_avatars']) {
-			if ($row['users_avatar']) {
-				$tvars['vars']['avatar'] = "<img src=\"" . avatars_url . "/" . $row['users_avatar'] . "\" alt=\"" . $row['author'] . "\" />";
-			} else {
-				// If gravatar integration is active, show avatar from GRAVATAR.COM
-				if ($config['avatars_gravatar']) {
-					$tvars['vars']['avatar'] = '<img src="http://www.gravatar.com/avatar/' . md5(strtolower($row['mail'])) . '.jpg?s=' . $config['avatar_wh'] . '&amp;d=' . urlencode($noAvatarURL) . '" alt=""/>';
-				} else {
-					$tvars['vars']['avatar'] = "<img src=\"" . $noAvatarURL . "\" alt=\"\" />";
-				}
-			}
-		} else {
-			$tvars['vars']['avatar'] = '';
-		}
-		if ($config['use_bbcodes']) {
-			$tvars['regx']["'\[quote\](.*?)\[/quote\]'si"] = '$1';
-		} else {
-			$tvars['regx']["'\[quote\](.*?)\[/quote\]'si"] = '';
-		}
-		if ($row['answer'] != '') {
-			$answer = $row['answer'];
-			if ($config['blocks_for_reg']) {
-				$answer = $parse->userblocks($answer);
-			}
-			if ($config['use_htmlformatter']) {
-				$answer = $parse->htmlformatter($answer);
-			}
-			if ($config['use_bbcodes']) {
-				$answer = $parse->bbcodes($answer);
-			}
-			if ($config['use_smilies']) {
-				$answer = $parse->smilies($answer);
-			}
-			$tvars['vars']['answer'] = $answer;
-			$tvars['vars']['name'] = $row['name'];
-			$tvars['regx']["'\[answer\](.*?)\[/answer\]'si"] = '$1';
-		} else {
-			$tvars['regx']["'\[answer\](.*?)\[/answer\]'si"] = '';
-		}
-		if (is_array($userROW) && (($userROW['status'] == 1) || ($userROW['status'] == 2))) {
-			$edit_link = admin_url . "/admin.php?mod=editcomments&amp;newsid=" . $newsID . "&amp;comid=" . $row['id'];
-			$delete_link = generateLink('core', 'plugin', array('plugin' => 'comments', 'handler' => 'delete'), array('id' => $row['id'], 'uT' => genUToken($row['id'])), true);
-			$tvars['vars']['[edit-com]'] = "<a href=\"" . $edit_link . "\" target=\"_blank\" title=\"" . $lang['addanswer'] . "\">";
-			$tvars['vars']['[/edit-com]'] = "</a>";
-			$tvars['vars']['[del-com]'] = "<a href=\"" . $delete_link . "\" title=\"" . $lang['comdelete'] . "\">";
-			$tvars['vars']['[/del-com]'] = "</a>";
-			$tvars['vars']['ip'] = "<a href=\"http://www.nic.ru/whois/?ip=$row[ip]\" title=\"" . $lang['whois'] . "\">" . $lang['whois'] . "</a>";
-			$tvars['vars']['[if-have-perm]'] = '';
-			$tvars['vars']['[/if-have-perm]'] = '';
-		} else {
-			$tvars['regx']["'\\[edit-com\\].*?\\[/edit-com\\]'si"] = '';
-			$tvars['regx']["'\\[del-com\\].*?\\[/del-com\\]'si"] = '';
-			$tvars['vars']['ip'] = '';
-			$tvars['regx']['#\[if-have-perm\].*?\[\/if-have-perm\]#si'] = '';
-		}
-		$tvars['regx']['#\[is-logged\](.+?)\[/is-logged\]#is'] = is_array($userROW) ? '$1' : '';
-		$tvars['regx']['#\[isnt-logged\](.+?)\[/isnt-logged\]#is'] = is_array($userROW) ? '' : '$1';
-		// RUN interceptors
-		if (isset($PFILTERS['comments']) && is_array($PFILTERS['comments']))
-			foreach ($PFILTERS['comments'] as $k => $v)
-				$v->showComments($newsID, $row, $comnum, $tvars);
-		// run OLD-STYLE interceptors
-		exec_acts('comments', $row);
-		// Show template
-		$tpl->vars($templateName, $tvars);
-		$output .= $tpl->show($templateName);
-	}
-	if ($callingParams['outprint']) {
-		return $output;
-	}
-	$template['vars']['mainblock'] .= $output;
+    if (isset($joinFilter['users']) && isset($joinFilter['users']['fields']) && is_array($joinFilter['users']['fields']) && (count($joinFilter['users']['fields']) > 0)) {
+        $sql = 'select c.*, '.
+            implode(', ', array_map('_cs_am', $joinFilter['users']['fields'])).
+            ' from '.prefix.'_comments c'.
+            ' left join '.uprefix.'_users u on c.author_id = u.id where c.post='.db_squote($newsID).($commID ? (' and c.id='.db_squote($commID)) : '');
+    } else {
+        $sql = 'select c.* from '.prefix.'_comments c WHERE c.post='.db_squote($newsID).($commID ? (' and c.id='.db_squote($commID)) : '');
+    }
+    $sql .= ' order by c.id'.(pluginGetVariable('comments', 'backorder') ? ' desc' : '');
+    // Comments counter
+    $comnum = 0;
+    // Check if we need to use limits
+    $limitStart = isset($callingParams['limitStart']) ? intval($callingParams['limitStart']) : 0;
+    $limitCount = isset($callingParams['limitCount']) ? intval($callingParams['limitCount']) : 0;
+    if ($limitStart || $limitCount) {
+        $sql .= ' limit '.$limitStart.', '.$limitCount;
+        $comnum = $limitStart;
+    }
+    $timestamp = pluginGetVariable('comments', 'timestamp');
+    if (!$timestamp) {
+        $timestamp = 'j.m.Y - H:i';
+    }
+    $output = '';
+    foreach ($mysql->select($sql) as $row) {
+        $comnum++;
+        $tvars['vars']['id'] = $row['id'];
+        $tvars['vars']['author'] = $row['author'];
+        $tvars['vars']['mail'] = $row['mail'];
+        $tvars['vars']['date'] = LangDate($timestamp, $row['postdate']);
+        if ($row['reg'] && getPluginStatusActive('uprofile')) {
+            $tvars['vars']['profile_link'] = checkLinkAvailable('uprofile', 'show') ?
+                generateLink('uprofile', 'show', ['name' => $row['author'], 'id' => $row['author_id']]) :
+                generateLink('core', 'plugin', ['plugin' => 'uprofile', 'handler' => 'show'], ['id' => $row['author_id']]);
+            $tvars['regx']["'\[profile\](.*?)\[/profile\]'si"] = '$1';
+        } else {
+            $tvars['vars']['profile_link'] = '';
+            $tvars['regx']["'\[profile\](.*?)\[/profile\]'si"] = '';
+        }
+        // Add [hide] tag processing
+        $text = $row['text'];
+        if ($config['blocks_for_reg']) {
+            $text = $parse->userblocks($text);
+        }
+        if ($config['use_bbcodes']) {
+            $text = $parse->bbcodes($text);
+        }
+        if ($config['use_htmlformatter']) {
+            $text = $parse->htmlformatter($text);
+        }
+        if ($config['use_smilies']) {
+            $text = $parse->smilies($text);
+        }
+        /*
+        if (intval($config['com_wrap']) && (strlen($text) > $config['com_wrap'])) {
+            $tvars['vars']['comment-short']	=	substr($text, 0, $config['com_wrap']);
+            $tvars['vars']['comment-full']	=	substr($text, $config['com_wrap']);
+            $tvars['regx']["'\[comment_full\](.*?)\[/comment_full\]'si"] = '$1';
+        } else {
+        */
+        $tvars['vars']['comment-short'] = $text;
+        $tvars['regx']["'\[comment_full\](.*?)\[/comment_full\]'si"] = '';
+        /* } */
+        if ($commID && $commDisplayNum) {
+            $tvars['vars']['comnum'] = $commDisplayNum;
+        } else {
+            if (pluginGetVariable('comments', 'backorder') && (intval($callingParams['total']) > 0)) {
+                $tvars['vars']['comnum'] = intval($callingParams['total']) - $comnum + 1;
+            } else {
+                $tvars['vars']['comnum'] = $comnum;
+            }
+        }
+        $tvars['vars']['alternating'] = ($comnum % 2) ? 'comment_even' : 'comment_odd';
+        if ($config['use_avatars']) {
+            if ($row['users_avatar']) {
+                $tvars['vars']['avatar'] = '<img src="'.avatars_url.'/'.$row['users_avatar'].'" alt="'.$row['author'].'" />';
+            } else {
+                // If gravatar integration is active, show avatar from GRAVATAR.COM
+                if ($config['avatars_gravatar']) {
+                    $tvars['vars']['avatar'] = '<img src="http://www.gravatar.com/avatar/'.md5(strtolower($row['mail'])).'.jpg?s='.$config['avatar_wh'].'&amp;d='.urlencode($noAvatarURL).'" alt=""/>';
+                } else {
+                    $tvars['vars']['avatar'] = '<img src="'.$noAvatarURL.'" alt="" />';
+                }
+            }
+        } else {
+            $tvars['vars']['avatar'] = '';
+        }
+        if ($config['use_bbcodes']) {
+            $tvars['regx']["'\[quote\](.*?)\[/quote\]'si"] = '$1';
+        } else {
+            $tvars['regx']["'\[quote\](.*?)\[/quote\]'si"] = '';
+        }
+        if ($row['answer'] != '') {
+            $answer = $row['answer'];
+            if ($config['blocks_for_reg']) {
+                $answer = $parse->userblocks($answer);
+            }
+            if ($config['use_htmlformatter']) {
+                $answer = $parse->htmlformatter($answer);
+            }
+            if ($config['use_bbcodes']) {
+                $answer = $parse->bbcodes($answer);
+            }
+            if ($config['use_smilies']) {
+                $answer = $parse->smilies($answer);
+            }
+            $tvars['vars']['answer'] = $answer;
+            $tvars['vars']['name'] = $row['name'];
+            $tvars['regx']["'\[answer\](.*?)\[/answer\]'si"] = '$1';
+        } else {
+            $tvars['regx']["'\[answer\](.*?)\[/answer\]'si"] = '';
+        }
+        if (is_array($userROW) && (($userROW['status'] == 1) || ($userROW['status'] == 2))) {
+            $edit_link = admin_url.'/admin.php?mod=editcomments&amp;newsid='.$newsID.'&amp;comid='.$row['id'];
+            $delete_link = generateLink('core', 'plugin', ['plugin' => 'comments', 'handler' => 'delete'], ['id' => $row['id'], 'uT' => genUToken($row['id'])], true);
+            $tvars['vars']['[edit-com]'] = '<a href="'.$edit_link.'" target="_blank" title="'.$lang['addanswer'].'">';
+            $tvars['vars']['[/edit-com]'] = '</a>';
+            $tvars['vars']['[del-com]'] = '<a href="'.$delete_link.'" title="'.$lang['comdelete'].'">';
+            $tvars['vars']['[/del-com]'] = '</a>';
+            $tvars['vars']['ip'] = "<a href=\"http://www.nic.ru/whois/?ip=$row[ip]\" title=\"".$lang['whois'].'">'.$lang['whois'].'</a>';
+            $tvars['vars']['[if-have-perm]'] = '';
+            $tvars['vars']['[/if-have-perm]'] = '';
+        } else {
+            $tvars['regx']["'\\[edit-com\\].*?\\[/edit-com\\]'si"] = '';
+            $tvars['regx']["'\\[del-com\\].*?\\[/del-com\\]'si"] = '';
+            $tvars['vars']['ip'] = '';
+            $tvars['regx']['#\[if-have-perm\].*?\[\/if-have-perm\]#si'] = '';
+        }
+        $tvars['regx']['#\[is-logged\](.+?)\[/is-logged\]#is'] = is_array($userROW) ? '$1' : '';
+        $tvars['regx']['#\[isnt-logged\](.+?)\[/isnt-logged\]#is'] = is_array($userROW) ? '' : '$1';
+        // RUN interceptors
+        if (isset($PFILTERS['comments']) && is_array($PFILTERS['comments'])) {
+            foreach ($PFILTERS['comments'] as $k => $v) {
+                $v->showComments($newsID, $row, $comnum, $tvars);
+            }
+        }
+        // run OLD-STYLE interceptors
+        exec_acts('comments', $row);
+        // Show template
+        $tpl->vars($templateName, $tvars);
+        $output .= $tpl->show($templateName);
+    }
+    if ($callingParams['outprint']) {
+        return $output;
+    }
+    $template['vars']['mainblock'] .= $output;
 }
 
 // $callingParams
@@ -206,66 +213,68 @@ function comments_show($newsID, $commID = 0, $commDisplayNum = 0, $callingParams
 //		'overrideTemplatePath'	=> alternative path for searching of template
 //		'noajax'		=> DISABLE AJAX mode
 //		'outprint'	 	=> flag: if set, output will be returned, elsewhere - will be added to mainblock
-function comments_showform($newsID, $callingParams = array()) {
-
-	global $mysql, $config, $template, $tpl, $userROW, $PFILTERS;
-	// -> desired template path
-	$templatePath = ($callingParams['overrideTemplatePath']) ? $callingParams['overrideTemplatePath'] : (tpl_site . 'plugins/comments');
-	// -> desired template
-	if ($callingParams['overrideTemplateName']) {
-		$templateName = $callingParams['overrideTemplateName'];
-	} else {
-		$templateName = 'comments.form';
-	}
-	$tpl->template($templateName, $templatePath);
-	if ($config['use_smilies']) {
-		$tvars['vars']['smilies'] = InsertSmilies('comments', 10);
-	} else {
-		$tvars['vars']['smilies'] = "";
-	}
-	// Lock AJAX calls if required
-	$tvars['regx']['#\[ajax\](.*?)\[\/ajax\]#is'] = $callingParams['noajax'] ? '' : '$1';
-	if ($_COOKIE['com_username'] && trim($_COOKIE['com_username']) != "") {
-		$tvars['vars']['savedname'] = secure_html(urldecode($_COOKIE['com_username']));
-		$tvars['vars']['savedmail'] = secure_html(urldecode($_COOKIE['com_usermail']));
-	} else {
-		$tvars['vars']['savedname'] = '';
-		$tvars['vars']['savedmail'] = '';
-	}
-	if (!is_array($userROW)) {
-		$tvars['vars']['[not-logged]'] = "";
-		$tvars['vars']['[/not-logged]'] = "";
-	} else {
-		$tvars['regx']["'\[not-logged\].*?\[/not-logged\]'si"] = "";
-	}
-	$tvars['vars']['admin_url'] = admin_url;
-	$tvars['vars']['rand'] = rand(00000, 99999);
-	if ($config['use_captcha'] && (!is_array($userROW))) {
-		$_SESSION['captcha'] = rand(00000, 99999);
-		$tvars['regx']["'\[captcha\](.*?)\[/captcha\]'si"] = '$1';
-	} else {
-		$tvars['regx']["'\[captcha\](.*?)\[/captcha\]'si"] = '';
-	}
-	$tvars['vars']['captcha_url'] = admin_url . "/captcha.php";
-	$tvars['vars']['bbcodes'] = BBCodes();
-	$tvars['vars']['skins_url'] = skins_url;
-	$tvars['vars']['newsid'] = $newsID . '#' . genUToken('comment.add.' . $newsID);
-	$tvars['vars']['request_uri'] = secure_html($_SERVER['REQUEST_URI']);
-	// Generate request URL
-	$link = generateLink('core', 'plugin', array('plugin' => 'comments', 'handler' => 'add'));
-	$tvars['vars']['post_url'] = $link;
-	// RUN interceptors
-	if (is_array($PFILTERS['comments']))
-		foreach ($PFILTERS['comments'] as $k => $v)
-			$v->addCommentsForm($newsID, $tvars);
-	// RUN interceptors ( OLD-style )
-	exec_acts('comments_form', $row);
-	$tpl->vars($templateName, $tvars);
-	$output = $tpl->show($templateName);
-	if ($callingParams['outprint']) {
-		return $output;
-	}
-	$template['vars']['mainblock'] .= $output;
+function comments_showform($newsID, $callingParams = [])
+{
+    global $mysql, $config, $template, $tpl, $userROW, $PFILTERS;
+    // -> desired template path
+    $templatePath = ($callingParams['overrideTemplatePath']) ? $callingParams['overrideTemplatePath'] : (tpl_site.'plugins/comments');
+    // -> desired template
+    if ($callingParams['overrideTemplateName']) {
+        $templateName = $callingParams['overrideTemplateName'];
+    } else {
+        $templateName = 'comments.form';
+    }
+    $tpl->template($templateName, $templatePath);
+    if ($config['use_smilies']) {
+        $tvars['vars']['smilies'] = InsertSmilies('comments', 10);
+    } else {
+        $tvars['vars']['smilies'] = '';
+    }
+    // Lock AJAX calls if required
+    $tvars['regx']['#\[ajax\](.*?)\[\/ajax\]#is'] = $callingParams['noajax'] ? '' : '$1';
+    if ($_COOKIE['com_username'] && trim($_COOKIE['com_username']) != '') {
+        $tvars['vars']['savedname'] = secure_html(urldecode($_COOKIE['com_username']));
+        $tvars['vars']['savedmail'] = secure_html(urldecode($_COOKIE['com_usermail']));
+    } else {
+        $tvars['vars']['savedname'] = '';
+        $tvars['vars']['savedmail'] = '';
+    }
+    if (!is_array($userROW)) {
+        $tvars['vars']['[not-logged]'] = '';
+        $tvars['vars']['[/not-logged]'] = '';
+    } else {
+        $tvars['regx']["'\[not-logged\].*?\[/not-logged\]'si"] = '';
+    }
+    $tvars['vars']['admin_url'] = admin_url;
+    $tvars['vars']['rand'] = rand(00000, 99999);
+    if ($config['use_captcha'] && (!is_array($userROW))) {
+        $_SESSION['captcha'] = rand(00000, 99999);
+        $tvars['regx']["'\[captcha\](.*?)\[/captcha\]'si"] = '$1';
+    } else {
+        $tvars['regx']["'\[captcha\](.*?)\[/captcha\]'si"] = '';
+    }
+    $tvars['vars']['captcha_url'] = admin_url.'/captcha.php';
+    $tvars['vars']['bbcodes'] = BBCodes();
+    $tvars['vars']['skins_url'] = skins_url;
+    $tvars['vars']['newsid'] = $newsID.'#'.genUToken('comment.add.'.$newsID);
+    $tvars['vars']['request_uri'] = secure_html($_SERVER['REQUEST_URI']);
+    // Generate request URL
+    $link = generateLink('core', 'plugin', ['plugin' => 'comments', 'handler' => 'add']);
+    $tvars['vars']['post_url'] = $link;
+    // RUN interceptors
+    if (is_array($PFILTERS['comments'])) {
+        foreach ($PFILTERS['comments'] as $k => $v) {
+            $v->addCommentsForm($newsID, $tvars);
+        }
+    }
+    // RUN interceptors ( OLD-style )
+    exec_acts('comments_form', $row);
+    $tpl->vars($templateName, $tvars);
+    $output = $tpl->show($templateName);
+    if ($callingParams['outprint']) {
+        return $output;
+    }
+    $template['vars']['mainblock'] .= $output;
 }
 
 // preload plugins

--- a/comments/install.php
+++ b/comments/install.php
@@ -1,6 +1,9 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
@@ -11,90 +14,91 @@ if (!defined('NGCMS')) die ('HAL');
 //	apply		- apply installation, with handy confirmation
 //	autoapply       - apply installation in automatic mode [INSTALL script]
 //
-function plugin_comments_install($action) {
+function plugin_comments_install($action)
+{
+    global $lang;
+    if ($action != 'autoapply') {
+        loadPluginLang('comments', 'config', '', '', ':');
+    }
+    // Fill DB_UPDATE configuration scheme
+    $db_update = [
+        [
+            'table'  => 'news',
+            'action' => 'cmodify',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'allow_com', 'type' => 'tinyint(1)', 'params' => "default '2'"],
+                ['action' => 'cmodify', 'name' => 'com', 'type' => 'int', 'params' => "default '0'"],
+            ],
+        ],
+        [
+            'table'  => 'category',
+            'action' => 'cmodify',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'allow_com', 'type' => 'tinyint(1)', 'params' => "default '2'"],
+            ],
+        ],
+        [
+            'table'  => 'comments',
+            'action' => 'cmodify',
+            'key'    => 'primary key(id), KEY `c_post` (`post`)',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'],
+                ['action' => 'cmodify', 'name' => 'postdate', 'type' => 'int', 'params' => "default '0'"],
+                ['action' => 'cmodify', 'name' => 'post', 'type' => 'int', 'params' => "default '0'"],
+                ['action' => 'cmodify', 'name' => 'name', 'type' => 'char(100)', 'params' => "default ''"],
+                ['action' => 'cmodify', 'name' => 'author', 'type' => 'char(100)', 'params' => "default ''"],
+                ['action' => 'cmodify', 'name' => 'author_id', 'type' => 'int', 'params' => "default '0'"],
+                ['action' => 'cmodify', 'name' => 'mail', 'type' => 'char(100)', 'params' => "default ''"],
+                ['action' => 'cmodify', 'name' => 'text', 'type' => 'text'],
+                ['action' => 'cmodify', 'name' => 'answer', 'type' => 'text'],
+                ['action' => 'cmodify', 'name' => 'ip', 'type' => 'char(15)', 'params' => "default ''"],
+                ['action' => 'cmodify', 'name' => 'reg', 'type' => 'tinyint(1)', 'params' => "default '0'"],
+            ],
+        ],
+        [
+            'table'  => 'users',
+            'action' => 'modify',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'com', 'type' => 'int', 'params' => "default '0'"],
+            ],
+        ],
+    ];
+    // Apply requested action
+    switch ($action) {
+        case 'confirm':
+            generate_install_page('comments', $lang['comments:desc_install']);
+            break;
+        case 'autoapply':
+        case 'apply':
+            if (fixdb_plugin_install('comments', $db_update, 'install', ($action == 'autoapply') ? true : false)) {
+                plugin_mark_installed('comments');
+            } else {
+                return false;
+            }
+            // Now we need to set some default params
+            $params = [
+                'regonly'            => 0,
+                'backorder'          => 0,
+                'maxlen'             => 500,
+                'maxwlen'            => 50,
+                'multi'              => 1,
+                'author_multi'       => 1,
+                'timestamp'          => 'j.m.Y - H:i',
+                'multipage'          => 1,
+                'multi_mcount'       => 10,
+                'multi_scount'       => 10,
+                'inform_author'      => 0,
+                'inform_admin'       => 0,
+                'global_default'     => 1,
+                'default_news'       => 2,
+                'default_categories' => 2,
+            ];
+            foreach ($params as $k => $v) {
+                extra_set_param('comments', $k, $v);
+            }
+            pluginsSaveConfig();
+            break;
+    }
 
-	global $lang;
-	if ($action != 'autoapply')
-		loadPluginLang('comments', 'config', '', '', ':');
-	// Fill DB_UPDATE configuration scheme
-	$db_update = array(
-		array(
-			'table'  => 'news',
-			'action' => 'cmodify',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'allow_com', 'type' => 'tinyint(1)', 'params' => "default '2'"),
-				array('action' => 'cmodify', 'name' => 'com', 'type' => 'int', 'params' => "default '0'"),
-			)
-		),
-		array(
-			'table'  => 'category',
-			'action' => 'cmodify',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'allow_com', 'type' => 'tinyint(1)', 'params' => "default '2'"),
-			)
-		),
-		array(
-			'table'  => 'comments',
-			'action' => 'cmodify',
-			'key'    => 'primary key(id), KEY `c_post` (`post`)',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'),
-				array('action' => 'cmodify', 'name' => 'postdate', 'type' => 'int', 'params' => "default '0'"),
-				array('action' => 'cmodify', 'name' => 'post', 'type' => 'int', 'params' => "default '0'"),
-				array('action' => 'cmodify', 'name' => 'name', 'type' => 'char(100)', 'params' => "default ''"),
-				array('action' => 'cmodify', 'name' => 'author', 'type' => 'char(100)', 'params' => "default ''"),
-				array('action' => 'cmodify', 'name' => 'author_id', 'type' => 'int', 'params' => "default '0'"),
-				array('action' => 'cmodify', 'name' => 'mail', 'type' => 'char(100)', 'params' => "default ''"),
-				array('action' => 'cmodify', 'name' => 'text', 'type' => 'text'),
-				array('action' => 'cmodify', 'name' => 'answer', 'type' => 'text'),
-				array('action' => 'cmodify', 'name' => 'ip', 'type' => 'char(15)', 'params' => "default ''"),
-				array('action' => 'cmodify', 'name' => 'reg', 'type' => 'tinyint(1)', 'params' => "default '0'"),
-			)
-		),
-		array(
-			'table'  => 'users',
-			'action' => 'modify',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'com', 'type' => 'int', 'params' => "default '0'"),
-			)
-		)
-	);
-	// Apply requested action
-	switch ($action) {
-		case 'confirm':
-			generate_install_page('comments', $lang['comments:desc_install']);
-			break;
-		case 'autoapply':
-		case 'apply':
-			if (fixdb_plugin_install('comments', $db_update, 'install', ($action == 'autoapply') ? true : false)) {
-				plugin_mark_installed('comments');
-			} else {
-				return false;
-			}
-			// Now we need to set some default params
-			$params = array(
-				'regonly'            => 0,
-				'backorder'          => 0,
-				'maxlen'             => 500,
-				'maxwlen'            => 50,
-				'multi'              => 1,
-				'author_multi'       => 1,
-				'timestamp'          => 'j.m.Y - H:i',
-				'multipage'          => 1,
-				'multi_mcount'       => 10,
-				'multi_scount'       => 10,
-				'inform_author'      => 0,
-				'inform_admin'       => 0,
-				'global_default'     => 1,
-				'default_news'       => 2,
-				'default_categories' => 2
-			);
-			foreach ($params as $k => $v) {
-				extra_set_param('comments', $k, $v);
-			}
-			pluginsSaveConfig();
-			break;
-	}
-
-	return true;
+    return true;
 }

--- a/comments/uninstall.php
+++ b/comments/uninstall.php
@@ -1,38 +1,40 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
 plugins_load_config();
-$db_update = array(
-	array(
-		'table'  => 'news',
-		'action' => 'modify',
-		'fields' => array(
-			array('action' => 'drop', 'name' => 'com'),
-			array('action' => 'drop', 'name' => 'allow_com'),
-		)
-	),
-	array(
-		'table'  => 'users',
-		'action' => 'modify',
-		'fields' => array(
-			array('action' => 'drop', 'name' => 'com'),
-		)
-	),
-	array(
-		'table'  => 'comments',
-		'action' => 'drop',
-	)
-);
+$db_update = [
+    [
+        'table'  => 'news',
+        'action' => 'modify',
+        'fields' => [
+            ['action' => 'drop', 'name' => 'com'],
+            ['action' => 'drop', 'name' => 'allow_com'],
+        ],
+    ],
+    [
+        'table'  => 'users',
+        'action' => 'modify',
+        'fields' => [
+            ['action' => 'drop', 'name' => 'com'],
+        ],
+    ],
+    [
+        'table'  => 'comments',
+        'action' => 'drop',
+    ],
+];
 if ($_REQUEST['action'] == 'commit') {
-	// If submit requested, do config save
-	if (fixdb_plugin_install('comments', $db_update, 'deinstall')) {
-		plugin_mark_deinstalled('comments');
-	}
+    // If submit requested, do config save
+    if (fixdb_plugin_install('comments', $db_update, 'deinstall')) {
+        plugin_mark_deinstalled('comments');
+    }
 } else {
-	$text = $lang['comments_desc_uninstall'];
-	generate_install_page('comments', $text, 'deinstall');
+    $text = $lang['comments_desc_uninstall'];
+    generate_install_page('comments', $text, 'deinstall');
 }
-?>

--- a/comments_akismet/antispam.php
+++ b/comments_akismet/antispam.php
@@ -1,32 +1,34 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('naHAL!1');
+if (!defined('NGCMS')) {
+    die('naHAL!1');
+}
 
 // Load LIBRARY
 loadPluginLibrary('comments', 'lib');
-include_once(root . "/plugins/comments_akismet/inc/Akismet.class.php");
+include_once root.'/plugins/comments_akismet/inc/Akismet.class.php';
 
-class AntispamFilterComments extends FilterComments {
-
-	function addComments($userRec, $newsRec, &$tvars, &$SQL) {
-
-		$akis = new Akismet(home, pluginGetVariable('comments_akismet', 'akismet_apikey'));
-		$akis->setAkismetServer(pluginGetVariable('comments_akismet', 'akismet_server'));
-		if ($akis->isKeyValid()) {
-			$akis->setCommentAuthor($SQL['author']);
-			$akis->setCommentAuthorEmail($SQL['mail']);
-			$akis->setCommentContent($SQL['text']);
-			if ($akis->isCommentSpam()) {
-				return array('result' => 0, 'errorText' => 'Akismet blocked your comment!');
-			} else {
-				return 1;
-			}
-		} else {
-			#print 'Akismet error';
-			return array('result' => 0, 'errorText' => 'Akismet key is invalid! ' . pluginGetVariable('comments_akismet', 'akismet_apikey'));
-		}
-	}
-
+class AntispamFilterComments extends FilterComments
+{
+    public function addComments($userRec, $newsRec, &$tvars, &$SQL)
+    {
+        $akis = new Akismet(home, pluginGetVariable('comments_akismet', 'akismet_apikey'));
+        $akis->setAkismetServer(pluginGetVariable('comments_akismet', 'akismet_server'));
+        if ($akis->isKeyValid()) {
+            $akis->setCommentAuthor($SQL['author']);
+            $akis->setCommentAuthorEmail($SQL['mail']);
+            $akis->setCommentContent($SQL['text']);
+            if ($akis->isCommentSpam()) {
+                return ['result' => 0, 'errorText' => 'Akismet blocked your comment!'];
+            } else {
+                return 1;
+            }
+        } else {
+            //print 'Akismet error';
+            return ['result' => 0, 'errorText' => 'Akismet key is invalid! '.pluginGetVariable('comments_akismet', 'akismet_apikey')];
+        }
+    }
 }
 
-register_filter('comments', 'antispam', new AntispamFilterComments);
+register_filter('comments', 'antispam', new AntispamFilterComments());

--- a/comments_akismet/config.php
+++ b/comments_akismet/config.php
@@ -1,16 +1,16 @@
 <?php
+
 plugins_load_config();
-$cfg = array();
-$cfgX = array();
-array_push($cfg, array('descr' => 'Плагин позволяет использовать сервис Akismet для фильтрации спама в комментариях'));
-array_push($cfgX, array('name' => 'akismet_server', 'title' => "API-сервер", 'type' => 'input', 'value' => extra_get_param($plugin, 'akismet_server') ? extra_get_param($plugin, 'akismet_server') : 'rest.akismet.com'));
-array_push($cfgX, array('name' => 'akismet_apikey', 'title' => "API-ключ", 'type' => 'input', 'value' => extra_get_param($plugin, 'akismet_apikey')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки</b>', 'entries' => $cfgX));
+$cfg = [];
+$cfgX = [];
+array_push($cfg, ['descr' => 'Плагин позволяет использовать сервис Akismet для фильтрации спама в комментариях']);
+array_push($cfgX, ['name' => 'akismet_server', 'title' => 'API-сервер', 'type' => 'input', 'value' => extra_get_param($plugin, 'akismet_server') ? extra_get_param($plugin, 'akismet_server') : 'rest.akismet.com']);
+array_push($cfgX, ['name' => 'akismet_apikey', 'title' => 'API-ключ', 'type' => 'input', 'value' => extra_get_param($plugin, 'akismet_apikey')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки</b>', 'entries' => $cfgX]);
 if ($_REQUEST['action'] == 'commit') {
-	// If submit requested, do config save
-	commit_plugin_config_changes($plugin, $cfg);
-	print_commit_complete($plugin);
+    // If submit requested, do config save
+    commit_plugin_config_changes($plugin, $cfg);
+    print_commit_complete($plugin);
 } else {
-	generate_config_page($plugin, $cfg);
+    generate_config_page($plugin, $cfg);
 }
-?>

--- a/feedback/config.php
+++ b/feedback/config.php
@@ -1,484 +1,509 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 // Load langs
 loadPluginLang('feedback', 'config', '', '', ':');
 // Load library
-include_once(root . "/plugins/feedback/lib/common.php");
+include_once root.'/plugins/feedback/lib/common.php';
 // Switch action
 switch ($_REQUEST['action']) {
-	case 'addform'  :
-		addForm();
-		showList();
-		break;
-	case 'saveform':
-		saveForm();
-		break;
-	case 'form'        :
-		showForm(0);
-		break;
-	case 'row'        :
-		showFormRow();
-		break;
-	case 'editrow'    :
-		editFormRow();
-		break;
-	case 'update'    :
-		if (doUpdate()) {
-			showForm();
-		}
-		break;
-	case 'delform'    :
-		delForm();
-		showList();
-		break;
-	default            :
-		showList();
+    case 'addform':
+        addForm();
+        showList();
+        break;
+    case 'saveform':
+        saveForm();
+        break;
+    case 'form':
+        showForm(0);
+        break;
+    case 'row':
+        showFormRow();
+        break;
+    case 'editrow':
+        editFormRow();
+        break;
+    case 'update':
+        if (doUpdate()) {
+            showForm();
+        }
+        break;
+    case 'delform':
+        delForm();
+        showList();
+        break;
+    default:
+        showList();
 }
 // Simply create new form
-function addForm() {
-
-	global $mysql, $lang;
-	$mysql->query("insert into " . prefix . "_feedback (name, title) values ('newform', 'New form')");
+function addForm()
+{
+    global $mysql, $lang;
+    $mysql->query('insert into '.prefix."_feedback (name, title) values ('newform', 'New form')");
 }
 
 // Save form params
-function saveForm() {
+function saveForm()
+{
+    global $mysql, $lang;
+    $id = intval($_REQUEST['id']);
+    // First - try to fetch form
+    if (!is_array($recF = $mysql->record('select * from '.prefix.'_feedback where id = '.$id))) {
+        msg(['type' => 'error', 'text' => 'Указанная вами форма не существует']);
+        showForm(1);
 
-	global $mysql, $lang;
-	$id = intval($_REQUEST['id']);
-	// First - try to fetch form
-	if (!is_array($recF = $mysql->record("select * from " . prefix . "_feedback where id = " . $id))) {
-		msg(array('type' => 'error', 'text' => 'Указанная вами форма не существует'));
-		showForm(1);
+        return;
+    }
+    // Готовим список email адресов пользователей
+    $emails = '';
+    if (is_array($_POST['elist'])) {
+        $elist = $_POST['elist'];
+        $eok = [];
+        $num = 1;
+        foreach ($elist as $erec) {
+            // Проверяем наличие email'ов в списке
+            $mlist = preg_split('# *(\,) *#', trim($erec[2], -1));
+            if (count($mlist) && strlen($mlist[0])) {
+                $eok[$num] = [$num, trim($erec[1]), $mlist];
+                $num++;
+            }
+        }
+        $emails = serialize($eok);
+    }
+    $name = trim($_REQUEST['name']);
+    // Проверяем ввод наименования
+    if ($name == '') {
+        msg(['type' => 'error', 'text' => 'Необходимо заполнить ID формы']);
+        showForm(1);
 
-		return;
-	}
-	// Готовим список email адресов пользователей
-	$emails = '';
-	if (is_array($_POST['elist'])) {
-		$elist = $_POST['elist'];
-		$eok = array();
-		$num = 1;
-		foreach ($elist as $erec) {
-			// Проверяем наличие email'ов в списке
-			$mlist = preg_split('# *(\,) *#', trim($erec[2], -1));
-			if (count($mlist) && strlen($mlist[0])) {
-				$eok[$num] = array($num, trim($erec[1]), $mlist);
-				$num++;
-			}
-		}
-		$emails = serialize($eok);
-	}
-	$name = trim($_REQUEST['name']);
-	// Проверяем ввод наименования
-	if ($name == '') {
-		msg(array('type' => 'error', 'text' => 'Необходимо заполнить ID формы'));
-		showForm(1);
+        return;
+    }
+    // Проверяем дубляж
+    if (is_array($mysql->record('select * from '.prefix.'_feedback where id <> '.$id.' and name ='.db_squote($name)))) {
+        msg(['type' => 'error', 'text' => 'Форма с таким ID уже существует. Нельзя использовать одинаковый ID для разных форм']);
+        showForm(1);
 
-		return;
-	}
-	// Проверяем дубляж
-	if (is_array($mysql->record("select * from " . prefix . "_feedback where id <> " . $id . " and name =" . db_squote($name)))) {
-		msg(array('type' => 'error', 'text' => 'Форма с таким ID уже существует. Нельзя использовать одинаковый ID для разных форм'));
-		showForm(1);
-
-		return;
-	}
-	// Сохраняем изменения
-	$flags = ($_REQUEST['jcheck'] ? '1' : '0') .
-		($_REQUEST['captcha'] ? '1' : '0') .
-		($_REQUEST['html'] ? '1' : '0') .
-		(((intval($_REQUEST['link_news']) >= 0) && (intval($_REQUEST['link_news']) <= 2)) ? intval($_REQUEST['link_news']) : 0) .
-		($_REQUEST['isSubj'] ? '1' : '0') .
-		($_REQUEST['utf8'] ? '1' : '0');
-	$params = array(
-		'name'        => $name,
-		'title'       => $_REQUEST['title'],
-		'template'    => $_REQUEST['template'],
-		'emails'      => $emails,
-		'description' => $_REQUEST['description'],
-		'active'      => $_REQUEST['active'],
-		'flags'       => $flags,
-		'subj'        => $_REQUEST['subj'],
-	);
-	$sqlParams = array();
-	foreach ($params as $k => $v) {
-		$sqlParams [] = $k . '=' . db_squote($v);
-	}
-	$mysql->query("update " . prefix . "_feedback set " . join(", ", $sqlParams) . " where id = " . $id);
-	//$mysql->query("update ".prefix."_feedback set name=".db_squote($name).", title=".db_squote($_REQUEST['title']).", template=".db_squote($_REQUEST['template']).", emails=".db_squote($emails).", description=".db_squote($_REQUEST['description']).", active=".intval($_REQUEST['active']).", flags=".db_squote($flags)." where id = ".$id);
-	showForm(1);
+        return;
+    }
+    // Сохраняем изменения
+    $flags = ($_REQUEST['jcheck'] ? '1' : '0').
+        ($_REQUEST['captcha'] ? '1' : '0').
+        ($_REQUEST['html'] ? '1' : '0').
+        (((intval($_REQUEST['link_news']) >= 0) && (intval($_REQUEST['link_news']) <= 2)) ? intval($_REQUEST['link_news']) : 0).
+        ($_REQUEST['isSubj'] ? '1' : '0').
+        ($_REQUEST['utf8'] ? '1' : '0');
+    $params = [
+        'name'        => $name,
+        'title'       => $_REQUEST['title'],
+        'template'    => $_REQUEST['template'],
+        'emails'      => $emails,
+        'description' => $_REQUEST['description'],
+        'active'      => $_REQUEST['active'],
+        'flags'       => $flags,
+        'subj'        => $_REQUEST['subj'],
+    ];
+    $sqlParams = [];
+    foreach ($params as $k => $v) {
+        $sqlParams[] = $k.'='.db_squote($v);
+    }
+    $mysql->query('update '.prefix.'_feedback set '.implode(', ', $sqlParams).' where id = '.$id);
+    //$mysql->query("update ".prefix."_feedback set name=".db_squote($name).", title=".db_squote($_REQUEST['title']).", template=".db_squote($_REQUEST['template']).", emails=".db_squote($emails).", description=".db_squote($_REQUEST['description']).", active=".intval($_REQUEST['active']).", flags=".db_squote($flags)." where id = ".$id);
+    showForm(1);
 }
 
-function showList() {
-
-	global $mysql, $lang, $twig;
-	$tVars = array();
-	$tForms = array();
-	foreach ($mysql->select("select * from " . prefix . "_feedback order by name") as $frow) {
-		$tForm = array(
-			'id'        => $frow['id'],
-			'name'      => $frow['name'],
-			'title'     => $frow['title'],
-			'link_news' => intval(substr($frow['flags'], 3, 1)),
-			'flags'     => array(
-				'active' => $frow['active'],
-			),
-			'linkEdit'  => '?mod=extra-config&plugin=feedback&action=form&id=' . $frow['id'],
-			'linkDel'   => '?mod=extra-config&plugin=feedback&action=delform&id=' . $frow['id'],
-		);
-		$tForms[] = $tForm;
-	}
-	$tVars['entries'] = $tForms;
-	$templateName = 'plugins/feedback/tpl/conf.forms.tpl';
-	$xt = $twig->loadTemplate($templateName);
-	echo $xt->render($tVars);
+function showList()
+{
+    global $mysql, $lang, $twig;
+    $tVars = [];
+    $tForms = [];
+    foreach ($mysql->select('select * from '.prefix.'_feedback order by name') as $frow) {
+        $tForm = [
+            'id'        => $frow['id'],
+            'name'      => $frow['name'],
+            'title'     => $frow['title'],
+            'link_news' => intval(substr($frow['flags'], 3, 1)),
+            'flags'     => [
+                'active' => $frow['active'],
+            ],
+            'linkEdit'  => '?mod=extra-config&plugin=feedback&action=form&id='.$frow['id'],
+            'linkDel'   => '?mod=extra-config&plugin=feedback&action=delform&id='.$frow['id'],
+        ];
+        $tForms[] = $tForm;
+    }
+    $tVars['entries'] = $tForms;
+    $templateName = 'plugins/feedback/tpl/conf.forms.tpl';
+    $xt = $twig->loadTemplate($templateName);
+    echo $xt->render($tVars);
 }
 
-function showForm($edMode) {
+function showForm($edMode)
+{
+    global $mysql, $lang, $twig;
+    $tVars = [];
+    // Load form
+    $id = intval($_REQUEST['id']);
+    $tvars = [];
+    if (!is_array($frow = $mysql->record('select * from '.prefix.'_feedback where id = '.$id))) {
+        $tVars['content'] = 'Указанная форма ['.$id.'] не существует!';
+        $xt = $twig->loadTemplate('plugins/feedback/tpl/conf.notify.tpl');
+        echo $xt->render($tVars);
 
-	global $mysql, $lang, $twig;
-	$tVars = array();
-	// Load form
-	$id = intval($_REQUEST['id']);
-	$tvars = array();
-	if (!is_array($frow = $mysql->record("select * from " . prefix . "_feedback where id = " . $id))) {
-		$tVars['content'] = "Указанная форма [" . $id . "] не существует!";
-		$xt = $twig->loadTemplate('plugins/feedback/tpl/conf.notify.tpl');
-		echo $xt->render($tVars);
-
-		return false;
-	}
-	$tVars['formID'] = $frow['id'];
-	$tVars['formName'] = $frow['name'];
-	// Unpack form data
-	$fData = unserialize($frow['struct']);
-	if (!is_array($fData)) $fData = array();
-	$tEntries = array();
-	foreach ($fData as $fName => $fInfo) {
-		$tEntry = array(
-			'name'  => $fInfo['name'],
-			'title' => $fInfo['title'],
-			'type'  => $fInfo['type'],
-			'auto'  => intval($fInfo['auto']),
-			'block' => intval($fInfo['block']),
-		);
-		$tEntries[] = $tEntry;
-	}
-	// Готовим список email'ов
-	$tEGroups = array();
-	if (($elist = unserialize($frow['emails'])) === false) {
-		$elist[1] = array(1, '', preg_split("# *(\r\n|\n) *#", $frow['emails']));
-	}
-	$num = 1;
-	foreach ($elist as $erec) {
-		$tEGroup = array(
-			'num'   => $erec[0],
-			'name'  => $erec[1],
-			'value' => secure_html(join(', ', $erec[2])),
-		);
-		$tEGroups[] = $tEGroup;
-		$num++;
-	}
-	$tEGroups[] = array($num, '', '');
-	$tVars['id'] = $frow['id'];
-	$tVars['name'] = $edMode ? $_REQUEST['name'] : $frow['name'];
-	$tVars['title'] = $edMode ? $_REQUEST['title'] : $frow['title'];
-	$tVars['description'] = $edMode ? $_REQUEST['description'] : $frow['description'];
-	$tVars['subj'] = $frow['subj'];
-	$tVars['url'] = generateLink('core', 'plugin', array('plugin' => 'feedback'), array('id' => $frow['id']), true, true);
-	$tVars['egroups'] = $tEGroups;
-	$tVars['link_news'] = array(
-		'options' => array(0, 1, 2),
-		'value'   => intval(substr($frow['flags'], 3, 1)),
-	);
-	$tVars['flags'] = array(
-		'active'   => intval($edMode ? $_REQUEST['active'] : $frow['active']),
-		'jcheck'   => intval($edMode ? $_REQUEST['jcheck'] : intval(substr($frow['flags'], 0, 1))),
-		'captcha'  => intval($edMode ? $_REQUEST['captcha'] : intval(substr($frow['flags'], 1, 1))),
-		'html'     => intval($edMode ? $_REQUEST['html'] : intval(substr($frow['flags'], 2, 1))),
-		'subj'     => intval(substr($frow['flags'], 4, 1)),
-		'utf8'     => intval($edMode ? $_REQUEST['utf8'] : intval(substr($frow['flags'], 5, 1))),
-		'haveForm' => 1,
-	);
-	// Generate list of templates
-	$lf = array('' => '<автоматически>');
-	foreach (feedback_listTemplates() as $k) {
-		if (substr($k, 0, 1) == ':') {
-			$lf[$k] = 'сайт: ' . $k;
-		} else {
-			$lf[$k] = 'плагин: ' . $k;
-		}
-	}
-	$lout = '';
-	foreach ($lf as $k => $v)
-		$lout .= '<option value="' . $k . '"' . ($frow['template'] == $k ? ' selected="selected"' : '') . '>' . $v . '</option>';
-	$tVars['template_options'] = $lout;
-	$tVars['entries'] = $tEntries;
-	// Show template files
-	$tVars['tfiles'] = feedback_locateTemplateFiles($frow['template'], substr($frow['flags'], 2, 1) ? true : false);
-	$xt = $twig->loadTemplate('plugins/feedback/tpl/conf.form.tpl');
-	echo $xt->render($tVars);
+        return false;
+    }
+    $tVars['formID'] = $frow['id'];
+    $tVars['formName'] = $frow['name'];
+    // Unpack form data
+    $fData = unserialize($frow['struct']);
+    if (!is_array($fData)) {
+        $fData = [];
+    }
+    $tEntries = [];
+    foreach ($fData as $fName => $fInfo) {
+        $tEntry = [
+            'name'  => $fInfo['name'],
+            'title' => $fInfo['title'],
+            'type'  => $fInfo['type'],
+            'auto'  => intval($fInfo['auto']),
+            'block' => intval($fInfo['block']),
+        ];
+        $tEntries[] = $tEntry;
+    }
+    // Готовим список email'ов
+    $tEGroups = [];
+    if (($elist = unserialize($frow['emails'])) === false) {
+        $elist[1] = [1, '', preg_split("# *(\r\n|\n) *#", $frow['emails'])];
+    }
+    $num = 1;
+    foreach ($elist as $erec) {
+        $tEGroup = [
+            'num'   => $erec[0],
+            'name'  => $erec[1],
+            'value' => secure_html(implode(', ', $erec[2])),
+        ];
+        $tEGroups[] = $tEGroup;
+        $num++;
+    }
+    $tEGroups[] = [$num, '', ''];
+    $tVars['id'] = $frow['id'];
+    $tVars['name'] = $edMode ? $_REQUEST['name'] : $frow['name'];
+    $tVars['title'] = $edMode ? $_REQUEST['title'] : $frow['title'];
+    $tVars['description'] = $edMode ? $_REQUEST['description'] : $frow['description'];
+    $tVars['subj'] = $frow['subj'];
+    $tVars['url'] = generateLink('core', 'plugin', ['plugin' => 'feedback'], ['id' => $frow['id']], true, true);
+    $tVars['egroups'] = $tEGroups;
+    $tVars['link_news'] = [
+        'options' => [0, 1, 2],
+        'value'   => intval(substr($frow['flags'], 3, 1)),
+    ];
+    $tVars['flags'] = [
+        'active'   => intval($edMode ? $_REQUEST['active'] : $frow['active']),
+        'jcheck'   => intval($edMode ? $_REQUEST['jcheck'] : intval(substr($frow['flags'], 0, 1))),
+        'captcha'  => intval($edMode ? $_REQUEST['captcha'] : intval(substr($frow['flags'], 1, 1))),
+        'html'     => intval($edMode ? $_REQUEST['html'] : intval(substr($frow['flags'], 2, 1))),
+        'subj'     => intval(substr($frow['flags'], 4, 1)),
+        'utf8'     => intval($edMode ? $_REQUEST['utf8'] : intval(substr($frow['flags'], 5, 1))),
+        'haveForm' => 1,
+    ];
+    // Generate list of templates
+    $lf = ['' => '<автоматически>'];
+    foreach (feedback_listTemplates() as $k) {
+        if (substr($k, 0, 1) == ':') {
+            $lf[$k] = 'сайт: '.$k;
+        } else {
+            $lf[$k] = 'плагин: '.$k;
+        }
+    }
+    $lout = '';
+    foreach ($lf as $k => $v) {
+        $lout .= '<option value="'.$k.'"'.($frow['template'] == $k ? ' selected="selected"' : '').'>'.$v.'</option>';
+    }
+    $tVars['template_options'] = $lout;
+    $tVars['entries'] = $tEntries;
+    // Show template files
+    $tVars['tfiles'] = feedback_locateTemplateFiles($frow['template'], substr($frow['flags'], 2, 1) ? true : false);
+    $xt = $twig->loadTemplate('plugins/feedback/tpl/conf.form.tpl');
+    echo $xt->render($tVars);
 }
 
-function showFormRow() {
-
-	global $mysql, $lang, $twig;
-	$tVars = array();
-	// Load form
-	$id = intval($_REQUEST['form_id']);
-	$fRowId = $_REQUEST['row'];
-	$recordFound = 0;
-	do {
-		// Check if form exists
-		if (!is_array($frow = $mysql->record("select * from " . prefix . "_feedback where id = " . $id))) {
-			$tVars['content'] = "Указанная форма [" . $id . "] не существует!";
-			break;
-		}
-		$tVars['flags']['haveForm'] = 1;
-		$tVars['formID'] = $frow['id'];
-		$tVars['formName'] = $frow['name'];
-		// Unpack form data
-		$fData = unserialize($frow['struct']);
-		if (!is_array($fData)) $fData = array();
-		// Check if form's row exists
-		if ($fRowId && !isset($fData[$fRowId])) {
-			$tVars['content'] = "Указанное поле [" . $id . "][" . $fRowId . "] не существует!";
-			break;
-		}
-		$editMode = ($fRowId) ? 1 : 0;
-		if ($editMode) {
-			$xRow = $fData[$fRowId];
-			$tVars['flags']['haveField'] = 1;
-			$tVars['fieldName'] = $xRow['name'];
-			$tVars['field']['name'] = $xRow['name'];
-			$tVars['field']['title'] = secure_html($xRow['title']);
-			$tVars['field']['default'] = secure_html($xRow['default']);
-			$tVars['field']['type']['value'] = $xRow['type'];
-			$tVars['field']['required']['value'] = $xRow['required'];
-			$tVars['field']['auto']['value'] = $xRow['auto'];
-			$tVars['field']['block']['value'] = $xRow['block'];
-			$tVars['field']['email_send']['value'] = $xRow['email_send'];
-			$tVars['field']['email_template']['value'] = $xRow['template'];
-		} else {
-			$tVars['flags']['addField'] = 1;
-			$tVars['field']['title'] = '';
-			$tVars['field']['type']['value'] = 'text';
-			$tVars['field']['required']['value'] = 0;
-			$tVars['field']['auto']['value'] = 0;
-			$tVars['field']['block']['value'] = 0;
-			$tVars['field']['email_template']['value'] = '';
-		}
-		$xsel = '';
-		foreach (array('text', 'email', 'textarea', 'select', 'date') as $ts) {
-			$tVars['field'][$ts . '_default'] = ($xRow['type'] == $ts) ? secure_html($xRow['default']) : '';
-			$xsel .= '<option value="' . $ts . '"' . (($xRow['type'] == $ts) ? ' selected' : '') . '>' . $lang['feedback:type.' . $ts];
-		}
-		$tVars['field']['type']['options'] = $xsel;
-		$tVars['field']['select_options'] = join("\n", $xRow['options']);
-		$tVars['field']['required']['options'] = array(0, 1);
-		$tVars['field']['auto']['options'] = array(0, 1, 2, 3);
-		$tVars['field']['block']['options'] = array(0, 1, 2);
-		$tVars['field']['email_send']['options'] = array(0, 1);
-		// prepare email send template list
-		$lf = array('' => '<не отправлять>');
-		foreach (feedback_listTemplates() as $k) {
-			if (substr($k, 0, 1) == ':') {
-				$lf[$k] = 'сайт: ' . $k;
-			} else {
-				$lf[$k] = 'плагин: ' . $k;
-			}
-		}
-		$tVars['field']['email_template']['options'] = $lf;
-		$recordFound = 1;
-	} while (0);
-	$templateName = 'plugins/feedback/tpl/' . ($recordFound ? 'conf.form.editrow' : 'conf.notify') . '.tpl';
-	$xt = $twig->loadTemplate($templateName);
-	echo $xt->render($tVars);
+function showFormRow()
+{
+    global $mysql, $lang, $twig;
+    $tVars = [];
+    // Load form
+    $id = intval($_REQUEST['form_id']);
+    $fRowId = $_REQUEST['row'];
+    $recordFound = 0;
+    do {
+        // Check if form exists
+        if (!is_array($frow = $mysql->record('select * from '.prefix.'_feedback where id = '.$id))) {
+            $tVars['content'] = 'Указанная форма ['.$id.'] не существует!';
+            break;
+        }
+        $tVars['flags']['haveForm'] = 1;
+        $tVars['formID'] = $frow['id'];
+        $tVars['formName'] = $frow['name'];
+        // Unpack form data
+        $fData = unserialize($frow['struct']);
+        if (!is_array($fData)) {
+            $fData = [];
+        }
+        // Check if form's row exists
+        if ($fRowId && !isset($fData[$fRowId])) {
+            $tVars['content'] = 'Указанное поле ['.$id.']['.$fRowId.'] не существует!';
+            break;
+        }
+        $editMode = ($fRowId) ? 1 : 0;
+        if ($editMode) {
+            $xRow = $fData[$fRowId];
+            $tVars['flags']['haveField'] = 1;
+            $tVars['fieldName'] = $xRow['name'];
+            $tVars['field']['name'] = $xRow['name'];
+            $tVars['field']['title'] = secure_html($xRow['title']);
+            $tVars['field']['default'] = secure_html($xRow['default']);
+            $tVars['field']['type']['value'] = $xRow['type'];
+            $tVars['field']['required']['value'] = $xRow['required'];
+            $tVars['field']['auto']['value'] = $xRow['auto'];
+            $tVars['field']['block']['value'] = $xRow['block'];
+            $tVars['field']['email_send']['value'] = $xRow['email_send'];
+            $tVars['field']['email_template']['value'] = $xRow['template'];
+        } else {
+            $tVars['flags']['addField'] = 1;
+            $tVars['field']['title'] = '';
+            $tVars['field']['type']['value'] = 'text';
+            $tVars['field']['required']['value'] = 0;
+            $tVars['field']['auto']['value'] = 0;
+            $tVars['field']['block']['value'] = 0;
+            $tVars['field']['email_template']['value'] = '';
+        }
+        $xsel = '';
+        foreach (['text', 'email', 'textarea', 'select', 'date'] as $ts) {
+            $tVars['field'][$ts.'_default'] = ($xRow['type'] == $ts) ? secure_html($xRow['default']) : '';
+            $xsel .= '<option value="'.$ts.'"'.(($xRow['type'] == $ts) ? ' selected' : '').'>'.$lang['feedback:type.'.$ts];
+        }
+        $tVars['field']['type']['options'] = $xsel;
+        $tVars['field']['select_options'] = implode("\n", $xRow['options']);
+        $tVars['field']['required']['options'] = [0, 1];
+        $tVars['field']['auto']['options'] = [0, 1, 2, 3];
+        $tVars['field']['block']['options'] = [0, 1, 2];
+        $tVars['field']['email_send']['options'] = [0, 1];
+        // prepare email send template list
+        $lf = ['' => '<не отправлять>'];
+        foreach (feedback_listTemplates() as $k) {
+            if (substr($k, 0, 1) == ':') {
+                $lf[$k] = 'сайт: '.$k;
+            } else {
+                $lf[$k] = 'плагин: '.$k;
+            }
+        }
+        $tVars['field']['email_template']['options'] = $lf;
+        $recordFound = 1;
+    } while (0);
+    $templateName = 'plugins/feedback/tpl/'.($recordFound ? 'conf.form.editrow' : 'conf.notify').'.tpl';
+    $xt = $twig->loadTemplate($templateName);
+    echo $xt->render($tVars);
 }
 
-function editFormRow() {
-
-	global $mysql, $lang, $twig;
-	// Check params
-	$id = intval($_REQUEST['form_id']);
-	$fRowId = $_REQUEST['name'];
-	$editMode = intval($_REQUEST['edit']);
-	$tVars = array();
-	$enabled = 0;
-	do {
-		// Check if form exists
-		if (!is_array($frow = $mysql->record("select * from " . prefix . "_feedback where id = " . $id))) {
-			$tVars['content'] = "Указанная форма [" . $id . "] не существует!";
-			break;
-		}
-		// Check if row id is not valid
-		if (is_numeric(substr($fRowId, 0, 1)) || (!preg_match("/^[a-zA-Z\d]+$/", $fRowId)) || (strlen($fRowId) < 3)) {
-			$tVars['content'] = "Необходимо соблюдать правила формирования ID!";
-			break;
-		}
-		$tVars['flags']['haveForm'] = 1;
-		$tVars['formID'] = $frow['id'];
-		$tVars['formName'] = $frow['name'];
-		// Unpack form data
-		$fData = unserialize($frow['struct']);
-		if (!is_array($fData)) $fData = array();
-		// Check if form's row exists
-		if ($editMode && !isset($fData[$fRowId])) {
-			$tVars['content'] = "Указанное поле [" . $id . "][" . $fRowId . "] не существует!";
-			break;
-		}
-		// For "add" mode - check if field already exists
-		if (!$editMode && isset($fData[$fRowId])) {
-			$tVars['content'] = "Указанное поле [" . $id . "][" . $fRowId . "] уже существует!";
-			break;
-		}
-		// Проверка корректности символов в имени [ только латница и цифры ]
-		if (!$editMode && !preg_match('#^[a-zA-Z0-9\.]+$#', $fRowId)) {
-			$tVars['content'] = "Имя поля содержит запрещенные символы. Разрешено использовать только символы латинского алфавита и цифры!";
-			break;
-		}
-		$tVars['flags']['haveField'] = 1;
-		$tVars['fieldName'] = $fRowId;
-		//
-		$enabled = 1;
-		// Fill field's params
-		$fld = array('name' => $fRowId, 'title' => $_REQUEST['title'], 'auto' => intval($_REQUEST['auto']), 'block' => intval($_REQUEST['block']));
-		if (intval($_REQUEST['required']))
-			$fld['required'] = 1;
-		switch ($_REQUEST['type']) {
-			case 'text':
-				$fld['type'] = 'text';
-				$fld['default'] = $_REQUEST['text_default'];
-				break;
-			case 'date':
-				$fld['type'] = 'date';
-				// Check default date
-				if (preg_match('#^ *(\d{1,2})\.(\d{1,2})\.(\d{4}) *$#', $_REQUEST['date_default'], $match) &&
-					($match[1] >= 1) && ($match[1] <= 31) && ($match[2] >= 1) && ($match[2] <= 12) && ($match[3] >= 1970) && ($match[3] <= 2099)
-				) {
-					$fld['default'] = $match[1] . '.' . $match[2] . '.' . $match[3];
-					$fld['default:vars']['day'] = $match[1];
-					$fld['default:vars']['month'] = $match[2];
-					$fld['default:vars']['year'] = $match[3];
-				}
-				break;
-			case 'textarea':
-				$fld['type'] = 'textarea';
-				$fld['default'] = $_REQUEST['textarea_default'];
-				break;
-			case 'email':
-				$fld['type'] = 'email';
-				$fld['default'] = '';
-				$fld['template'] = $_REQUEST['email_template'];
-				break;
-			case 'select':
-				$fld['type'] = 'select';
-				$fld['options'] = array();
-				if ($_REQUEST['select_storekeys']) {
-					$fld['storekeys'] = 1;
-				}
-				foreach (explode("\n", $_REQUEST['select_options']) as $row) {
-					if (!strlen(trim($row)))
-						continue;
-					$fld['options'][] = trim($row);
-				}
-				break;
-			default:
-				$tVars['content'] = "Неподдерживаемый тип поля";
-				break;
-		}
-		if (!isset($fld['type']))
-			break;
-		// Everything is correct. Let's update field data
-		$fData[$fRowId] = $fld;
-		$mysql->query("update " . prefix . "_feedback set struct = " . db_squote(serialize($fData)) . " where id = " . $frow['id']);
-		$tVars['content'] = "Поле изменено";
-	} while (0);
-	// Show template
-	$xt = $twig->loadTemplate('plugins/feedback/tpl/conf.notify.tpl');
-	echo $xt->render($tVars);
-}
-
-//
-//
-function doUpdate() {
-
-	global $mysql, $twig;
-	// Check params
-	$id = intval($_REQUEST['id']);
-	$fRowId = $_REQUEST['name'];
-	$enabled = 0;
-	$tVars = array();
-	do {
-		// Check if form exists
-		if (!is_array($frow = $mysql->record("select * from " . prefix . "_feedback where id = " . $id))) {
-			$tVars['content'] = "Указанная форма [" . $id . "] не существует!";
-			break;
-		}
-		$tVars['flags']['haveForm'] = 1;
-		$tVars['formID'] = $frow['id'];
-		$tVars['formName'] = $frow['name'];
-		// Unpack form data
-		$fData = unserialize($frow['struct']);
-		if (!is_array($fData)) $fData = array();
-		// Check if form's row exists
-		if (!isset($fData[$fRowId])) {
-			$tVars['content'] = "Указанное поле [" . $id . "][" . $fRowId . "] не существует!";
-			break;
-		}
-		$enabled = 1;
-	} while (0);
-	if (!$enabled) {
-		// Show template
-		$xt = $twig->loadTemplate('plugins/feedback/tpl/conf.notify.tpl');
-		echo $xt->render($tVars);
-
-		return false;
-	}
-	// Now make an action
-	switch ($_REQUEST['subaction']) {
-		case 'del':
-			unset($fData[$fRowId]);
-			break;
-		case 'up':
-			array_key_move($fData, $fRowId, -1);
-			break;
-		case 'down':
-			array_key_move($fData, $fRowId, 1);
-			break;
-	}
-	$mysql->query("update " . prefix . "_feedback set struct = " . db_squote(serialize($fData)) . " where id = " . $frow['id']);
-
-	return true;
+function editFormRow()
+{
+    global $mysql, $lang, $twig;
+    // Check params
+    $id = intval($_REQUEST['form_id']);
+    $fRowId = $_REQUEST['name'];
+    $editMode = intval($_REQUEST['edit']);
+    $tVars = [];
+    $enabled = 0;
+    do {
+        // Check if form exists
+        if (!is_array($frow = $mysql->record('select * from '.prefix.'_feedback where id = '.$id))) {
+            $tVars['content'] = 'Указанная форма ['.$id.'] не существует!';
+            break;
+        }
+        // Check if row id is not valid
+        if (is_numeric(substr($fRowId, 0, 1)) || (!preg_match("/^[a-zA-Z\d]+$/", $fRowId)) || (strlen($fRowId) < 3)) {
+            $tVars['content'] = 'Необходимо соблюдать правила формирования ID!';
+            break;
+        }
+        $tVars['flags']['haveForm'] = 1;
+        $tVars['formID'] = $frow['id'];
+        $tVars['formName'] = $frow['name'];
+        // Unpack form data
+        $fData = unserialize($frow['struct']);
+        if (!is_array($fData)) {
+            $fData = [];
+        }
+        // Check if form's row exists
+        if ($editMode && !isset($fData[$fRowId])) {
+            $tVars['content'] = 'Указанное поле ['.$id.']['.$fRowId.'] не существует!';
+            break;
+        }
+        // For "add" mode - check if field already exists
+        if (!$editMode && isset($fData[$fRowId])) {
+            $tVars['content'] = 'Указанное поле ['.$id.']['.$fRowId.'] уже существует!';
+            break;
+        }
+        // Проверка корректности символов в имени [ только латница и цифры ]
+        if (!$editMode && !preg_match('#^[a-zA-Z0-9\.]+$#', $fRowId)) {
+            $tVars['content'] = 'Имя поля содержит запрещенные символы. Разрешено использовать только символы латинского алфавита и цифры!';
+            break;
+        }
+        $tVars['flags']['haveField'] = 1;
+        $tVars['fieldName'] = $fRowId;
+        //
+        $enabled = 1;
+        // Fill field's params
+        $fld = ['name' => $fRowId, 'title' => $_REQUEST['title'], 'auto' => intval($_REQUEST['auto']), 'block' => intval($_REQUEST['block'])];
+        if (intval($_REQUEST['required'])) {
+            $fld['required'] = 1;
+        }
+        switch ($_REQUEST['type']) {
+            case 'text':
+                $fld['type'] = 'text';
+                $fld['default'] = $_REQUEST['text_default'];
+                break;
+            case 'date':
+                $fld['type'] = 'date';
+                // Check default date
+                if (preg_match('#^ *(\d{1,2})\.(\d{1,2})\.(\d{4}) *$#', $_REQUEST['date_default'], $match) &&
+                    ($match[1] >= 1) && ($match[1] <= 31) && ($match[2] >= 1) && ($match[2] <= 12) && ($match[3] >= 1970) && ($match[3] <= 2099)
+                ) {
+                    $fld['default'] = $match[1].'.'.$match[2].'.'.$match[3];
+                    $fld['default:vars']['day'] = $match[1];
+                    $fld['default:vars']['month'] = $match[2];
+                    $fld['default:vars']['year'] = $match[3];
+                }
+                break;
+            case 'textarea':
+                $fld['type'] = 'textarea';
+                $fld['default'] = $_REQUEST['textarea_default'];
+                break;
+            case 'email':
+                $fld['type'] = 'email';
+                $fld['default'] = '';
+                $fld['template'] = $_REQUEST['email_template'];
+                break;
+            case 'select':
+                $fld['type'] = 'select';
+                $fld['options'] = [];
+                if ($_REQUEST['select_storekeys']) {
+                    $fld['storekeys'] = 1;
+                }
+                foreach (explode("\n", $_REQUEST['select_options']) as $row) {
+                    if (!strlen(trim($row))) {
+                        continue;
+                    }
+                    $fld['options'][] = trim($row);
+                }
+                break;
+            default:
+                $tVars['content'] = 'Неподдерживаемый тип поля';
+                break;
+        }
+        if (!isset($fld['type'])) {
+            break;
+        }
+        // Everything is correct. Let's update field data
+        $fData[$fRowId] = $fld;
+        $mysql->query('update '.prefix.'_feedback set struct = '.db_squote(serialize($fData)).' where id = '.$frow['id']);
+        $tVars['content'] = 'Поле изменено';
+    } while (0);
+    // Show template
+    $xt = $twig->loadTemplate('plugins/feedback/tpl/conf.notify.tpl');
+    echo $xt->render($tVars);
 }
 
 //
-function delForm() {
+//
+function doUpdate()
+{
+    global $mysql, $twig;
+    // Check params
+    $id = intval($_REQUEST['id']);
+    $fRowId = $_REQUEST['name'];
+    $enabled = 0;
+    $tVars = [];
+    do {
+        // Check if form exists
+        if (!is_array($frow = $mysql->record('select * from '.prefix.'_feedback where id = '.$id))) {
+            $tVars['content'] = 'Указанная форма ['.$id.'] не существует!';
+            break;
+        }
+        $tVars['flags']['haveForm'] = 1;
+        $tVars['formID'] = $frow['id'];
+        $tVars['formName'] = $frow['name'];
+        // Unpack form data
+        $fData = unserialize($frow['struct']);
+        if (!is_array($fData)) {
+            $fData = [];
+        }
+        // Check if form's row exists
+        if (!isset($fData[$fRowId])) {
+            $tVars['content'] = 'Указанное поле ['.$id.']['.$fRowId.'] не существует!';
+            break;
+        }
+        $enabled = 1;
+    } while (0);
+    if (!$enabled) {
+        // Show template
+        $xt = $twig->loadTemplate('plugins/feedback/tpl/conf.notify.tpl');
+        echo $xt->render($tVars);
 
-	global $mysql, $lang;
-	$mysql->query("delete from " . prefix . "_feedback where id = " . intval($_REQUEST['id']));
+        return false;
+    }
+    // Now make an action
+    switch ($_REQUEST['subaction']) {
+        case 'del':
+            unset($fData[$fRowId]);
+            break;
+        case 'up':
+            array_key_move($fData, $fRowId, -1);
+            break;
+        case 'down':
+            array_key_move($fData, $fRowId, 1);
+            break;
+    }
+    $mysql->query('update '.prefix.'_feedback set struct = '.db_squote(serialize($fData)).' where id = '.$frow['id']);
+
+    return true;
 }
 
-function array_key_move(&$arr, $key, $offset) {
+//
+function delForm()
+{
+    global $mysql, $lang;
+    $mysql->query('delete from '.prefix.'_feedback where id = '.intval($_REQUEST['id']));
+}
 
-	$keys = array_keys($arr);
-	$index = -1;
-	foreach ($keys as $k => $v) if ($v == $key) {
-		$index = $k;
-		break;
-	}
-	if ($index == -1) return 0;
-	$index2 = $index + $offset;
-	if ($index2 < 0) $index2 = 0;
-	if ($index2 > (count($arr) - 1)) $index2 = count($arr) - 1;
-	if ($index == $index2) return 1;
-	$a = min($index, $index2);
-	$b = max($index, $index2);
-	$arr = array_slice($arr, 0, $a) +
-		array_slice($arr, $b, 1) +
-		array_slice($arr, $a + 1, $b - $a) +
-		array_slice($arr, $a, 1) +
-		array_slice($arr, $b, count($arr) - $b);
+function array_key_move(&$arr, $key, $offset)
+{
+    $keys = array_keys($arr);
+    $index = -1;
+    foreach ($keys as $k => $v) {
+        if ($v == $key) {
+            $index = $k;
+            break;
+        }
+    }
+    if ($index == -1) {
+        return 0;
+    }
+    $index2 = $index + $offset;
+    if ($index2 < 0) {
+        $index2 = 0;
+    }
+    if ($index2 > (count($arr) - 1)) {
+        $index2 = count($arr) - 1;
+    }
+    if ($index == $index2) {
+        return 1;
+    }
+    $a = min($index, $index2);
+    $b = max($index, $index2);
+    $arr = array_slice($arr, 0, $a) +
+        array_slice($arr, $b, 1) +
+        array_slice($arr, $a + 1, $b - $a) +
+        array_slice($arr, $a, 1) +
+        array_slice($arr, $b, count($arr) - $b);
 }

--- a/feedback/feedback.php
+++ b/feedback/feedback.php
@@ -1,16 +1,19 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 register_plugin_page('feedback', '', 'plugin_feedback_screen', 0);
 register_plugin_page('feedback', 'post', 'plugin_feedback_post', 0);
 loadPluginLang('feedback', 'main', '', '', ':');
 // Load library
-include_once(root . "/plugins/feedback/lib/common.php");
+include_once root.'/plugins/feedback/lib/common.php';
 //
 // Show feedback form
-function plugin_feedback_screen() {
-
-	plugin_feedback_showScreen();
+function plugin_feedback_screen()
+{
+    plugin_feedback_showScreen();
 }
 
 //
@@ -18,475 +21,486 @@ function plugin_feedback_screen() {
 // Mode:
 // * 0 - initial show
 // * 1 - show filled earlier values (error filling some fields)
-function plugin_feedback_showScreen($mode = 0, $errorText = '') {
+function plugin_feedback_showScreen($mode = 0, $errorText = '')
+{
+    global $template, $lang, $mysql, $userROW, $PFILTERS, $twig, $SYSTEM_FLAGS;
+    $output = '';
+    $hiddenFields = [];
+    $ptpl_url = admin_url.'/plugins/feedback/tpl';
+    // Determine paths for all template files
+    $tpath = locatePluginTemplates(['site.form', 'site.notify'], 'feedback', pluginGetVariable('feedback', 'localsource'));
+    $SYSTEM_FLAGS['info']['title']['group'] = $lang['feedback:header.title'];
+    $form_id = intval($_REQUEST['id']);
+    $xt = $twig->loadTemplate($tpath['site.notify'].'site.notify.tpl', $conversionConfig);
+    // Get form data
+    if (!is_array($frow = $mysql->record('select * from '.prefix.'_feedback where active = 1 and id = '.$form_id))) {
+        $tVars = [
+            'title'    => $lang['feedback:form.no.title'],
+            'ptpl_url' => $ptpl_url,
+            'entries'  => $lang['feedback:form.no.description'],
+        ];
+        $template['vars']['mainblock'] = $xt->render($tVars);
 
-	global $template, $lang, $mysql, $userROW, $PFILTERS, $twig, $SYSTEM_FLAGS;
-	$output = '';
-	$hiddenFields = array();
-	$ptpl_url = admin_url . '/plugins/feedback/tpl';
-	// Determine paths for all template files
-	$tpath = locatePluginTemplates(array('site.form', 'site.notify'), 'feedback', pluginGetVariable('feedback', 'localsource'));
-	$SYSTEM_FLAGS['info']['title']['group'] = $lang['feedback:header.title'];
-	$form_id = intval($_REQUEST['id']);
-	$xt = $twig->loadTemplate($tpath['site.notify'] . 'site.notify.tpl', $conversionConfig);
-	// Get form data
-	if (!is_array($frow = $mysql->record("select * from " . prefix . "_feedback where active = 1 and id = " . $form_id))) {
-		$tVars = array(
-			'title'    => $lang['feedback:form.no.title'],
-			'ptpl_url' => $ptpl_url,
-			'entries'  => $lang['feedback:form.no.description'],
-		);
-		$template['vars']['mainblock'] = $xt->render($tVars);
+        return 1;
+    }
+    $SYSTEM_FLAGS['info']['title']['item'] = $frow['title'];
+    // Unpack form data
+    $fData = unserialize($frow['struct']);
+    if (!is_array($fData)) {
+        $fData = [];
+    }
+    // Resolve UTF-8 POST issue if data are sent in UTF-8 coding
+    $flagsUTF = substr($frow['flags'], 5, 1) ? true : false;
+    $isUTF = 0;
+    foreach ($_REQUEST as $k => $v) {
+        if (preg_match('#^fld_#', $k, $null) && detectUTF8($v)) {
+            $isUTF = 1;
+            break;
+        }
+    }
+    // Process link with news
+    $link_news = intval(substr($frow['flags'], 3, 1));
+    $nrow = '';
+    $xfValues = [];
+    if ($link_news > 0) {
+        $linked_id = intval($_REQUEST['linked_id']);
+        if (!$linked_id || !is_array($nrow = $mysql->record('select * from '.prefix.'_news where (id = '.db_squote($linked_id).') and (approve = 1)'))) {
+            // No link is provided, but link if required
+            if ($link_news == 2) {
+                $tVars = [
+                    'title'    => $lang['feedback:form.nolink.title'],
+                    'ptpl_url' => $ptpl_url,
+                    'entries'  => $lang['feedback:form.nolink.description'],
+                ];
+                $template['vars']['mainblock'] = $xt->render($tVars);
 
-		return 1;
-	}
-	$SYSTEM_FLAGS['info']['title']['item'] = $frow['title'];
-	// Unpack form data
-	$fData = unserialize($frow['struct']);
-	if (!is_array($fData)) $fData = array();
-	// Resolve UTF-8 POST issue if data are sent in UTF-8 coding
-	$flagsUTF = substr($frow['flags'], 5, 1) ? true : false;
-	$isUTF = 0;
-	foreach ($_REQUEST as $k => $v) {
-		if (preg_match("#^fld_#", $k, $null) && detectUTF8($v)) {
-			$isUTF = 1;
-			break;
-		}
-	}
-	// Process link with news
-	$link_news = intval(substr($frow['flags'], 3, 1));
-	$nrow = '';
-	$xfValues = array();
-	if ($link_news > 0) {
-		$linked_id = intval($_REQUEST['linked_id']);
-		if (!$linked_id || !is_array($nrow = $mysql->record("select * from " . prefix . "_news where (id = " . db_squote($linked_id) . ") and (approve = 1)"))) {
-			// No link is provided, but link if required
-			if ($link_news == 2) {
-				$tVars = array(
-					'title'    => $lang['feedback:form.nolink.title'],
-					'ptpl_url' => $ptpl_url,
-					'entries'  => $lang['feedback:form.nolink.description'],
-				);
-				$template['vars']['mainblock'] = $xt->render($tVars);
-
-				return 1;
-			}
-		} else {
-			// Got data
-			if (function_exists('xf_decode'))
-				$xfValues = xf_decode($nrow['xfields']);
-			$hiddenFields['linked_id'] = $linked_id;
-		}
-	}
-	// XFields values from user's profile
-	$xfUserValues = array();
-	if (function_exists('xf_decode') && isset($userROW['xfields']) && ($userROW['xfields'] != ''))
-		$xfUserValues = xf_decode($userROW['xfields']);
-	// Choose template to use
-	$tFile = feedback_locateTemplateFiles($frow['template']);
-	/*
-		if ($frow['template'] && file_exists(root.'plugins/feedback/tpl/templates/'.$frow['template'].'.tpl')) {
-			$tP = root.'plugins/feedback/tpl/templates/';
-			$tN = $frow['template'];
-		} else {
-			$tP = $tpath['site.form'];
-			$tN = 'site.form';
-		}
-	*/
-	$xt = $twig->loadTemplate($tFile['site']['file']);
-	$tVars = array(
-		'ptpl_url'    => $tFile['site']['path'],
-		'title'       => $frow['title'],
-		'name'        => $frow['name'],
-		'description' => $frow['description'],
-		'id'          => $frow['id'],
-		'form_url'    => generateLink('core', 'plugin', array('plugin' => 'feedback', 'handler' => 'post'), array()),
-		'errorText'   => $errorText,
-		'flags'       => array(
-			'error'     => ($errorText) ? 1 : 0,
-			'link_news' => $link_news,
-		),
-	);
-	if ($link_news) {
-		$tVars['news'] = array(
-			'id'    => $nrow['id'],
-			'title' => $nrow['title'],
-			'url'   => newsGenerateLink($nrow),
-		);
-	}
-	$tEntries = array();
-	$FBF_DATA = array();
-	foreach ($fData as $fName => $fInfo) {
-		$tEntry = array(
-			'name'  => 'fld_' . $fInfo['name'],
-			'title' => $fInfo['title'],
-			'type'  => $fInfo['type'],
-		);
-		$FBF_DATA[$fName] = array($fInfo['type'], intval($fInfo['required']), iconv('Windows-1251', 'UTF-8', $fInfo['title']));
-		// Fill value
-		$setValue = '';
-		if ($mode && (!$fInfo['block'])) {
-			// FILLED EARLIER
-			$setValue = secure_html(($isUTF && $flagsUTF) ? iconv('UTF-8', 'Windows-1251//TRANSLIT', $_REQUEST['fld_' . $fInfo['name']]) : $_REQUEST['fld_' . $fInfo['name']]);
-		} else {
-			// INITIAL SHOW
-			$setValue = secure_html($fInfo['default']);
-			// If 'by parameter' mode is set, check if this variable was passed in GET
-			if (($fInfo['auto'] == 1) && isset($_REQUEST['v_' . $fInfo['name']])) {
-				$setValue = secure_html(($isUTF && $flagsUTF) ? iconv('UTF-8', 'Windows-1251//TRANSLIT', $_REQUEST['v_' . $fInfo['name']]) : $_REQUEST['v_' . $fInfo['name']]);
-			} else if ($fInfo['auto'] == 2) {
-				$setValue = secure_html($xfValues[$fInfo['name']]);
-			} else if ($fInfo['auto'] == 3) {
-				$setValue = secure_html($xfUserValues[$fInfo['name']]);
-			}
-		}
-		switch ($fInfo['type']) {
-			case 'text':
-			case 'textarea':
-			case 'email':
-				$tEntry['value'] = $setValue;
-				break;
-			case 'date':
-				// Prepare parsed date for show (in `show again` mode)
-				$setValueDay = $fInfo['default:vars']['day'];
-				$setValueMonth = $fInfo['default:vars']['month'];
-				$setValueYear = $fInfo['default:vars']['year'];
-				if ($mode) {
-					if ((intval($_REQUEST['fld_' . $fInfo['name'] . ':day']) >= 1) &&
-						(intval($_REQUEST['fld_' . $fInfo['name'] . ':day']) <= 31) &&
-						(intval($_REQUEST['fld_' . $fInfo['name'] . ':month']) >= 1) &&
-						(intval($_REQUEST['fld_' . $fInfo['name'] . ':month']) <= 12) &&
-						(intval($_REQUEST['fld_' . $fInfo['name'] . ':year']) >= 1970) &&
-						(intval($_REQUEST['fld_' . $fInfo['name'] . ':year']) <= 2020)
-					) {
-						$setValueDay = intval($_REQUEST['fld_' . $fInfo['name'] . ':day']);
-						$setValueMonth = intval($_REQUEST['fld_' . $fInfo['name'] . ':month']);
-						$setValueYear = intval($_REQUEST['fld_' . $fInfo['name'] . ':year']);
-					}
-				}
-				$opts = $fInfo['required'] ? '' : '<option value="">--</option>';
-				for ($di = 1; $di <= 31; $di++) {
-					$opts .= '<option value="' . $di . '"' . ($di == $setValueDay ? ' selected="selected"' : '') . '>' . sprintf('%02u', $di) . '</option>';
-				}
-				$tEntry['options']['day'] = $opts;
-				$opts = $fInfo['required'] ? '' : '<option value="">--</option>';
-				for ($di = 1; $di <= 12; $di++) {
-					$opts .= '<option value="' . $di . '"' . ($di == $setValueMonth ? ' selected="selected"' : '') . '>' . sprintf('%02u', $di) . '</option>';
-				}
-				$tEntry['options']['month'] = $opts;
-				$opts = $fInfo['required'] ? '' : '<option value="">--</option>';
-				$yearLimit = date('Y');
-				for ($di = 1970; $di <= $yearLimit; $di++) {
-					$opts .= '<option value="' . $di . '"' . ($di == $setValueYear ? ' selected="selected"' : '') . '>' . $di . '</option>';
-				}
-				$tEntry['options']['year'] = $opts;
-				break;
-			case 'select':
-				$opts = '';
-				if (is_array($fInfo['options']))
-					foreach ($fInfo['options'] as $k => $v) {
-						$opts .= '<option value="' . secure_html($v) . '"' . ($v == $setValue ? ' selected="selected"' : '') . '>' . secure_html($v) . '</option>';
-					}
-				$tEntry['options']['select'] = $opts;
-		}
-		$tEntry['flags'] = array(
-			'is_text'     => ($fInfo['type'] == 'text') ? 1 : 0,
-			'is_textarea' => ($fInfo['type'] == 'textarea') ? 1 : 0,
-			'is_select'   => ($fInfo['type'] == 'select') ? 1 : 0,
-			'is_date'     => ($fInfo['type'] == 'date') ? 1 : 0,
-			'required'    => $fInfo['required'] ? 1 : 0,
-		);
-		$tEntries [] = $tEntry;
-	}
-	// Feel entries
-	$tVars['entries'] = $tEntries;
-	$tVars['FBF_DATA'] = json_encode($FBF_DATA);
-	// Check if we need to check variable content via JScript
-	if (substr($frow['flags'], 0, 1)) {
-		$tVars['flags']['jcheck'] = 1;
-	}
-	// Check if we need captcha
-	if (substr($frow['flags'], 1, 1)) {
-		$tVars['flags']['captcha'] = 1;
-		$tVars['captcha_url'] = admin_url . "/captcha.php?id=feedback";
-		$tVars['captcha_rand'] = rand(00000, 99999);
-		$_SESSION['captcha.feedback'] = rand(00000, 99999);
-	}
-	// Check if we need to show `select destination notification address` menu
-	$em = unserialize($frow['emails']);
-	if ($em === false) {
-		$em[1] = array(1, '', preg_split("# *(\r\n|\n) *#", $frow['emails']));
-	}
-	if (count($em) > 1) {
-		$tVars['flags']['recipients'] = 1;
-		$options = '';
-		foreach ($em as $er) {
-			$options .= '<option value="' . $er[0] . '">' . (($er[1] == '') ? (join(', ', $er[2])) : $er[1]) . '</option>';
-		}
-		$tVars['recipients_list'] = $options;
-	}
-	// Prepare hidden fields
-	$hF = '';
-	foreach ($hiddenFields as $k => $v) {
-		$hF .= '<input type="hidden" name="' . $k . '" value="' . htmlspecialchars($v, ENT_COMPAT | ENT_HTML401, 'cp1251') . '"/>' . "\n";
-	}
-	$tVars['hidden_fields'] = $hF;
-	// Process filters (if any)
-	if (is_array($PFILTERS['feedback']))
-		foreach ($PFILTERS['feedback'] as $k => $v) {
-			$v->onShow($form_id, $frow, $fData, $tVars);
-		}
-	$template['vars']['mainblock'] = $xt->render($tVars);
+                return 1;
+            }
+        } else {
+            // Got data
+            if (function_exists('xf_decode')) {
+                $xfValues = xf_decode($nrow['xfields']);
+            }
+            $hiddenFields['linked_id'] = $linked_id;
+        }
+    }
+    // XFields values from user's profile
+    $xfUserValues = [];
+    if (function_exists('xf_decode') && isset($userROW['xfields']) && ($userROW['xfields'] != '')) {
+        $xfUserValues = xf_decode($userROW['xfields']);
+    }
+    // Choose template to use
+    $tFile = feedback_locateTemplateFiles($frow['template']);
+    /*
+        if ($frow['template'] && file_exists(root.'plugins/feedback/tpl/templates/'.$frow['template'].'.tpl')) {
+            $tP = root.'plugins/feedback/tpl/templates/';
+            $tN = $frow['template'];
+        } else {
+            $tP = $tpath['site.form'];
+            $tN = 'site.form';
+        }
+    */
+    $xt = $twig->loadTemplate($tFile['site']['file']);
+    $tVars = [
+        'ptpl_url'    => $tFile['site']['path'],
+        'title'       => $frow['title'],
+        'name'        => $frow['name'],
+        'description' => $frow['description'],
+        'id'          => $frow['id'],
+        'form_url'    => generateLink('core', 'plugin', ['plugin' => 'feedback', 'handler' => 'post'], []),
+        'errorText'   => $errorText,
+        'flags'       => [
+            'error'     => ($errorText) ? 1 : 0,
+            'link_news' => $link_news,
+        ],
+    ];
+    if ($link_news) {
+        $tVars['news'] = [
+            'id'    => $nrow['id'],
+            'title' => $nrow['title'],
+            'url'   => newsGenerateLink($nrow),
+        ];
+    }
+    $tEntries = [];
+    $FBF_DATA = [];
+    foreach ($fData as $fName => $fInfo) {
+        $tEntry = [
+            'name'  => 'fld_'.$fInfo['name'],
+            'title' => $fInfo['title'],
+            'type'  => $fInfo['type'],
+        ];
+        $FBF_DATA[$fName] = [$fInfo['type'], intval($fInfo['required']), iconv('Windows-1251', 'UTF-8', $fInfo['title'])];
+        // Fill value
+        $setValue = '';
+        if ($mode && (!$fInfo['block'])) {
+            // FILLED EARLIER
+            $setValue = secure_html(($isUTF && $flagsUTF) ? iconv('UTF-8', 'Windows-1251//TRANSLIT', $_REQUEST['fld_'.$fInfo['name']]) : $_REQUEST['fld_'.$fInfo['name']]);
+        } else {
+            // INITIAL SHOW
+            $setValue = secure_html($fInfo['default']);
+            // If 'by parameter' mode is set, check if this variable was passed in GET
+            if (($fInfo['auto'] == 1) && isset($_REQUEST['v_'.$fInfo['name']])) {
+                $setValue = secure_html(($isUTF && $flagsUTF) ? iconv('UTF-8', 'Windows-1251//TRANSLIT', $_REQUEST['v_'.$fInfo['name']]) : $_REQUEST['v_'.$fInfo['name']]);
+            } elseif ($fInfo['auto'] == 2) {
+                $setValue = secure_html($xfValues[$fInfo['name']]);
+            } elseif ($fInfo['auto'] == 3) {
+                $setValue = secure_html($xfUserValues[$fInfo['name']]);
+            }
+        }
+        switch ($fInfo['type']) {
+            case 'text':
+            case 'textarea':
+            case 'email':
+                $tEntry['value'] = $setValue;
+                break;
+            case 'date':
+                // Prepare parsed date for show (in `show again` mode)
+                $setValueDay = $fInfo['default:vars']['day'];
+                $setValueMonth = $fInfo['default:vars']['month'];
+                $setValueYear = $fInfo['default:vars']['year'];
+                if ($mode) {
+                    if ((intval($_REQUEST['fld_'.$fInfo['name'].':day']) >= 1) &&
+                        (intval($_REQUEST['fld_'.$fInfo['name'].':day']) <= 31) &&
+                        (intval($_REQUEST['fld_'.$fInfo['name'].':month']) >= 1) &&
+                        (intval($_REQUEST['fld_'.$fInfo['name'].':month']) <= 12) &&
+                        (intval($_REQUEST['fld_'.$fInfo['name'].':year']) >= 1970) &&
+                        (intval($_REQUEST['fld_'.$fInfo['name'].':year']) <= 2020)
+                    ) {
+                        $setValueDay = intval($_REQUEST['fld_'.$fInfo['name'].':day']);
+                        $setValueMonth = intval($_REQUEST['fld_'.$fInfo['name'].':month']);
+                        $setValueYear = intval($_REQUEST['fld_'.$fInfo['name'].':year']);
+                    }
+                }
+                $opts = $fInfo['required'] ? '' : '<option value="">--</option>';
+                for ($di = 1; $di <= 31; $di++) {
+                    $opts .= '<option value="'.$di.'"'.($di == $setValueDay ? ' selected="selected"' : '').'>'.sprintf('%02u', $di).'</option>';
+                }
+                $tEntry['options']['day'] = $opts;
+                $opts = $fInfo['required'] ? '' : '<option value="">--</option>';
+                for ($di = 1; $di <= 12; $di++) {
+                    $opts .= '<option value="'.$di.'"'.($di == $setValueMonth ? ' selected="selected"' : '').'>'.sprintf('%02u', $di).'</option>';
+                }
+                $tEntry['options']['month'] = $opts;
+                $opts = $fInfo['required'] ? '' : '<option value="">--</option>';
+                $yearLimit = date('Y');
+                for ($di = 1970; $di <= $yearLimit; $di++) {
+                    $opts .= '<option value="'.$di.'"'.($di == $setValueYear ? ' selected="selected"' : '').'>'.$di.'</option>';
+                }
+                $tEntry['options']['year'] = $opts;
+                break;
+            case 'select':
+                $opts = '';
+                if (is_array($fInfo['options'])) {
+                    foreach ($fInfo['options'] as $k => $v) {
+                        $opts .= '<option value="'.secure_html($v).'"'.($v == $setValue ? ' selected="selected"' : '').'>'.secure_html($v).'</option>';
+                    }
+                }
+                $tEntry['options']['select'] = $opts;
+        }
+        $tEntry['flags'] = [
+            'is_text'     => ($fInfo['type'] == 'text') ? 1 : 0,
+            'is_textarea' => ($fInfo['type'] == 'textarea') ? 1 : 0,
+            'is_select'   => ($fInfo['type'] == 'select') ? 1 : 0,
+            'is_date'     => ($fInfo['type'] == 'date') ? 1 : 0,
+            'required'    => $fInfo['required'] ? 1 : 0,
+        ];
+        $tEntries[] = $tEntry;
+    }
+    // Feel entries
+    $tVars['entries'] = $tEntries;
+    $tVars['FBF_DATA'] = json_encode($FBF_DATA);
+    // Check if we need to check variable content via JScript
+    if (substr($frow['flags'], 0, 1)) {
+        $tVars['flags']['jcheck'] = 1;
+    }
+    // Check if we need captcha
+    if (substr($frow['flags'], 1, 1)) {
+        $tVars['flags']['captcha'] = 1;
+        $tVars['captcha_url'] = admin_url.'/captcha.php?id=feedback';
+        $tVars['captcha_rand'] = rand(00000, 99999);
+        $_SESSION['captcha.feedback'] = rand(00000, 99999);
+    }
+    // Check if we need to show `select destination notification address` menu
+    $em = unserialize($frow['emails']);
+    if ($em === false) {
+        $em[1] = [1, '', preg_split("# *(\r\n|\n) *#", $frow['emails'])];
+    }
+    if (count($em) > 1) {
+        $tVars['flags']['recipients'] = 1;
+        $options = '';
+        foreach ($em as $er) {
+            $options .= '<option value="'.$er[0].'">'.(($er[1] == '') ? (implode(', ', $er[2])) : $er[1]).'</option>';
+        }
+        $tVars['recipients_list'] = $options;
+    }
+    // Prepare hidden fields
+    $hF = '';
+    foreach ($hiddenFields as $k => $v) {
+        $hF .= '<input type="hidden" name="'.$k.'" value="'.htmlspecialchars($v, ENT_COMPAT | ENT_HTML401, 'cp1251').'"/>'."\n";
+    }
+    $tVars['hidden_fields'] = $hF;
+    // Process filters (if any)
+    if (is_array($PFILTERS['feedback'])) {
+        foreach ($PFILTERS['feedback'] as $k => $v) {
+            $v->onShow($form_id, $frow, $fData, $tVars);
+        }
+    }
+    $template['vars']['mainblock'] = $xt->render($tVars);
 }
 
 //
 // Post feedback message
-function plugin_feedback_post() {
+function plugin_feedback_post()
+{
+    global $template, $lang, $mysql, $userROW, $SYSTEM_FLAGS, $PFILTERS, $twig, $SUPRESS_TEMPLATE_SHOW, $SUPRESS_MAINBLOCK_SHOW;
+    // Determine paths for all template files
+    $tpath = locatePluginTemplates(['site.form', 'site.notify', 'mail.html', 'mail.text'], 'feedback', pluginGetVariable('feedback', 'localsource'));
+    $ptpl_url = admin_url.'/plugins/feedback/tpl';
+    $form_id = intval($_REQUEST['id']);
+    $SYSTEM_FLAGS['info']['title']['group'] = $lang['feedback:header.title'];
+    $xt = $twig->loadTemplate($tpath['site.notify'].'site.notify.tpl');
+    // Get form data
+    if (!is_array($frow = $mysql->record('select * from '.prefix.'_feedback where active = 1 and id = '.$form_id))) {
+        $tVars = [
+            'title'    => $lang['feedback:form.no.title'],
+            'ptpl_url' => $ptpl_url,
+            'entries'  => $lang['feedback:form.no.description'],
+        ];
+        $template['vars']['mainblock'] = $xt->render($tVars);
 
-	global $template, $lang, $mysql, $userROW, $SYSTEM_FLAGS, $PFILTERS, $twig, $SUPRESS_TEMPLATE_SHOW, $SUPRESS_MAINBLOCK_SHOW;
-	// Determine paths for all template files
-	$tpath = locatePluginTemplates(array('site.form', 'site.notify', 'mail.html', 'mail.text'), 'feedback', pluginGetVariable('feedback', 'localsource'));
-	$ptpl_url = admin_url . '/plugins/feedback/tpl';
-	$form_id = intval($_REQUEST['id']);
-	$SYSTEM_FLAGS['info']['title']['group'] = $lang['feedback:header.title'];
-	$xt = $twig->loadTemplate($tpath['site.notify'] . 'site.notify.tpl');
-	// Get form data
-	if (!is_array($frow = $mysql->record("select * from " . prefix . "_feedback where active = 1 and id = " . $form_id))) {
-		$tVars = array(
-			'title'    => $lang['feedback:form.no.title'],
-			'ptpl_url' => $ptpl_url,
-			'entries'  => $lang['feedback:form.no.description'],
-		);
-		$template['vars']['mainblock'] = $xt->render($tVars);
+        return 1;
+    }
+    $SYSTEM_FLAGS['info']['title']['item'] = str_replace('{title}', $frow['title'], $lang['feedback:header.send']);
+    // Unpack form data
+    $fData = unserialize($frow['struct']);
+    if (!is_array($fData)) {
+        $fData = [];
+    }
+    // Process link with news
+    $link_news = intval(substr($frow['flags'], 3, 1));
+    $nrow = '';
+    $xfValues = [];
+    if ($link_news > 0) {
+        $linked_id = intval($_REQUEST['linked_id']);
+        if (!$linked_id || !is_array($nrow = $mysql->record('select * from '.prefix.'_news where (id = '.db_squote($linked_id).') and (approve = 1)'))) {
+            // No link is provided, but link if required
+            if ($link_news == 2) {
+                $tVars = [
+                    'title'    => $lang['feedback:form.nolink.title'],
+                    'ptpl_url' => $ptpl_url,
+                    'entries'  => $lang['feedback:form.nolink.description'],
+                ];
+                $template['vars']['mainblock'] = $xt->render($tVars);
 
-		return 1;
-	}
-	$SYSTEM_FLAGS['info']['title']['item'] = str_replace('{title}', $frow['title'], $lang['feedback:header.send']);
-	// Unpack form data
-	$fData = unserialize($frow['struct']);
-	if (!is_array($fData)) $fData = array();
-	// Process link with news
-	$link_news = intval(substr($frow['flags'], 3, 1));
-	$nrow = '';
-	$xfValues = array();
-	if ($link_news > 0) {
-		$linked_id = intval($_REQUEST['linked_id']);
-		if (!$linked_id || !is_array($nrow = $mysql->record("select * from " . prefix . "_news where (id = " . db_squote($linked_id) . ") and (approve = 1)"))) {
-			// No link is provided, but link if required
-			if ($link_news == 2) {
-				$tVars = array(
-					'title'    => $lang['feedback:form.nolink.title'],
-					'ptpl_url' => $ptpl_url,
-					'entries'  => $lang['feedback:form.nolink.description'],
-				);
-				$template['vars']['mainblock'] = $xt->render($tVars);
+                return 1;
+            }
+        } else {
+            // Got data
+            if (function_exists('xf_decode')) {
+                $xfValues = xf_decode($nrow['xfields']);
+            }
+        }
+    }
+    // Check if captcha check if needed
+    if (substr($frow['flags'], 1, 1)) {
+        $vcode = $_REQUEST['vcode'];
+        if ((!$vcode) || ($vcode != $_SESSION['captcha.feedback'])) {
+            // Wrong CAPTCHA code (!!!)
+            plugin_feedback_showScreen(1, $lang['feedback:sform.captcha.badcode']);
 
-				return 1;
-			}
-		} else {
-			// Got data
-			if (function_exists('xf_decode'))
-				$xfValues = xf_decode($nrow['xfields']);
-		}
-	}
-	// Check if captcha check if needed
-	if (substr($frow['flags'], 1, 1)) {
-		$vcode = $_REQUEST['vcode'];
-		if ((!$vcode) || ($vcode != $_SESSION['captcha.feedback'])) {
-			// Wrong CAPTCHA code (!!!)
-			plugin_feedback_showScreen(1, $lang['feedback:sform.captcha.badcode']);
+            return;
+        }
+    }
+    // Check if user requested HTML message format
+    $flagHTML = substr($frow['flags'], 2, 1) ? true : false;
+    $flagSubj = substr($frow['flags'], 4, 1) ? true : false;
+    $flagsUTF = substr($frow['flags'], 5, 1) ? true : false;
+    $mailTN = 'mail.'.($flagHTML ? 'html' : 'text');
+    // Scan all fields and fill data. Prepare outgoing email.
+    $output = '';
+    $tVars = [
+        'flags'   => [
+            'link_news' => ($linked_id > 0) ? 1 : 0,
+        ],
+        'form'    => [
+            'id'          => $frow['id'],
+            'title'       => $frow['title'],
+            'description' => $frow['description'],
+        ],
+        'values'  => [],
+        'entries' => [],
+    ];
+    if ($linked_id > 0) {
+        $tVars['news'] = [
+            'id'    => $nrow['id'],
+            'title' => $nrow['title'],
+            'url'   => newsGenerateLink($nrow, false, 0, true),
+        ];
+    }
+    // Resolve UTF-8 POST issue if data are sent in UTF-8 coding
+    $isUTF = 0;
+    foreach ($_REQUEST as $k => $v) {
+        if (preg_match('#^fld_#', $k, $null) && detectUTF8($v)) {
+            $isUTF = 1;
+            break;
+        }
+    }
+    $tEntries = [];
+    $fieldValues = [];
+    foreach ($fData as $fName => $fInfo) {
+        $fieldValue = '';
+        switch ($fInfo['type']) {
+            case 'date':
+                $fieldValue = $_REQUEST['fld_'.$fName.':day'].'.'.$_REQUEST['fld_'.$fName.':month'].'.'.$_REQUEST['fld_'.$fName.':year'];
+                break;
+            default:
+                if ($isUTF && $flagsUTF) {
+                    $fieldValue = iconv('UTF-8', 'Windows-1251//TRANSLIT', $_REQUEST['fld_'.$fName]);
+                } else {
+                    $fieldValue = $_REQUEST['fld_'.$fName];
+                }
+        }
+        // Check if required field is filled
+        if ($fInfo['required'] && (strlen($fieldValue) < 1)) {
+            // Don't allow to post request
+            plugin_feedback_showScreen(1, str_replace(['{name}', '{title}'], [$fName, $fInfo['title']], $lang['feedback:sform.reqfld']));
 
-			return;
-		}
-	}
-	// Check if user requested HTML message format
-	$flagHTML = substr($frow['flags'], 2, 1) ? true : false;
-	$flagSubj = substr($frow['flags'], 4, 1) ? true : false;
-	$flagsUTF = substr($frow['flags'], 5, 1) ? true : false;
-	$mailTN = 'mail.' . ($flagHTML ? 'html' : 'text');
-	// Scan all fields and fill data. Prepare outgoing email.
-	$output = '';
-	$tVars = array(
-		'flags'   => array(
-			'link_news' => ($linked_id > 0) ? 1 : 0,
-		),
-		'form'    => array(
-			'id'          => $frow['id'],
-			'title'       => $frow['title'],
-			'description' => $frow['description'],
-		),
-		'values'  => array(),
-		'entries' => array(),
-	);
-	if ($linked_id > 0) {
-		$tVars['news'] = array(
-			'id'    => $nrow['id'],
-			'title' => $nrow['title'],
-			'url'   => newsGenerateLink($nrow, false, 0, true),
-		);
-	}
-	// Resolve UTF-8 POST issue if data are sent in UTF-8 coding
-	$isUTF = 0;
-	foreach ($_REQUEST as $k => $v) {
-		if (preg_match("#^fld_#", $k, $null) && detectUTF8($v)) {
-			$isUTF = 1;
-			break;
-		}
-	}
-	$tEntries = array();
-	$fieldValues = array();
-	foreach ($fData as $fName => $fInfo) {
-		$fieldValue = '';
-		switch ($fInfo['type']) {
-			case 'date':
-				$fieldValue = $_REQUEST['fld_' . $fName . ':day'] . '.' . $_REQUEST['fld_' . $fName . ':month'] . '.' . $_REQUEST['fld_' . $fName . ':year'];
-				break;
-			default:
-				if ($isUTF && $flagsUTF) {
-					$fieldValue = iconv('UTF-8', 'Windows-1251//TRANSLIT', $_REQUEST['fld_' . $fName]);
-				} else {
-					$fieldValue = $_REQUEST['fld_' . $fName];
-				}
-		}
-		// Check if required field is filled
-		if ($fInfo['required'] && (strlen($fieldValue) < 1)) {
-			// Don't allow to post request
-			plugin_feedback_showScreen(1, str_replace(array('{name}', '{title}'), array($fName, $fInfo['title']), $lang['feedback:sform.reqfld']));
+            return;
+        }
+        $fieldValues[$fName] = str_replace("\n", "<br/>\n", secure_html($fieldValue));
+        $tEntry = [
+            'id'    => $fName,
+            'title' => secure_html($fInfo['title']),
+            'value' => $fieldValues[$fName],
+        ];
+        $tEntries[] = $tEntry;
+    }
+    $tVars['entries'] = $tEntries;
+    $tVars['values'] = $fieldValues;
+    // Process filters (if any) [[ basic filter model ]]
+    if (is_array($PFILTERS['feedback'])) {
+        // OLD style
+        foreach ($PFILTERS['feedback'] as $k => $v) {
+            $v->onProcess($form_id, $frow, $fData, $flagHTML, $tVars);
+        }
+        // NEW style
+        foreach ($PFILTERS['feedback'] as $k => $v) {
+            if (!$v->onProcessEx($form_id, $frow, $fData, $flagHTML, $tVars, $tResult)) {
+                // BLOCK action
+                $msg = '';
+                if ($tResult['rawmsg']) {
+                    $msg = $tResult['rawmsg'];
+                } else {
+                    $msg = str_replace(['{plugin}', '{error}', '{field}'], [$k, $tResult['msg'], $tResult['field']], $lang['feedback:sform.plugin'.($tResult['field'] ? '.field' : '')]);
+                }
+                plugin_feedback_showScreen(1, $msg);
 
-			return;
-		}
-		$fieldValues[$fName] = str_replace("\n", "<br/>\n", secure_html($fieldValue));
-		$tEntry = array(
-			'id'    => $fName,
-			'title' => secure_html($fInfo['title']),
-			'value' => $fieldValues[$fName],
-		);
-		$tEntries [] = $tEntry;
-	}
-	$tVars['entries'] = $tEntries;
-	$tVars['values'] = $fieldValues;
-	// Process filters (if any) [[ basic filter model ]]
-	if (is_array($PFILTERS['feedback'])) {
-		// OLD style
-		foreach ($PFILTERS['feedback'] as $k => $v) {
-			$v->onProcess($form_id, $frow, $fData, $flagHTML, $tVars);
-		}
-		// NEW style
-		foreach ($PFILTERS['feedback'] as $k => $v) {
-			if (!$v->onProcessEx($form_id, $frow, $fData, $flagHTML, $tVars, $tResult)) {
-				// BLOCK action
-				$msg = '';
-				if ($tResult['rawmsg']) {
-					$msg = $tResult['rawmsg'];
-				} else {
-					$msg = str_replace(array('{plugin}', '{error}', '{field}'), array($k, $tResult['msg'], $tResult['field']), $lang['feedback:sform.plugin' . ($tResult['field'] ? '.field' : '')]);
-				}
-				plugin_feedback_showScreen(1, $msg);
+                return;
+            }
+        }
+    }
+    // =====[ Prepare to send message ]=====
+    // Select recipient group
+    $em = unserialize($frow['emails']);
+    if ($em === false) {
+        $em[1] = [1, '', preg_split("# *(\r\n|\n) *#", $frow['emails'])];
+    }
+    $elist = (isset($em[intval($_POST['recipient'])])) ? $em[intval($_POST['recipient'])][2] : $em[1][2];
+    $eGroupName = (isset($em[intval($_POST['recipient'])])) ? $em[intval($_POST['recipient'])][1] : $em[1][1];
+    // Prepare EMAIL content
+    $mailSubject = str_replace(['{name}', '{title}'], [$frow['name'], $frow['title']], $flagSubj ? $frow['subj'] : $lang['feedback:mail.subj']);
+    // Load template for ADMIN notification
+    $tfiles = feedback_locateTemplateFiles($frow['template'], $flagHTML);
+    $xt = $twig->loadTemplate($tfiles['mail']['file']);
+    // Render ADMIN email body
+    $mailBody = $xt->render($tVars);
+    // Prepare plugin NOTIFICATION structure
+    $eNotify = [
+        'recipient'   => $elist,
+        'subject'     => $mailSubject,
+        'body'        => $mailBody,
+        'contentType' => 'text/'.($flagHTML ? 'html' : 'plain'),
+    ];
+    // Try to SEND via PLUGIN
+    $isSentViaPlugin = false;
+    $tResult = [];
+    foreach ($PFILTERS['feedback'] as $k => $v) {
+        if ($v->onSendEx($form_id, $frow, $fData, $eNotify, $tVars, $tResult)) {
+            $isSentViaPlugin = true;
+            break;
+        }
+    }
+    $mailCount = 0;
+    if (!$isSentViaPlugin) {
+        // PLUGINS DIDN'T SENT MESSAGE, use LEGACY MODE
+        foreach ($elist as $email) {
+            if (trim($email) == '') {
+                continue;
+            }
+            $mailCount++;
+            sendEmailMessage($email, $mailSubject, $mailBody, false, false, 'text/'.($flagHTML ? 'html' : 'plain'));
+        }
+        // Check if we need to send notification to user
+        // -- list of user's email
+        $eSendList = [];
+        foreach ($fData as $fName => $fInfo) {
+            // FIELD TYPE == Email + NOTIFICATION REQUEST is SET
+            if (($fInfo['type'] == 'email') && ($fInfo['template'] != '')) {
+                $tfiles = feedback_locateTemplateFiles($fInfo['template'], $flagHTML);
+                $tfn = $tfiles['mail']['file'];
+                if ((filter_var($fieldValues[$fName], FILTER_VALIDATE_EMAIL) !== false) && file_exists($tfn)) {
+                    $eSendList[] = $fieldValues[$fName];
+                    $xtu = $twig->loadTemplate($tfn);
+                    // Render USER email body
+                    $umailBody = $xtu->render($tVars);
+                    sendEmailMessage($fieldValues[$fName], $mailSubject, $umailBody, false, false, 'text/'.($flagHTML ? 'html' : 'plain'));
+                }
+            }
+        }
+    }
+    // Do post processing notification
+    if (is_array($PFILTERS['feedback'])) {
+        foreach ($PFILTERS['feedback'] as $k => $v) {
+            $v->onProcessNotify($form_id);
+        }
+    }
+    // Lock used captcha code if captcha is enabled
+    if (substr($frow['flags'], 1, 1)) {
+        //		$_SESSION['captcha.feedback'] = rand(00000, 99999);
+    }
+    // USER notification
+    // - DONE via plugin
+    if ($isSentViaPlugin && ($tResult['redirect'] || $tResult['notify.raw'] || $tResult['notify.template'])) {
+        if ($tResult['redirect']) {
+            $SUPRESS_TEMPLATE_SHOW = true;
+            $SUPRESS_MAINBLOCK_SHOW = true;
+            header('Location: '.$tResult['redirect']);
 
-				return;
-			}
-		}
-	}
-	// =====[ Prepare to send message ]=====
-	// Select recipient group
-	$em = unserialize($frow['emails']);
-	if ($em === false) {
-		$em[1] = array(1, '', preg_split("# *(\r\n|\n) *#", $frow['emails']));
-	}
-	$elist = (isset($em[intval($_POST['recipient'])])) ? $em[intval($_POST['recipient'])][2] : $em[1][2];
-	$eGroupName = (isset($em[intval($_POST['recipient'])])) ? $em[intval($_POST['recipient'])][1] : $em[1][1];
-	// Prepare EMAIL content
-	$mailSubject = str_replace(array('{name}', '{title}'), array($frow['name'], $frow['title']), $flagSubj ? $frow['subj'] : $lang['feedback:mail.subj']);
-	// Load template for ADMIN notification
-	$tfiles = feedback_locateTemplateFiles($frow['template'], $flagHTML);
-	$xt = $twig->loadTemplate($tfiles['mail']['file']);
-	// Render ADMIN email body
-	$mailBody = $xt->render($tVars);
-	// Prepare plugin NOTIFICATION structure
-	$eNotify = array(
-		'recipient'   => $elist,
-		'subject'     => $mailSubject,
-		'body'        => $mailBody,
-		'contentType' => 'text/' . ($flagHTML ? 'html' : 'plain'),
-	);
-	// Try to SEND via PLUGIN
-	$isSentViaPlugin = false;
-	$tResult = array();
-	foreach ($PFILTERS['feedback'] as $k => $v) {
-		if ($v->onSendEx($form_id, $frow, $fData, $eNotify, $tVars, $tResult)) {
-			$isSentViaPlugin = true;
-			break;
-		}
-	}
-	$mailCount = 0;
-	if (!$isSentViaPlugin) {
-		// PLUGINS DIDN'T SENT MESSAGE, use LEGACY MODE
-		foreach ($elist as $email) {
-			if (trim($email) == '')
-				continue;
-			$mailCount++;
-			sendEmailMessage($email, $mailSubject, $mailBody, false, false, 'text/' . ($flagHTML ? 'html' : 'plain'));
-		}
-		// Check if we need to send notification to user
-		// -- list of user's email
-		$eSendList = array();
-		foreach ($fData as $fName => $fInfo) {
-			// FIELD TYPE == Email + NOTIFICATION REQUEST is SET
-			if (($fInfo['type'] == 'email') && ($fInfo['template'] != '')) {
-				$tfiles = feedback_locateTemplateFiles($fInfo['template'], $flagHTML);
-				$tfn = $tfiles['mail']['file'];
-				if ((filter_var($fieldValues[$fName], FILTER_VALIDATE_EMAIL) !== false) && file_exists($tfn)) {
-					$eSendList [] = $fieldValues[$fName];
-					$xtu = $twig->loadTemplate($tfn);
-					// Render USER email body
-					$umailBody = $xtu->render($tVars);
-					sendEmailMessage($fieldValues[$fName], $mailSubject, $umailBody, false, false, 'text/' . ($flagHTML ? 'html' : 'plain'));
-				}
-			}
-		}
-	}
-	// Do post processing notification
-	if (is_array($PFILTERS['feedback']))
-		foreach ($PFILTERS['feedback'] as $k => $v) {
-			$v->onProcessNotify($form_id);
-		}
-	// Lock used captcha code if captcha is enabled
-	if (substr($frow['flags'], 1, 1)) {
-		//		$_SESSION['captcha.feedback'] = rand(00000, 99999);
-	}
-	// USER notification
-	// - DONE via plugin
-	if ($isSentViaPlugin && ($tResult['redirect'] || $tResult['notify.raw'] || $tResult['notify.template'])) {
-		if ($tResult['redirect']) {
-			$SUPRESS_TEMPLATE_SHOW = true;
-			$SUPRESS_MAINBLOCK_SHOW = true;
-			header('Location: ' . $tResult['redirect']);
+            return;
+        }
+        if ($tResult['notify.raw']) {
+            $SUPRESS_TEMPLATE_SHOW = true;
+            $template['mainblock'] = $tResult['notify.raw'];
 
-			return;
-		}
-		if ($tResult['notify.raw']) {
-			$SUPRESS_TEMPLATE_SHOW = true;
-			$template['mainblock'] = $tResult['notify.raw'];
+            return;
+        }
+        if ($tResult['notify.template']) {
+            $template['mainblock'] = $tResult['notify.template'];
 
-			return;
-		}
-		if ($tResult['notify.template']) {
-			$template['mainblock'] = $tResult['notify.template'];
-
-			return;
-		}
-	}
-	$notifyMessage = ($isSentViaPlugin && $tResult['notify.msg']) ? $tResult['notify.msg'] : str_replace('{ecount}', $mailCount, $lang['feedback:confirm.message']);
-	// Prepare user's notification
-	$xt = $twig->loadTemplate($tpath['site.notify'] . 'site.notify.tpl');
-	$tVars = array(
-		'title'    => $frow['title'],
-		'ptpl_url' => $ptpl_url,
-		'entries'  => $notifyMessage,
-		'usermail' => array(
-			'count' => count($eSendList),
-			'list'  => $eSendList,
-		),
-	);
-	$template['vars']['mainblock'] = $xt->render($tVars);
+            return;
+        }
+    }
+    $notifyMessage = ($isSentViaPlugin && $tResult['notify.msg']) ? $tResult['notify.msg'] : str_replace('{ecount}', $mailCount, $lang['feedback:confirm.message']);
+    // Prepare user's notification
+    $xt = $twig->loadTemplate($tpath['site.notify'].'site.notify.tpl');
+    $tVars = [
+        'title'    => $frow['title'],
+        'ptpl_url' => $ptpl_url,
+        'entries'  => $notifyMessage,
+        'usermail' => [
+            'count' => count($eSendList),
+            'list'  => $eSendList,
+        ],
+    ];
+    $template['vars']['mainblock'] = $xt->render($tVars);
 }

--- a/feedback/install.php
+++ b/feedback/install.php
@@ -1,6 +1,9 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
@@ -11,46 +14,47 @@ if (!defined('NGCMS')) die ('HAL');
 //	apply		- apply installation, with handy confirmation
 //	autoapply       - apply installation in automatic mode [INSTALL script]
 //
-function plugin_feedback_install($action) {
+function plugin_feedback_install($action)
+{
+    global $lang;
+    if ($action != 'autoapply') {
+        loadPluginLang('feedback', 'config', '', '', ':');
+    }
+    // Fill DB_UPDATE configuration scheme
+    $db_update = [
+        [
+            'table'  => 'feedback',
+            'action' => 'cmodify',
+            'key'    => 'primary key(id)',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'],
+                ['action' => 'cmodify', 'name' => 'active', 'type' => 'int', 'params' => 'default 0'],
+                ['action' => 'cmodify', 'name' => 'regonly', 'type' => 'int', 'params' => 'default 0'],
+                ['action' => 'cmodify', 'name' => 'flags', 'type' => 'char(20)'],
+                ['action' => 'cmodify', 'name' => 'name', 'type' => 'char(40)'],
+                ['action' => 'cmodify', 'name' => 'title', 'type' => 'char(80)'],
+                ['action' => 'cmodify', 'name' => 'subj', 'type' => 'char(100)'],
+                ['action' => 'cmodify', 'name' => 'description', 'type' => 'text'],
+                ['action' => 'cmodify', 'name' => 'struct', 'type' => 'text'],
+                ['action' => 'cmodify', 'name' => 'template', 'type' => 'char(50)'],
+                ['action' => 'cmodify', 'name' => 'emails', 'type' => 'text'],
+            ],
+        ],
+    ];
+    // Apply requested action
+    switch ($action) {
+        case 'confirm':
+            generate_install_page('feedback', $lang['feedback:text.install']);
+            break;
+        case 'autoapply':
+        case 'apply':
+            if (fixdb_plugin_install('feedback', $db_update, 'install', ($action == 'autoapply') ? true : false)) {
+                plugin_mark_installed('feedback');
+            } else {
+                return false;
+            }
+            break;
+    }
 
-	global $lang;
-	if ($action != 'autoapply')
-		loadPluginLang('feedback', 'config', '', '', ':');
-	// Fill DB_UPDATE configuration scheme
-	$db_update = array(
-		array(
-			'table'  => 'feedback',
-			'action' => 'cmodify',
-			'key'    => 'primary key(id)',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'),
-				array('action' => 'cmodify', 'name' => 'active', 'type' => 'int', 'params' => 'default 0'),
-				array('action' => 'cmodify', 'name' => 'regonly', 'type' => 'int', 'params' => 'default 0'),
-				array('action' => 'cmodify', 'name' => 'flags', 'type' => 'char(20)'),
-				array('action' => 'cmodify', 'name' => 'name', 'type' => 'char(40)'),
-				array('action' => 'cmodify', 'name' => 'title', 'type' => 'char(80)'),
-				array('action' => 'cmodify', 'name' => 'subj', 'type' => 'char(100)'),
-				array('action' => 'cmodify', 'name' => 'description', 'type' => 'text'),
-				array('action' => 'cmodify', 'name' => 'struct', 'type' => 'text'),
-				array('action' => 'cmodify', 'name' => 'template', 'type' => 'char(50)'),
-				array('action' => 'cmodify', 'name' => 'emails', 'type' => 'text'),
-			)
-		),
-	);
-	// Apply requested action
-	switch ($action) {
-		case 'confirm':
-			generate_install_page('feedback', $lang['feedback:text.install']);
-			break;
-		case 'autoapply':
-		case 'apply':
-			if (fixdb_plugin_install('feedback', $db_update, 'install', ($action == 'autoapply') ? true : false)) {
-				plugin_mark_installed('feedback');
-			} else {
-				return false;
-			}
-			break;
-	}
-
-	return true;
+    return true;
 }

--- a/feedback/lib/common.php
+++ b/feedback/lib/common.php
@@ -1,111 +1,119 @@
 <?php
+
 //
 // Class for managing feedback forms
-class FeedbackFilter {
+class FeedbackFilter
+{
+    // Action executed when form is showed
+    public function onShow($formID, $formStruct, $formData, &$tvars)
+    {
+    }
 
-	// Action executed when form is showed
-	function onShow($formID, $formStruct, $formData, &$tvars) {
-	}
+    // Action executed when form is posted
+    public function onProcess($formID, $formStruct, $formData, $flagHTML, &$tVars)
+    {
+    }
 
-	// Action executed when form is posted
-	function onProcess($formID, $formStruct, $formData, $flagHTML, &$tVars) {
-	}
+    // EXTENDED: Action executed when form is posted, should return TRUE to continue processing
+    public function onProcessEx($formID, $formStruct, $formData, $flagHTML, &$tVars, &$tResult)
+    {
+        return true;
+    }
 
-	// EXTENDED: Action executed when form is posted, should return TRUE to continue processing
-	function onProcessEx($formID, $formStruct, $formData, $flagHTML, &$tVars, &$tResult) {
+    // EXTENDED: Send processor
+    public function onSendEx($formID, $formStruct, $formData, $msgData, $tVars, &$tResult)
+    {
+        return false;
+    }
 
-		return true;
-	}
-
-	// EXTENDED: Send processor
-	function onSendEx($formID, $formStruct, $formData, $msgData, $tVars, &$tResult) {
-
-		return false;
-	}
-
-	// Action executed when post request is completed
-	function onProcessNotify($formID) {
-	}
+    // Action executed when post request is completed
+    public function onProcessNotify($formID)
+    {
+    }
 }
 
 // Find list of available templates
-function feedback_listTemplates() {
+function feedback_listTemplates()
+{
 
-	// Scan available directories
-	$dScan = array(
-		tpl_site . '/plugins/feedback/custom' => ':',
-		extras_dir . '/feedback/tpl/custom'   => '',
-	);
-	$dList = array();
-	// Check if there are custom templates in site template
-	foreach ($dScan as $dPath => $dPrefix) {
-		if (is_dir($dPath) && ($dh = opendir($dPath))) {
-			while (($fn = readdir($dh)) !== false) {
-				if (in_array($fn, array('.', '..')))
-					continue;
-				if (is_dir($dPath . '/' . $fn))
-					$dList [] = $dPrefix . $fn;
-			}
-		}
-	}
+    // Scan available directories
+    $dScan = [
+        tpl_site.'/plugins/feedback/custom' => ':',
+        extras_dir.'/feedback/tpl/custom'   => '',
+    ];
+    $dList = [];
+    // Check if there are custom templates in site template
+    foreach ($dScan as $dPath => $dPrefix) {
+        if (is_dir($dPath) && ($dh = opendir($dPath))) {
+            while (($fn = readdir($dh)) !== false) {
+                if (in_array($fn, ['.', '..'])) {
+                    continue;
+                }
+                if (is_dir($dPath.'/'.$fn)) {
+                    $dList[] = $dPrefix.$fn;
+                }
+            }
+        }
+    }
 
-	return $dList;
+    return $dList;
 }
 
 // Find location of template files for specific template
-function feedback_locateTemplateFiles($tName, bool $flagHTML = false) {
+function feedback_locateTemplateFiles($tName, bool $flagHTML = false)
+{
 
-	// Determine template names/path, that will be used during form generation
-	$tpath = locatePluginTemplates(array('site.form', 'site.notify', 'mail.html', 'mail.text'), 'feedback', pluginGetVariable('feedback', 'localsource'));
-	// Default
-	$tpDisplayPath = $tpath['site.form'];
-	$tpDisplay = $tpDisplayPath . 'site.form.tpl';
-	$tpDisplayFound = 0;
-	$tpMailPath = $tpath['mail.' . ($flagHTML ? 'html' : 'text')];
-	$tpMail = $tpMailPath . 'mail.' . ($flagHTML ? 'html' : 'text') . '.tpl';
-	$tpMailFound = 0;
-	if ($tName) {
-		// --- Site template
-		if ((substr($tName, 0, 1) == ':')) {
-			// -- Display template
-			if (file_exists(tpl_site . 'plugins/feedback/custom/' . substr($tName, 1) . '/site.form.tpl')) {
-				$tpDisplayPath = tpl_site . 'plugins/feedback/custom/' . substr($tName, 1) . '/';
-				$tpDisplay = $tpDisplayPath . 'site.form.tpl';
-				$tpDisplayFound = 1;
-			}
-			// -- Mail template
-			if (file_exists(tpl_site . 'plugins/feedback/custom/' . substr($tName, 1) . '/mail.' . ($flagHTML ? 'html' : 'text') . '.tpl')) {
-				$tpMailPath = tpl_site . 'plugins/feedback/custom/' . substr($tName, 1) . '/';
-				$tpMail = $tpMailPath . 'mail.' . ($flagHTML ? 'html' : 'text') . '.tpl';
-				$tpMailFound = 1;
-			}
-		} else {
-			// --- Plugin template
-			// -- Display template
-			if (file_exists(root . 'plugins/feedback/tpl/custom/' . $tName . '/site.form.tpl')) {
-				$tpDisplayPath = root . 'plugins/feedback/tpl/custom/' . $tName . '/';
-				$tpDisplay = $tpDisplayPath . 'site.form.tpl';
-				$tpDisplayFound = 1;
-			}
-			// -- Mail template
-			if (file_exists(root . 'plugins/feedback/tpl/custom/' . $tName . '/mail.' . ($flagHTML ? 'html' : 'text') . '.tpl')) {
-				$tpMailPath = root . 'plugins/feedback/tpl/custom/' . $tName . '/';
-				$tpMail = $tpMailPath . 'mail.' . ($flagHTML ? 'html' : 'text') . '.tpl';
-				$tpMailFound = 1;
-			}
-		}
-	}
+    // Determine template names/path, that will be used during form generation
+    $tpath = locatePluginTemplates(['site.form', 'site.notify', 'mail.html', 'mail.text'], 'feedback', pluginGetVariable('feedback', 'localsource'));
+    // Default
+    $tpDisplayPath = $tpath['site.form'];
+    $tpDisplay = $tpDisplayPath.'site.form.tpl';
+    $tpDisplayFound = 0;
+    $tpMailPath = $tpath['mail.'.($flagHTML ? 'html' : 'text')];
+    $tpMail = $tpMailPath.'mail.'.($flagHTML ? 'html' : 'text').'.tpl';
+    $tpMailFound = 0;
+    if ($tName) {
+        // --- Site template
+        if ((substr($tName, 0, 1) == ':')) {
+            // -- Display template
+            if (file_exists(tpl_site.'plugins/feedback/custom/'.substr($tName, 1).'/site.form.tpl')) {
+                $tpDisplayPath = tpl_site.'plugins/feedback/custom/'.substr($tName, 1).'/';
+                $tpDisplay = $tpDisplayPath.'site.form.tpl';
+                $tpDisplayFound = 1;
+            }
+            // -- Mail template
+            if (file_exists(tpl_site.'plugins/feedback/custom/'.substr($tName, 1).'/mail.'.($flagHTML ? 'html' : 'text').'.tpl')) {
+                $tpMailPath = tpl_site.'plugins/feedback/custom/'.substr($tName, 1).'/';
+                $tpMail = $tpMailPath.'mail.'.($flagHTML ? 'html' : 'text').'.tpl';
+                $tpMailFound = 1;
+            }
+        } else {
+            // --- Plugin template
+            // -- Display template
+            if (file_exists(root.'plugins/feedback/tpl/custom/'.$tName.'/site.form.tpl')) {
+                $tpDisplayPath = root.'plugins/feedback/tpl/custom/'.$tName.'/';
+                $tpDisplay = $tpDisplayPath.'site.form.tpl';
+                $tpDisplayFound = 1;
+            }
+            // -- Mail template
+            if (file_exists(root.'plugins/feedback/tpl/custom/'.$tName.'/mail.'.($flagHTML ? 'html' : 'text').'.tpl')) {
+                $tpMailPath = root.'plugins/feedback/tpl/custom/'.$tName.'/';
+                $tpMail = $tpMailPath.'mail.'.($flagHTML ? 'html' : 'text').'.tpl';
+                $tpMailFound = 1;
+            }
+        }
+    }
 
-	return array(
-		'site' => array(
-			'path'    => $tpDisplayPath,
-			'file'    => $tpDisplay,
-			'isFound' => $tpDisplayFound,
-		),
-		'mail' => array(
-			'path'    => $tpMailPath,
-			'file'    => $tpMail,
-			'isFound' => $tpMailFound,
-		),
-	);
+    return [
+        'site' => [
+            'path'    => $tpDisplayPath,
+            'file'    => $tpDisplay,
+            'isFound' => $tpDisplayFound,
+        ],
+        'mail' => [
+            'path'    => $tpMailPath,
+            'file'    => $tpMail,
+            'isFound' => $tpMailFound,
+        ],
+    ];
 }

--- a/feedback/uninstall.php
+++ b/feedback/uninstall.php
@@ -1,22 +1,24 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
 plugins_load_config();
 loadPluginLang('feedback', 'config', '', '', ':');
-$db_update = array(
-	array(
-		'table'  => 'feedback',
-		'action' => 'drop',
-	),
-);
+$db_update = [
+    [
+        'table'  => 'feedback',
+        'action' => 'drop',
+    ],
+];
 if ($_REQUEST['action'] == 'commit') {
-	if (fixdb_plugin_install($plugin, $db_update, 'deinstall')) {
-		plugin_mark_deinstalled($plugin);
-	}
+    if (fixdb_plugin_install($plugin, $db_update, 'deinstall')) {
+        plugin_mark_deinstalled($plugin);
+    }
 } else {
-	generate_install_page($plugin, $lang['feedback:text.deinstall'], 'deinstall');
+    generate_install_page($plugin, $lang['feedback:text.deinstall'], 'deinstall');
 }
-?>

--- a/gsmg/config.php
+++ b/gsmg/config.php
@@ -1,44 +1,46 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
 // Preload config file
 plugins_load_config();
 // Fill configuration parameters
-$cfg = array();
-$cfgX = array();
-array_push($cfg, array('descr' => 'Плагин генерации XML карты сайта для поисковой системы Google'));
-array_push($cfgX, array('name' => 'main', 'title' => "Добавлять головную страницу в карту сайта", 'descr' => "<b>Да</b> - страница будет добавляться в карту сайта<br /><b>Нет</b> - страница не будет добавляться в карту сайта", 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(extra_get_param($plugin, 'main'))));
-array_push($cfgX, array('name' => 'main_pr', 'title' => "Приоритет головной страницы", 'descr' => 'значение от <b>0.0</b> до <b>1.0</b>', 'type' => 'input', 'value' => (extra_get_param($plugin, 'main_pr') == '') ? '1.0' : extra_get_param($plugin, 'main_pr')));
-array_push($cfgX, array('name' => 'mainp', 'title' => "Добавлять постраничку головной страницы в карту сайта", 'descr' => "<b>Да</b> - страница будет добавляться в карту сайта<br /><b>Нет</b> - страница не будет добавляться в карту сайта", 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(extra_get_param($plugin, 'mainp'))));
-array_push($cfgX, array('name' => 'mainp_pr', 'title' => "Приоритет постранички головной страницы", 'descr' => 'значение от <b>0.0</b> до <b>1.0</b>', 'type' => 'input', 'value' => (extra_get_param($plugin, 'mainp_pr') == '') ? '0.5' : extra_get_param($plugin, 'mainp_pr')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки для головной страницы сайта</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'cat', 'title' => "Добавлять страницы категорий в карту сайта", 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(extra_get_param($plugin, 'cat'))));
-array_push($cfgX, array('name' => 'cat_pr', 'title' => "Приоритет страниц категорий", 'type' => 'input', 'value' => (extra_get_param($plugin, 'cat_pr') == '') ? '0.5' : extra_get_param($plugin, 'cat_pr')));
-array_push($cfgX, array('name' => 'catp', 'title' => "Добавлять постраничку страниц категорий в карту сайта", 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(extra_get_param($plugin, 'catp'))));
-array_push($cfgX, array('name' => 'catp_pr', 'title' => "Приоритет постранички категорий", 'type' => 'input', 'value' => (extra_get_param($plugin, 'catp_pr') == '') ? '0.5' : extra_get_param($plugin, 'catp_pr')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки для страниц категорий</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'news', 'title' => "Добавлять страницы новостей в карту сайта", 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(extra_get_param($plugin, 'news'))));
-array_push($cfgX, array('name' => 'news_pr', 'title' => "Приоритет страниц новостей", 'type' => 'input', 'value' => (extra_get_param($plugin, 'news_pr') == '') ? '0.3' : extra_get_param($plugin, 'news_pr')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки для страниц новостей</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'static', 'title' => "Добавлять статические страницы в карту сайта", 'type' => 'select', 'values' => array('0' => 'Нет', '1' => 'Да'), 'value' => intval(extra_get_param($plugin, 'static'))));
-array_push($cfgX, array('name' => 'static_pr', 'title' => "Приоритет статических страниц", 'type' => 'input', 'value' => (extra_get_param($plugin, 'static_pr') == '') ? '0.3' : extra_get_param($plugin, 'static_pr')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки для статических страниц</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'cache', 'title' => "Использовать кеширование карты сайта<br /><small><b>Да</b> - кеширование используется<br /><b>Нет</b> - кеширование не используется</small>", 'type' => 'select', 'values' => array('1' => 'Да', '0' => 'Нет'), 'value' => intval(extra_get_param($plugin, 'cache'))));
-array_push($cfgX, array('name' => 'cacheExpire', 'title' => 'Период обновления кеша (в секундах)<br /><small>(через сколько секунд происходит обновление кеша. Значение по умолчанию: <b>10800</b>, т.е. 3 часа)', 'type' => 'input', 'value' => intval(extra_get_param($plugin, 'cacheExpire')) ? extra_get_param($plugin, 'cacheExpire') : '10800'));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки кеширования</b>', 'entries' => $cfgX));
-// RUN 
+$cfg = [];
+$cfgX = [];
+array_push($cfg, ['descr' => 'Плагин генерации XML карты сайта для поисковой системы Google']);
+array_push($cfgX, ['name' => 'main', 'title' => 'Добавлять головную страницу в карту сайта', 'descr' => '<b>Да</b> - страница будет добавляться в карту сайта<br /><b>Нет</b> - страница не будет добавляться в карту сайта', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(extra_get_param($plugin, 'main'))]);
+array_push($cfgX, ['name' => 'main_pr', 'title' => 'Приоритет головной страницы', 'descr' => 'значение от <b>0.0</b> до <b>1.0</b>', 'type' => 'input', 'value' => (extra_get_param($plugin, 'main_pr') == '') ? '1.0' : extra_get_param($plugin, 'main_pr')]);
+array_push($cfgX, ['name' => 'mainp', 'title' => 'Добавлять постраничку головной страницы в карту сайта', 'descr' => '<b>Да</b> - страница будет добавляться в карту сайта<br /><b>Нет</b> - страница не будет добавляться в карту сайта', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(extra_get_param($plugin, 'mainp'))]);
+array_push($cfgX, ['name' => 'mainp_pr', 'title' => 'Приоритет постранички головной страницы', 'descr' => 'значение от <b>0.0</b> до <b>1.0</b>', 'type' => 'input', 'value' => (extra_get_param($plugin, 'mainp_pr') == '') ? '0.5' : extra_get_param($plugin, 'mainp_pr')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки для головной страницы сайта</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'cat', 'title' => 'Добавлять страницы категорий в карту сайта', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(extra_get_param($plugin, 'cat'))]);
+array_push($cfgX, ['name' => 'cat_pr', 'title' => 'Приоритет страниц категорий', 'type' => 'input', 'value' => (extra_get_param($plugin, 'cat_pr') == '') ? '0.5' : extra_get_param($plugin, 'cat_pr')]);
+array_push($cfgX, ['name' => 'catp', 'title' => 'Добавлять постраничку страниц категорий в карту сайта', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(extra_get_param($plugin, 'catp'))]);
+array_push($cfgX, ['name' => 'catp_pr', 'title' => 'Приоритет постранички категорий', 'type' => 'input', 'value' => (extra_get_param($plugin, 'catp_pr') == '') ? '0.5' : extra_get_param($plugin, 'catp_pr')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки для страниц категорий</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'news', 'title' => 'Добавлять страницы новостей в карту сайта', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(extra_get_param($plugin, 'news'))]);
+array_push($cfgX, ['name' => 'news_pr', 'title' => 'Приоритет страниц новостей', 'type' => 'input', 'value' => (extra_get_param($plugin, 'news_pr') == '') ? '0.3' : extra_get_param($plugin, 'news_pr')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки для страниц новостей</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'static', 'title' => 'Добавлять статические страницы в карту сайта', 'type' => 'select', 'values' => ['0' => 'Нет', '1' => 'Да'], 'value' => intval(extra_get_param($plugin, 'static'))]);
+array_push($cfgX, ['name' => 'static_pr', 'title' => 'Приоритет статических страниц', 'type' => 'input', 'value' => (extra_get_param($plugin, 'static_pr') == '') ? '0.3' : extra_get_param($plugin, 'static_pr')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки для статических страниц</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'cache', 'title' => 'Использовать кеширование карты сайта<br /><small><b>Да</b> - кеширование используется<br /><b>Нет</b> - кеширование не используется</small>', 'type' => 'select', 'values' => ['1' => 'Да', '0' => 'Нет'], 'value' => intval(extra_get_param($plugin, 'cache'))]);
+array_push($cfgX, ['name' => 'cacheExpire', 'title' => 'Период обновления кеша (в секундах)<br /><small>(через сколько секунд происходит обновление кеша. Значение по умолчанию: <b>10800</b>, т.е. 3 часа)', 'type' => 'input', 'value' => intval(extra_get_param($plugin, 'cacheExpire')) ? extra_get_param($plugin, 'cacheExpire') : '10800']);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки кеширования</b>', 'entries' => $cfgX]);
+// RUN
 if ($_REQUEST['action'] == 'commit') {
-	// If submit requested, do config save
-	commit_plugin_config_changes($plugin, $cfg);
-	print_commit_complete($plugin);
+    // If submit requested, do config save
+    commit_plugin_config_changes($plugin, $cfg);
+    print_commit_complete($plugin);
 } else {
-	generate_config_page($plugin, $cfg);
+    generate_config_page($plugin, $cfg);
 }
-?>

--- a/gsmg/gsmg.php
+++ b/gsmg/gsmg.php
@@ -1,109 +1,114 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 register_plugin_page('gsmg', '', 'plugin_gsmg_screen', 0);
 // Load library
-include_once(root . "/plugins/gsmg/lib/common.php");
-function plugin_gsmg_screen() {
+include_once root.'/plugins/gsmg/lib/common.php';
+function plugin_gsmg_screen()
+{
+    global $config, $mysql, $catz, $catmap, $SUPRESS_TEMPLATE_SHOW, $SYSTEM_FLAGS, $PFILTERS;
+    $SUPRESS_TEMPLATE_SHOW = 1;
+    $SUPRESS_MAINBLOCK_SHOW = 1;
+    @header('Content-type: text/xml; charset=utf-8');
+    $SYSTEM_FLAGS['http.headers'] = [
+        'content-type'  => 'application/xml; charset=utf-8',
+        'cache-control' => 'private',
+    ];
+    if (extra_get_param('gsmg', 'cache')) {
+        $cacheData = cacheRetrieveFile('gsmg.txt', extra_get_param('gsmg', 'cacheExpire'), 'gsmg');
+        if ($cacheData != false) {
+            // We got data from cache. Return it and stop
+            echo $cacheData;
 
-	global $config, $mysql, $catz, $catmap, $SUPRESS_TEMPLATE_SHOW, $SYSTEM_FLAGS, $PFILTERS;
-	$SUPRESS_TEMPLATE_SHOW = 1;
-	$SUPRESS_MAINBLOCK_SHOW = 1;
-	@header('Content-type: text/xml; charset=utf-8');
-	$SYSTEM_FLAGS['http.headers'] = array(
-		'content-type'  => 'application/xml; charset=utf-8',
-		'cache-control' => 'private',
-	);
-	if (extra_get_param('gsmg', 'cache')) {
-		$cacheData = cacheRetrieveFile('gsmg.txt', extra_get_param('gsmg', 'cacheExpire'), 'gsmg');
-		if ($cacheData != false) {
-			// We got data from cache. Return it and stop
-			print $cacheData;
-
-			return;
-		}
-	}
-	$output = '<?xml version="1.0" encoding="UTF-8"?>';
-	$output .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
-	// Настройки постранички
-	if ($config['number'] < 1)
-		$config['number'] = 5;
-	// Надо ли выводить данные с головной страницы
-	if (extra_get_param('gsmg', 'main')) {
-		$output .= "<url>";
-		$output .= "<loc>" . generateLink('news', 'main', array(), array(), false, true) . "</loc>";
-		$output .= "<priority>" . floatval(extra_get_param('gsmg', 'main_pr')) . "</priority>";
-		$lm = $mysql->record("select date(from_unixtime(max(postdate))) as pd from " . prefix . "_news");
-		$output .= "<lastmod>" . $lm['pd'] . "</lastmod>";
-		$output .= "<changefreq>daily</changefreq>";
-		$output .= "</url>";
-		if (extra_get_param('gsmg', 'mainp')) {
-			$cnt = $mysql->record("select count(*) as cnt from " . prefix . "_news");
-			$pages = ceil($cnt['cnt'] / $config['number']);
-			for ($i = 2; $i <= $pages; $i++) {
-				$output .= "<url>";
-				$output .= "<loc>" . generateLink('news', 'main', array('page' => $i), array(), false, true) . "</loc>";
-				$output .= "<priority>" . floatval(extra_get_param('gsmg', 'mainp_pr')) . "</priority>";
-				$output .= "<lastmod>" . $lm['pd'] . "</lastmod>";
-				$output .= "<changefreq>daily</changefreq>";
-				$output .= "</url>";
-			}
-		}
-	}
-	// Надо ли выводить данные по категориям
-	if (extra_get_param('gsmg', 'cat')) {
-		foreach ($catmap as $id => $altname) {
-			$output .= "<url>";
-			$output .= "<loc>" . generateLink('news', 'by.category', array('category' => $altname, 'catid' => $id), array(), false, true) . "</loc>";
-			$output .= "<priority>" . floatval(extra_get_param('gsmg', 'cat_pr')) . "</priority>";
-			$output .= "<lastmod>" . $lm['pd'] . "</lastmod>";
-			$output .= "<changefreq>daily</changefreq>";
-			$output .= "</url>";
-			if (extra_get_param('gsmg', 'catp')) {
-				$cn = ($catz[$altname]['number'] > 0) ? $catz[$altname]['number'] : $config['number'];
-				$pages = ceil($catz[$altname]['posts'] / $cn);
-				for ($i = 2; $i <= $pages; $i++) {
-					$output .= "<url>";
-					$output .= "<loc>" . generateLink('news', 'by.category', array('category' => $altname, 'catid' => $id, 'page' => $i), array(), false, true) . "</loc>";
-					$output .= "<priority>" . floatval(extra_get_param('gsmg', 'catp_pr')) . "</priority>";
-					$output .= "<lastmod>" . $lm['pd'] . "</lastmod>";
-					$output .= "<changefreq>daily</changefreq>";
-					$output .= "</url>";
-				}
-			}
-		}
-	}
-	// Надо ли выводить данные по новостям
-	if (extra_get_param('gsmg', 'news')) {
-		$query = "select id, postdate, author, author_id, alt_name, editdate, catid from " . prefix . "_news where approve = 1 order by id desc";
-		foreach ($mysql->select($query, 1) as $rec) {
-			$link = newsGenerateLink($rec, false, 0, true);
-			$output .= "<url>";
-			$output .= "<loc>" . $link . "</loc>";
-			$output .= "<priority>" . floatval(extra_get_param('gsmg', 'news_pr')) . "</priority>";
-			$output .= "<lastmod>" . strftime("%Y-%m-%d", max($rec['editdate'], $rec['postdate'])) . "</lastmod>";
-			$output .= "<changefreq>daily</changefreq>";
-			$output .= "</url>";
-		}
-	}
-	// Надо ли выводить данные по статическим страницам
-	if (extra_get_param('gsmg', 'static')) {
-		$query = "select id, alt_name from " . prefix . "_static where approve = 1";
-		foreach ($mysql->select($query, 1) as $rec) {
-			$link = generatePluginLink('static', '', array('altname' => $rec['alt_name'], 'id' => $rec['id']), array(), false, true);
-			$output .= "<url>";
-			$output .= "<loc>" . $link . "</loc>";
-			$output .= "<priority>" . floatval(extra_get_param('gsmg', 'static_pr')) . "</priority>";
-			$output .= "<lastmod>" . $lm['pd'] . "</lastmod>";
-			$output .= "<changefreq>weekly</changefreq>";
-			$output .= "</url>";
-		}
-	}
-	if (is_array($PFILTERS['gsmg']))
-		foreach ($PFILTERS['gsmg'] as $k => $v) {
-			$v->onShow($output);
-		}
-	$output .= "</urlset>";
-	print $output;
-	cacheStoreFile('gsmg.txt', $output, 'gsmg');
+            return;
+        }
+    }
+    $output = '<?xml version="1.0" encoding="UTF-8"?>';
+    $output .= '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">';
+    // Настройки постранички
+    if ($config['number'] < 1) {
+        $config['number'] = 5;
+    }
+    // Надо ли выводить данные с головной страницы
+    if (extra_get_param('gsmg', 'main')) {
+        $output .= '<url>';
+        $output .= '<loc>'.generateLink('news', 'main', [], [], false, true).'</loc>';
+        $output .= '<priority>'.floatval(extra_get_param('gsmg', 'main_pr')).'</priority>';
+        $lm = $mysql->record('select date(from_unixtime(max(postdate))) as pd from '.prefix.'_news');
+        $output .= '<lastmod>'.$lm['pd'].'</lastmod>';
+        $output .= '<changefreq>daily</changefreq>';
+        $output .= '</url>';
+        if (extra_get_param('gsmg', 'mainp')) {
+            $cnt = $mysql->record('select count(*) as cnt from '.prefix.'_news');
+            $pages = ceil($cnt['cnt'] / $config['number']);
+            for ($i = 2; $i <= $pages; $i++) {
+                $output .= '<url>';
+                $output .= '<loc>'.generateLink('news', 'main', ['page' => $i], [], false, true).'</loc>';
+                $output .= '<priority>'.floatval(extra_get_param('gsmg', 'mainp_pr')).'</priority>';
+                $output .= '<lastmod>'.$lm['pd'].'</lastmod>';
+                $output .= '<changefreq>daily</changefreq>';
+                $output .= '</url>';
+            }
+        }
+    }
+    // Надо ли выводить данные по категориям
+    if (extra_get_param('gsmg', 'cat')) {
+        foreach ($catmap as $id => $altname) {
+            $output .= '<url>';
+            $output .= '<loc>'.generateLink('news', 'by.category', ['category' => $altname, 'catid' => $id], [], false, true).'</loc>';
+            $output .= '<priority>'.floatval(extra_get_param('gsmg', 'cat_pr')).'</priority>';
+            $output .= '<lastmod>'.$lm['pd'].'</lastmod>';
+            $output .= '<changefreq>daily</changefreq>';
+            $output .= '</url>';
+            if (extra_get_param('gsmg', 'catp')) {
+                $cn = ($catz[$altname]['number'] > 0) ? $catz[$altname]['number'] : $config['number'];
+                $pages = ceil($catz[$altname]['posts'] / $cn);
+                for ($i = 2; $i <= $pages; $i++) {
+                    $output .= '<url>';
+                    $output .= '<loc>'.generateLink('news', 'by.category', ['category' => $altname, 'catid' => $id, 'page' => $i], [], false, true).'</loc>';
+                    $output .= '<priority>'.floatval(extra_get_param('gsmg', 'catp_pr')).'</priority>';
+                    $output .= '<lastmod>'.$lm['pd'].'</lastmod>';
+                    $output .= '<changefreq>daily</changefreq>';
+                    $output .= '</url>';
+                }
+            }
+        }
+    }
+    // Надо ли выводить данные по новостям
+    if (extra_get_param('gsmg', 'news')) {
+        $query = 'select id, postdate, author, author_id, alt_name, editdate, catid from '.prefix.'_news where approve = 1 order by id desc';
+        foreach ($mysql->select($query, 1) as $rec) {
+            $link = newsGenerateLink($rec, false, 0, true);
+            $output .= '<url>';
+            $output .= '<loc>'.$link.'</loc>';
+            $output .= '<priority>'.floatval(extra_get_param('gsmg', 'news_pr')).'</priority>';
+            $output .= '<lastmod>'.strftime('%Y-%m-%d', max($rec['editdate'], $rec['postdate'])).'</lastmod>';
+            $output .= '<changefreq>daily</changefreq>';
+            $output .= '</url>';
+        }
+    }
+    // Надо ли выводить данные по статическим страницам
+    if (extra_get_param('gsmg', 'static')) {
+        $query = 'select id, alt_name from '.prefix.'_static where approve = 1';
+        foreach ($mysql->select($query, 1) as $rec) {
+            $link = generatePluginLink('static', '', ['altname' => $rec['alt_name'], 'id' => $rec['id']], [], false, true);
+            $output .= '<url>';
+            $output .= '<loc>'.$link.'</loc>';
+            $output .= '<priority>'.floatval(extra_get_param('gsmg', 'static_pr')).'</priority>';
+            $output .= '<lastmod>'.$lm['pd'].'</lastmod>';
+            $output .= '<changefreq>weekly</changefreq>';
+            $output .= '</url>';
+        }
+    }
+    if (is_array($PFILTERS['gsmg'])) {
+        foreach ($PFILTERS['gsmg'] as $k => $v) {
+            $v->onShow($output);
+        }
+    }
+    $output .= '</urlset>';
+    echo $output;
+    cacheStoreFile('gsmg.txt', $output, 'gsmg');
 }

--- a/gsmg/install.php
+++ b/gsmg/install.php
@@ -1,9 +1,12 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 plugins_load_config();
 // Load library
-include_once(root . "/plugins/gsmg/lib/common.php");
+include_once root.'/plugins/gsmg/lib/common.php';
 //
 // Configuration file for plugin
 //
@@ -14,22 +17,23 @@ include_once(root . "/plugins/gsmg/lib/common.php");
 //  apply       - apply installation, with handy confirmation
 //  autoapply       - apply installation in automatic mode [INSTALL script]
 //
-function plugin_gsmg_install($action) {
+function plugin_gsmg_install($action)
+{
 
-	// Apply requested action
-	switch ($action) {
-		case 'confirm':
-			generate_install_page('gsmg', '');
-			break;
-		case 'autoapply':
-		case 'apply':
-			create_gsmg_urls();
-			plugin_mark_installed('gsmg');
-			$url = home . "/engine/admin.php?mod=extras";
-			header("HTTP/1.1 301 Moved Permanently");
-			header("Location: {$url}");
-			break;
-	}
+    // Apply requested action
+    switch ($action) {
+        case 'confirm':
+            generate_install_page('gsmg', '');
+            break;
+        case 'autoapply':
+        case 'apply':
+            create_gsmg_urls();
+            plugin_mark_installed('gsmg');
+            $url = home.'/engine/admin.php?mod=extras';
+            header('HTTP/1.1 301 Moved Permanently');
+            header("Location: {$url}");
+            break;
+    }
 
-	return true;
+    return true;
 }

--- a/gsmg/lib/common.php
+++ b/gsmg/lib/common.php
@@ -1,65 +1,65 @@
 <?php
+
 //
 // Class for managing gsmg
-class gsmgFilter {
-
-	// Action executed when page is showed
-	function onShow(&$output) {
-	}
+class gsmgFilter
+{
+    // Action executed when page is showed
+    public function onShow(&$output)
+    {
+    }
 }
 
-function create_gsmg_urls() {
-
-	$ULIB = new urlLibrary();
-	$ULIB->loadConfig();
-	$ULIB->registerCommand('gsmg', '',
-		array(
-			'vars'  => array(),
-			'descr' => array('russian' => 'Лента gsmg'),
-		)
-	);
-	$ULIB->saveConfig();
-	$UHANDLER = new urlHandler();
-	$UHANDLER->loadConfig();
-	$UHANDLER->registerHandler(0,
-		array(
-			'pluginName'       => 'gsmg',
-			'handlerName'      => '',
-			'flagPrimary'      => true,
-			'flagFailContinue' => false,
-			'flagDisabled'     => false,
-			'rstyle'           => array(
-				'rcmd'     => '/gsmg.xml',
-				'regex'    => '#^/gsmg.xml$#',
-				'regexMap' =>
-					array(),
-				'reqCheck' =>
-					array(),
-				'setVars'  =>
-					array(),
-				'genrMAP'  =>
-					array(
-						0 =>
-							array(
-								0 => 0,
-								1 => '/gsmg.xml',
-								2 => 0,
-							),
-					),
-			),
-		)
-	);
-	$UHANDLER->saveConfig();
+function create_gsmg_urls()
+{
+    $ULIB = new urlLibrary();
+    $ULIB->loadConfig();
+    $ULIB->registerCommand(
+        'gsmg',
+        '',
+        [
+            'vars'  => [],
+            'descr' => ['russian' => 'Лента gsmg'],
+        ]
+    );
+    $ULIB->saveConfig();
+    $UHANDLER = new urlHandler();
+    $UHANDLER->loadConfig();
+    $UHANDLER->registerHandler(
+        0,
+        [
+            'pluginName'       => 'gsmg',
+            'handlerName'      => '',
+            'flagPrimary'      => true,
+            'flagFailContinue' => false,
+            'flagDisabled'     => false,
+            'rstyle'           => [
+                'rcmd'     => '/gsmg.xml',
+                'regex'    => '#^/gsmg.xml$#',
+                'regexMap' => [],
+                'reqCheck' => [],
+                'setVars'  => [],
+                'genrMAP'  => [
+                    0 => [
+                        0 => 0,
+                        1 => '/gsmg.xml',
+                        2 => 0,
+                    ],
+                ],
+            ],
+        ]
+    );
+    $UHANDLER->saveConfig();
 }
 
-function remove_gsmg_urls() {
-
-	$ULIB = new urlLibrary();
-	$ULIB->loadConfig();
-	$ULIB->removeCommand('gsmg', '');
-	$ULIB->saveConfig();
-	$UHANDLER = new urlHandler();
-	$UHANDLER->loadConfig();
-	$UHANDLER->removePluginHandlers('gsmg', '');
-	$UHANDLER->saveConfig();
+function remove_gsmg_urls()
+{
+    $ULIB = new urlLibrary();
+    $ULIB->loadConfig();
+    $ULIB->removeCommand('gsmg', '');
+    $ULIB->saveConfig();
+    $UHANDLER = new urlHandler();
+    $UHANDLER->loadConfig();
+    $UHANDLER->removePluginHandlers('gsmg', '');
+    $UHANDLER->saveConfig();
 }

--- a/gsmg/lib/common.php
+++ b/gsmg/lib/common.php
@@ -19,7 +19,7 @@ function create_gsmg_urls()
         '',
         [
             'vars'  => [],
-            'descr' => ['russian' => 'Ëåíòà gsmg'],
+            'descr' => ['russian' => 'Ð›ÐµÐ½Ñ‚Ð° gsmg'],
         ]
     );
     $ULIB->saveConfig();

--- a/gsmg/uninstall.php
+++ b/gsmg/uninstall.php
@@ -1,18 +1,21 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 // Load library
-include_once(root . "/plugins/gsmg/lib/common.php");
+include_once root.'/plugins/gsmg/lib/common.php';
 //
 // Configuration file for plugin
 //
 plugins_load_config();
 if ($_REQUEST['action'] == 'commit') {
-	remove_gsmg_urls();
-	plugin_mark_deinstalled($plugin);
-	$url = home . "/engine/admin.php?mod=extras";
-	header("HTTP/1.1 301 Moved Permanently");
-	header("Location: {$url}");
+    remove_gsmg_urls();
+    plugin_mark_deinstalled($plugin);
+    $url = home.'/engine/admin.php?mod=extras';
+    header('HTTP/1.1 301 Moved Permanently');
+    header("Location: {$url}");
 } else {
-	generate_install_page($plugin, 'Удаление плагина', 'deinstall');
+    generate_install_page($plugin, 'Удаление плагина', 'deinstall');
 }

--- a/lastcomments/config.php
+++ b/lastcomments/config.php
@@ -1,41 +1,44 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
 // Preload config file
 plugins_load_config();
 // Fill configuration parameters
-$cfg = array();
-$cfgX = array();
-array_push($cfg, array('descr' => 'Плагин отображает последние комментарии, оставленные на новости сайта.'));
-array_push($cfgX, array('name' => 'sidepanel', 'title' => 'Включить генерацию боковой панели', 'descr' => '<b>Да</b> - панель будет генерироваться<br/><b>Нет</b> - панель не будет генерироваться', 'type' => 'select', 'values' => array('0' => $lang['noa'], '1' => $lang['yesa']), 'value' => pluginGetVariable('lastcomments', 'sidepanel')));
-array_push($cfgX, array('name' => 'number', 'title' => 'Количество выводимых комментариев', 'descr' => 'Значение по умолчанию: <b>10</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => pluginGetVariable('lastcomments', 'number')));
-array_push($cfgX, array('name' => 'comm_length', 'title' => 'Усечение длины комментария', 'descr' => 'Кол-во символов из комментария для отображения<br/>Значение по умолчанию: <b>50</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => pluginGetVariable('lastcomments', 'comm_length')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки боковой панели</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'ppage', 'title' => 'Разрешить собственную страницу плагина', 'descr' => '<b>Да</b> - собственная страница разрешена<br/><b>Нет</b> - собственная страница запрещена', 'type' => 'select', 'values' => array('0' => $lang['noa'], '1' => $lang['yesa']), 'value' => pluginGetVariable('lastcomments', 'ppage')));
-array_push($cfgX, array('name' => 'pp_number', 'title' => 'Количество выводимых комментариев', 'descr' => 'Значение по умолчанию: <b>30</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => pluginGetVariable('lastcomments', 'pp_number')));
-array_push($cfgX, array('name' => 'pp_comm_length', 'title' => 'Усечение длины комментария', 'descr' => 'Кол-во символов из комментария для отображения<br/>Значение по умолчанию: <b>500</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => pluginGetVariable('lastcomments', 'pp_comm_length')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки собственной страницы плагина</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'rssfeed', 'title' => 'Разрешить rss-ленту плагина', 'descr' => '<b>Да</b> - rss-лента разрешена<br/><b>Нет</b> - rss-лента запрещена', 'type' => 'select', 'values' => array('0' => $lang['noa'], '1' => $lang['yesa']), 'value' => pluginGetVariable('lastcomments', 'rssfeed')));
-array_push($cfgX, array('name' => 'rss_number', 'title' => 'Количество выводимых комментариев', 'descr' => 'Значение по умолчанию: <b>30</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => pluginGetVariable('lastcomments', 'rss_number')));
-array_push($cfgX, array('name' => 'rss_comm_length', 'title' => 'Усечение длины комментария', 'descr' => 'Кол-во символов из комментария для отображения<br/>Значение по умолчанию: <b>500</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => pluginGetVariable('lastcomments', 'rss_comm_length')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки собственной страницы плагина</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'localsource', 'title' => "Выберите каталог из которого плагин будет брать шаблоны для отображения<br /><small><b>Шаблон сайта</b> - плагин будет пытаться взять шаблоны из общего шаблона сайта; в случае недоступности - шаблоны будут взяты из собственного каталога плагина<br /><b>Плагин</b> - шаблоны будут браться из собственного каталога плагина</small>", 'type' => 'select', 'values' => array('0' => 'Шаблон сайта', '1' => 'Плагин'), 'value' => intval(pluginGetVariable($plugin, 'localsource'))));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки отображения</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'cache', 'title' => "Использовать кеширование данных<br /><small><b>Да</b> - кеширование используется<br /><b>Нет</b> - кеширование не используется</small>", 'type' => 'select', 'values' => array('1' => 'Да', '0' => 'Нет'), 'value' => intval(pluginGetVariable($plugin, 'cache'))));
-array_push($cfgX, array('name' => 'cacheExpire', 'title' => "Период обновления кеша<br /><small>(через сколько секунд происходит обновление кеша. Значение по умолчанию: <b>60</b>)</small>", 'type' => 'input', 'value' => intval(pluginGetVariable($plugin, 'cacheExpire')) ? pluginGetVariable($plugin, 'cacheExpire') : '60'));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки кеширования</b>', 'entries' => $cfgX));
+$cfg = [];
+$cfgX = [];
+array_push($cfg, ['descr' => 'Плагин отображает последние комментарии, оставленные на новости сайта.']);
+array_push($cfgX, ['name' => 'sidepanel', 'title' => 'Включить генерацию боковой панели', 'descr' => '<b>Да</b> - панель будет генерироваться<br/><b>Нет</b> - панель не будет генерироваться', 'type' => 'select', 'values' => ['0' => $lang['noa'], '1' => $lang['yesa']], 'value' => pluginGetVariable('lastcomments', 'sidepanel')]);
+array_push($cfgX, ['name' => 'number', 'title' => 'Количество выводимых комментариев', 'descr' => 'Значение по умолчанию: <b>10</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => pluginGetVariable('lastcomments', 'number')]);
+array_push($cfgX, ['name' => 'comm_length', 'title' => 'Усечение длины комментария', 'descr' => 'Кол-во символов из комментария для отображения<br/>Значение по умолчанию: <b>50</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => pluginGetVariable('lastcomments', 'comm_length')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки боковой панели</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'ppage', 'title' => 'Разрешить собственную страницу плагина', 'descr' => '<b>Да</b> - собственная страница разрешена<br/><b>Нет</b> - собственная страница запрещена', 'type' => 'select', 'values' => ['0' => $lang['noa'], '1' => $lang['yesa']], 'value' => pluginGetVariable('lastcomments', 'ppage')]);
+array_push($cfgX, ['name' => 'pp_number', 'title' => 'Количество выводимых комментариев', 'descr' => 'Значение по умолчанию: <b>30</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => pluginGetVariable('lastcomments', 'pp_number')]);
+array_push($cfgX, ['name' => 'pp_comm_length', 'title' => 'Усечение длины комментария', 'descr' => 'Кол-во символов из комментария для отображения<br/>Значение по умолчанию: <b>500</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => pluginGetVariable('lastcomments', 'pp_comm_length')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки собственной страницы плагина</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'rssfeed', 'title' => 'Разрешить rss-ленту плагина', 'descr' => '<b>Да</b> - rss-лента разрешена<br/><b>Нет</b> - rss-лента запрещена', 'type' => 'select', 'values' => ['0' => $lang['noa'], '1' => $lang['yesa']], 'value' => pluginGetVariable('lastcomments', 'rssfeed')]);
+array_push($cfgX, ['name' => 'rss_number', 'title' => 'Количество выводимых комментариев', 'descr' => 'Значение по умолчанию: <b>30</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => pluginGetVariable('lastcomments', 'rss_number')]);
+array_push($cfgX, ['name' => 'rss_comm_length', 'title' => 'Усечение длины комментария', 'descr' => 'Кол-во символов из комментария для отображения<br/>Значение по умолчанию: <b>500</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => pluginGetVariable('lastcomments', 'rss_comm_length')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки собственной страницы плагина</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'localsource', 'title' => 'Выберите каталог из которого плагин будет брать шаблоны для отображения<br /><small><b>Шаблон сайта</b> - плагин будет пытаться взять шаблоны из общего шаблона сайта; в случае недоступности - шаблоны будут взяты из собственного каталога плагина<br /><b>Плагин</b> - шаблоны будут браться из собственного каталога плагина</small>', 'type' => 'select', 'values' => ['0' => 'Шаблон сайта', '1' => 'Плагин'], 'value' => intval(pluginGetVariable($plugin, 'localsource'))]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки отображения</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'cache', 'title' => 'Использовать кеширование данных<br /><small><b>Да</b> - кеширование используется<br /><b>Нет</b> - кеширование не используется</small>', 'type' => 'select', 'values' => ['1' => 'Да', '0' => 'Нет'], 'value' => intval(pluginGetVariable($plugin, 'cache'))]);
+array_push($cfgX, ['name' => 'cacheExpire', 'title' => 'Период обновления кеша<br /><small>(через сколько секунд происходит обновление кеша. Значение по умолчанию: <b>60</b>)</small>', 'type' => 'input', 'value' => intval(pluginGetVariable($plugin, 'cacheExpire')) ? pluginGetVariable($plugin, 'cacheExpire') : '60']);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки кеширования</b>', 'entries' => $cfgX]);
 // RUN
 if ($_REQUEST['action'] == 'commit') {
-	// If submit requested, do config save
-	commit_plugin_config_changes('lastcomments', $cfg);
-	print_commit_complete('lastcomments');
+    // If submit requested, do config save
+    commit_plugin_config_changes('lastcomments', $cfg);
+    print_commit_complete('lastcomments');
 } else {
-	generate_config_page('lastcomments', $cfg);
+    generate_config_page('lastcomments', $cfg);
 }

--- a/lastcomments/install.php
+++ b/lastcomments/install.php
@@ -1,46 +1,45 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
-function plugin_lastcomments_install($action) {
-
-	global $config, $lang;
-	$ULIB = new urlLibrary();
-	$ULIB->loadConfig();
-	$ULIB->registerCommand('lastcomments', '',
-		array(
-			'vars'  =>
-				array(),
-			'descr' => array('russian' => 'Страница с последними комментариями'),
-		)
-	);
-	$ULIB->registerCommand('lastcomments', 'rss',
-		array(
-			'vars'  =>
-				array(),
-			'descr' => array('russian' => 'Rss лента последних комментариев'),
-		)
-	);
-	// Apply requested action
-	switch ($action) {
-		case 'confirm':
-			generate_install_page('lastcomments', "GO GO GO");
-			break;
-		case 'autoapply':
-		case 'apply':
-			if (fixdb_plugin_install('lastcomments', array(), 'install', ($action == 'autoapply') ? true : false)) {
-				plugin_mark_installed('lastcomments');
-			} else {
-				return false;
-			}
-			$ULIB->saveConfig();
-			break;
-	}
-
-	return true;
+if (!defined('NGCMS')) {
+    die('HAL');
 }
+function plugin_lastcomments_install($action)
+{
+    global $config, $lang;
+    $ULIB = new urlLibrary();
+    $ULIB->loadConfig();
+    $ULIB->registerCommand(
+        'lastcomments',
+        '',
+        [
+            'vars'  => [],
+            'descr' => ['russian' => 'Страница с последними комментариями'],
+        ]
+    );
+    $ULIB->registerCommand(
+        'lastcomments',
+        'rss',
+        [
+            'vars'  => [],
+            'descr' => ['russian' => 'Rss лента последних комментариев'],
+        ]
+    );
+    // Apply requested action
+    switch ($action) {
+        case 'confirm':
+            generate_install_page('lastcomments', 'GO GO GO');
+            break;
+        case 'autoapply':
+        case 'apply':
+            if (fixdb_plugin_install('lastcomments', [], 'install', ($action == 'autoapply') ? true : false)) {
+                plugin_mark_installed('lastcomments');
+            } else {
+                return false;
+            }
+            $ULIB->saveConfig();
+            break;
+    }
 
-
-
-
-
-
+    return true;
+}

--- a/lastcomments/lastcomments.php
+++ b/lastcomments/lastcomments.php
@@ -1,19 +1,22 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 define('lastcomments_version', '0.10');
 // ==============================================
 // Side bar widget
 // ==============================================
-function lastcomments_block() {
-
-	global $template;
-	// Action if sidepanel is enabled
-	if (pluginGetVariable('lastcomments', 'sidepanel')) {
-		$template['vars']['plugin_lastcomments'] = lastcomments();
-	} else {
-		$template['vars']['plugin_lastcomments'] = "";
-	}
+function lastcomments_block()
+{
+    global $template;
+    // Action if sidepanel is enabled
+    if (pluginGetVariable('lastcomments', 'sidepanel')) {
+        $template['vars']['plugin_lastcomments'] = lastcomments();
+    } else {
+        $template['vars']['plugin_lastcomments'] = '';
+    }
 }
 
 registerActionHandler('index', 'lastcomments_block');
@@ -21,16 +24,16 @@ registerActionHandler('index', 'lastcomments_block');
 // ==============================================
 // Plugin page
 // ==============================================
-function lastcomments_page() {
-
-	global $SYSTEM_FLAGS, $template, $CurrentHandler;
-	// Action if ppage is enabled
-	if (pluginGetVariable('lastcomments', 'ppage') && ($CurrentHandler['handlerParams']['value']['pluginName'] == 'core')) {
-		$SYSTEM_FLAGS['info']['title']['group'] = "lastcomments";
-		$template['vars']['mainblock'] = lastcomments(1);
-	} else {
-		error404();
-	}
+function lastcomments_page()
+{
+    global $SYSTEM_FLAGS, $template, $CurrentHandler;
+    // Action if ppage is enabled
+    if (pluginGetVariable('lastcomments', 'ppage') && ($CurrentHandler['handlerParams']['value']['pluginName'] == 'core')) {
+        $SYSTEM_FLAGS['info']['title']['group'] = 'lastcomments';
+        $template['vars']['mainblock'] = lastcomments(1);
+    } else {
+        error404();
+    }
 }
 
 register_plugin_page('lastcomments', '', 'lastcomments_page', 0);
@@ -38,23 +41,23 @@ register_plugin_page('lastcomments', '', 'lastcomments_page', 0);
 // ==============================================
 // Rss feed
 // ==============================================
-function lastcomments_rssfeed() {
-
-	global $SUPRESS_TEMPLATE_SHOW, $SUPRESS_MAINBLOCK_SHOW, $CurrentHandler;
-	// Action if rssfeed is enabled
-	if (pluginGetVariable('lastcomments', 'rssfeed') && !(checkLinkAvailable('lastcomments', 'rss') && $CurrentHandler['handlerParams']['value']['pluginName'] == 'core')) {
-		// Hide Template
-		$SUPRESS_TEMPLATE_SHOW = true;
-		$SUPRESS_MAINBLOCK_SHOW = true;
-		// Disable index actions
-		actionDisable("index");
-		actionDisable("index_pre");
-		actionDisable("index_post");
-		// launch rss
-		echo lastcomments(2);
-	} else {
-		error404();
-	}
+function lastcomments_rssfeed()
+{
+    global $SUPRESS_TEMPLATE_SHOW, $SUPRESS_MAINBLOCK_SHOW, $CurrentHandler;
+    // Action if rssfeed is enabled
+    if (pluginGetVariable('lastcomments', 'rssfeed') && !(checkLinkAvailable('lastcomments', 'rss') && $CurrentHandler['handlerParams']['value']['pluginName'] == 'core')) {
+        // Hide Template
+        $SUPRESS_TEMPLATE_SHOW = true;
+        $SUPRESS_MAINBLOCK_SHOW = true;
+        // Disable index actions
+        actionDisable('index');
+        actionDisable('index_pre');
+        actionDisable('index_post');
+        // launch rss
+        echo lastcomments(2);
+    } else {
+        error404();
+    }
 }
 
 register_plugin_page('lastcomments', 'rss', 'lastcomments_rssfeed', 0);
@@ -62,179 +65,182 @@ register_plugin_page('lastcomments', 'rss', 'lastcomments_rssfeed', 0);
 // ==============================================
 // Some magic
 // ==============================================
-function lastcomments($mode = 0) {
+function lastcomments($mode = 0)
+{
+    global $config, $mysql, $twig, $twigLoader, $parse, $TemplateCache;
+    switch ($mode) {
+        case 1:
+            $tpl_prefix = 'pp_';    // plugin page
+            break;
+        case 2:
+            $tpl_prefix = 'rss_';    // rss feed
+            break;
+        case 0:
+        default:
+            $tpl_prefix = '';        // sidepanel widget
+            break;
+    }
+    // Generate cache file name [ we should take into account SWITCHER plugin & calling parameters ]
+    $cacheFileName = md5('lastcomments'.$config['theme'].$config['default_lang'].$tpl_prefix).'.txt';
+    if (pluginGetVariable('lastcomments', 'cache')) {
+        $cacheData = cacheRetrieveFile($cacheFileName, pluginGetVariable('lastcomments', 'cacheExpire'), 'lastcomments');
+        if ($cacheData != false) {
+            // We got data from cache. Return it and stop
+            return $cacheData;
+        }
+    }
+    // Preload template configuration variables
+    @templateLoadVariables();
+    // Use default <noavatar> file
+    // - Check if noavatar is defined on template level
+    $tplVars = $TemplateCache['site']['#variables'];
+    $noAvatarURL = (isset($tplVars['configuration']) && is_array($tplVars['configuration']) && isset($tplVars['configuration']['noAvatarImage']) && $tplVars['configuration']['noAvatarImage']) ? (tpl_url.'/'.$tplVars['configuration']['noAvatarImage']) : (avatars_url.'/noavatar.gif');
+    //
+    // Prepare for battle
+    $comm_num = 0;
+    $number = intval(pluginGetVariable('lastcomments', $tpl_prefix.'number'));
+    $comm_length = intval(pluginGetVariable('lastcomments', $tpl_prefix.'comm_length'));
+    if (($number < 1) || ($number > 50)) {
+        $number = $tpl_prefix ? 30 : 10;
+    }
+    if (($comm_length < 10) || ($comm_length > ($tpl_prefix ? 500 : 100))) {
+        $comm_length = $tpl_prefix ? 500 : 50;
+    }
+    if ($mode == 2) {
+        $old_locale = setlocale(LC_TIME, 0);
+        setlocale(LC_TIME, 'en_EN');
+    }
+    $query = 'select c.*, u.avatar as users_avatar, u.id as uid, n.id as nid, n.title, n.alt_name, n.catid, n.postdate as npostdate from '.prefix.'_comments c left join '.prefix.'_news n on c.post=n.id left join '.uprefix.'_users u on c.author_id = u.id where n.approve=1 order by c.id desc limit '.$number;
+    $data = [];
+    foreach ($mysql->select($query) as $row) {
+        // Parse comments
+        $text = $row['text'];
+        if ($config['blocks_for_reg']) {
+            $text = $parse->userblocks($text);
+        }
+        if ($config['use_bbcodes']) {
+            $text = $parse->bbcodes($text);
+        }
+        if ($config['use_htmlformatter']) {
+            $text = $parse->htmlformatter($text);
+        }
+        if ($config['use_smilies']) {
+            $text = $parse->smilies($text);
+        }
+        if (strlen($text) > $comm_length) {
+            $text = $parse->truncateHTML($text, $comm_length);
+        }
+        $comm_num++;
+        // gen answer
+        if ($row['answer'] != '') {
+            $answer = $row['answer'];
+            $name = $row['name'];
+            if ($config['blocks_for_reg']) {
+                $answer = $parse->userblocks($answer);
+            }
+            if ($config['use_htmlformatter']) {
+                $answer = $parse->htmlformatter($answer);
+            }
+            if ($config['use_bbcodes']) {
+                $answer = $parse->bbcodes($answer);
+            }
+            if ($config['use_smilies']) {
+                $answer = $parse->smilies($answer);
+            }
+        }
+        // gen avatar
+        if ($config['use_avatars']) {
+            if ($row['users_avatar']) {
+                $avatar = '<img src="'.avatars_url.'/'.$row['users_avatar'].'" alt="'.$row['author'].'" />';
+                $avatar_url = avatars_url.'/'.$row['users_avatar'];
+            } else {
+                // If gravatar integration is active, show avatar from GRAVATAR.COM
+                if ($config['avatars_gravatar']) {
+                    $avatar = '<img src="http://www.gravatar.com/avatar/'.md5(strtolower($row['mail'])).'?s='.$config['avatar_wh'].'&amp;d='.urlencode($noAvatarURL).'" alt=""/>';
+                    $avatar_url = 'http://www.gravatar.com/avatar/'.md5(strtolower($row['mail'])).'?s='.$config['avatar_wh'].'&amp;d='.urlencode($noAvatarURL);
+                } else {
+                    $avatar = '<img src="'.$noAvatarURL.'" alt="" />';
+                    $avatar_url = $noAvatarURL;
+                }
+            }
+        } else {
+            $avatar = '';
+            $avatar_url = '';
+        }
+        if ($row['author_id'] && getPluginStatusActive('uprofile')) {
+            $author_link = checkLinkAvailable('uprofile', 'show') ?
+                generateLink('uprofile', 'show', ['name' => $row['author'], 'id' => $row['author_id']]) :
+                generateLink('core', 'plugin', ['plugin' => 'uprofile', 'handler' => 'show'], ['id' => $row['author_id']]);
+        } else {
+            $author_link = '';
+        }
+        $data[] = [
+            'link'          => newsGenerateLink(['id' => $row['nid'], 'alt_name' => $row['alt_name'], 'catid' => $row['catid'], 'postdate' => $row['npostdate']]),
+            'date'          => langdate('d.m.Y', $row['postdate']),
+            'author'        => str_replace('<', '&lt;', $row['author']),
+            'author_id'     => $row['author_id'],
+            'title'         => str_replace('<', '&lt;', $row['title']),
+            'text'          => $text,
+            'category_link' => GetCategories($row['catid']),
+            'comnum'        => $comm_num,
+            'author_link'   => $author_link,
+            'avatar'        => $avatar,
+            'avatar_url'    => $avatar_url,
+            'answer'        => $answer,
+            'name'          => $name,
+            'alternating'   => ($comnum % 2) ? 'lastcomments_even' : 'lastcomments_odd',
+            'rsslink'       => home.'?id='.$row['nid'],
+            'rssdate'       => gmstrftime('%a, %d %b %Y %H:%M:%S GMT', $row['postdate']),
+        ];
+    }
+    $tpath = locatePluginTemplates([$tpl_prefix.'lastcomments', $tpl_prefix.'entries'], 'lastcomments', pluginGetVariable('lastcomments', 'localsource'));
+    // Prepare REGEX conversion table
+    $conversionConfigRegex = [
+        "#\[profile\](.*?)\[/profile\]#si"       => "{% if (entry.author_id) and (pluginIsActive('uprofile')) %}$1{% endif %}",
+        "#\[answer\](.*?)\[/answer\]#si"         => "{% if (entry.answer != '') %}$1{% endif %}",
+        "#\[nocomments\](.*?)\[/nocomments\]#si" => '{% if (comnum == 0) %}$1{% endif %}',
+        //		"#\{l_([0-9a-zA-Z\-\_\.\#]+)}#"					=> "{{ lang['$1'] }}",
+    ];
+    // Prepare conversion table
+    $conversionConfig = [
+        '{tpl_url}'       => '{{ tpl_url }}',
+        '{link}'          => '{{ entry.link }}',
+        '{date}'          => '{{ entry.date }}',
+        '{author}'        => '{{ entry.author }}',
+        '{author_id}'     => '{{ entry.author_id }}',
+        '{title}'         => '{{ entry.title }}',
+        '{text}'          => '{{ entry.text }}',
+        '{category_link}' => '{{ entry.category_link }}',
+        '{comnum}'        => '{{ entry.comnum }}',
+        '{author_link}'   => '{{ entry.author_link }}',
+        '{avatar}'        => '{{ entry.avatar }}',
+        '{avatar_url}'    => '{{ entry.avatar_url }}',
+        '{answer}'        => '{{ entry.answer }}',
+        '{name}'          => '{{ entry.name }}',
+        '{alternating}'   => '{{ entry.alternating }}',
+        '{entries}'       => '{% for entry in entries %}{% include localPath(0) ~ "entries.tpl" %}{% endfor %}',
+    ];
+    $twigLoader->setConversion($tpath[$tpl_prefix.'lastcomments'].$tpl_prefix.'lastcomments'.'.tpl', $conversionConfig, $conversionConfigRegex);
+    $twigLoader->setConversion($tpath[$tpl_prefix.'entries'].$tpl_prefix.'entries'.'.tpl', $conversionConfig, $conversionConfigRegex);
+    if (isset($tpath[$tpl_prefix.'entries'])) {
+        $twig->loadTemplate($tpath[$tpl_prefix.'entries'].$tpl_prefix.'entries'.'.tpl');
+    }
+    $xt = $twig->loadTemplate($tpath[$tpl_prefix.'lastcomments'].$tpl_prefix.'lastcomments'.'.tpl');
+    $tVars = [
+        'comnum'      => $comm_num,
+        'entries'     => $data,
+        'home_title'  => $config['home_title'],
+        'home_url'    => $config['home_url'],
+        'description' => $config['description'],
+        'generator'   => 'Plugin Lastcomments ('.lastcomments_version.') // Next Generation CMS ('.engineName.' '.engineVersion.')',
+    ];
+    $output = $xt->render($tVars);
+    if ($mode == 2) {
+        setlocale(LC_TIME, $old_locale);
+    }
+    if (pluginGetVariable('lastcomments', 'cache')) {
+        cacheStoreFile($cacheFileName, $output, 'lastcomments');
+    }
 
-	global $config, $mysql, $twig, $twigLoader, $parse, $TemplateCache;
-	switch ($mode) {
-		case 1:
-			$tpl_prefix = "pp_";    // plugin page
-			break;
-		case 2:
-			$tpl_prefix = "rss_";    // rss feed
-			break;
-		case 0:
-		default:
-			$tpl_prefix = "";        // sidepanel widget
-			break;
-	}
-	// Generate cache file name [ we should take into account SWITCHER plugin & calling parameters ]
-	$cacheFileName = md5('lastcomments' . $config['theme'] . $config['default_lang'] . $tpl_prefix) . '.txt';
-	if (pluginGetVariable('lastcomments', 'cache')) {
-		$cacheData = cacheRetrieveFile($cacheFileName, pluginGetVariable('lastcomments', 'cacheExpire'), 'lastcomments');
-		if ($cacheData != false) {
-			// We got data from cache. Return it and stop
-			return $cacheData;
-		}
-	}
-	// Preload template configuration variables
-	@templateLoadVariables();
-	// Use default <noavatar> file
-	// - Check if noavatar is defined on template level
-	$tplVars = $TemplateCache['site']['#variables'];
-	$noAvatarURL = (isset($tplVars['configuration']) && is_array($tplVars['configuration']) && isset($tplVars['configuration']['noAvatarImage']) && $tplVars['configuration']['noAvatarImage']) ? (tpl_url . "/" . $tplVars['configuration']['noAvatarImage']) : (avatars_url . "/noavatar.gif");
-	//
-	// Prepare for battle
-	$comm_num = 0;
-	$number = intval(pluginGetVariable('lastcomments', $tpl_prefix . 'number'));
-	$comm_length = intval(pluginGetVariable('lastcomments', $tpl_prefix . 'comm_length'));
-	if (($number < 1) || ($number > 50)) {
-		$number = $tpl_prefix ? 30 : 10;
-	}
-	if (($comm_length < 10) || ($comm_length > ($tpl_prefix ? 500 : 100))) {
-		$comm_length = $tpl_prefix ? 500 : 50;
-	}
-	if ($mode == 2) {
-		$old_locale = setlocale(LC_TIME, 0);
-		setlocale(LC_TIME, 'en_EN');
-	}
-	$query = "select c.*, u.avatar as users_avatar, u.id as uid, n.id as nid, n.title, n.alt_name, n.catid, n.postdate as npostdate from " . prefix . "_comments c left join " . prefix . "_news n on c.post=n.id left join " . uprefix . "_users u on c.author_id = u.id where n.approve=1 order by c.id desc limit " . $number;
-	$data = array();
-	foreach ($mysql->select($query) as $row) {
-		// Parse comments
-		$text = $row['text'];
-		if ($config['blocks_for_reg']) {
-			$text = $parse->userblocks($text);
-		}
-		if ($config['use_bbcodes']) {
-			$text = $parse->bbcodes($text);
-		}
-		if ($config['use_htmlformatter']) {
-			$text = $parse->htmlformatter($text);
-		}
-		if ($config['use_smilies']) {
-			$text = $parse->smilies($text);
-		}
-		if (strlen($text) > $comm_length) {
-			$text = $parse->truncateHTML($text, $comm_length);
-		}
-		$comm_num++;
-		// gen answer
-		if ($row['answer'] != '') {
-			$answer = $row['answer'];
-			$name = $row['name'];
-			if ($config['blocks_for_reg']) {
-				$answer = $parse->userblocks($answer);
-			}
-			if ($config['use_htmlformatter']) {
-				$answer = $parse->htmlformatter($answer);
-			}
-			if ($config['use_bbcodes']) {
-				$answer = $parse->bbcodes($answer);
-			}
-			if ($config['use_smilies']) {
-				$answer = $parse->smilies($answer);
-			}
-		}
-		// gen avatar
-		if ($config['use_avatars']) {
-			if ($row['users_avatar']) {
-				$avatar = "<img src=\"" . avatars_url . "/" . $row['users_avatar'] . "\" alt=\"" . $row['author'] . "\" />";
-				$avatar_url = avatars_url . "/" . $row['users_avatar'];
-			} else {
-				// If gravatar integration is active, show avatar from GRAVATAR.COM
-				if ($config['avatars_gravatar']) {
-					$avatar = '<img src="http://www.gravatar.com/avatar/' . md5(strtolower($row['mail'])) . '?s=' . $config['avatar_wh'] . '&amp;d=' . urlencode($noAvatarURL) . '" alt=""/>';
-					$avatar_url = 'http://www.gravatar.com/avatar/' . md5(strtolower($row['mail'])) . '?s=' . $config['avatar_wh'] . '&amp;d=' . urlencode($noAvatarURL);
-				} else {
-					$avatar = "<img src=\"" . $noAvatarURL . "\" alt=\"\" />";
-					$avatar_url = $noAvatarURL;
-				}
-			}
-		} else {
-			$avatar = '';
-			$avatar_url = '';
-		}
-		if ($row['author_id'] && getPluginStatusActive('uprofile')) {
-			$author_link = checkLinkAvailable('uprofile', 'show') ?
-				generateLink('uprofile', 'show', array('name' => $row['author'], 'id' => $row['author_id'])) :
-				generateLink('core', 'plugin', array('plugin' => 'uprofile', 'handler' => 'show'), array('id' => $row['author_id']));
-		} else {
-			$author_link = '';
-		}
-		$data[] = array(
-			'link'          => newsGenerateLink(array('id' => $row['nid'], 'alt_name' => $row['alt_name'], 'catid' => $row['catid'], 'postdate' => $row['npostdate'])),
-			'date'          => langdate('d.m.Y', $row['postdate']),
-			'author'        => str_replace('<', '&lt;', $row['author']),
-			'author_id'     => $row['author_id'],
-			'title'         => str_replace('<', '&lt;', $row['title']),
-			'text'          => $text,
-			'category_link' => GetCategories($row['catid']),
-			'comnum'        => $comm_num,
-			'author_link'   => $author_link,
-			'avatar'        => $avatar,
-			'avatar_url'    => $avatar_url,
-			'answer'        => $answer,
-			'name'          => $name,
-			'alternating'   => ($comnum % 2) ? "lastcomments_even" : "lastcomments_odd",
-			'rsslink'       => home . "?id=" . $row['nid'],
-			'rssdate'       => gmstrftime('%a, %d %b %Y %H:%M:%S GMT', $row['postdate']),
-		);
-	}
-	$tpath = locatePluginTemplates(array($tpl_prefix . 'lastcomments', $tpl_prefix . 'entries'), 'lastcomments', pluginGetVariable('lastcomments', 'localsource'));
-	// Prepare REGEX conversion table
-	$conversionConfigRegex = array(
-		"#\[profile\](.*?)\[/profile\]#si"       => "{% if (entry.author_id) and (pluginIsActive('uprofile')) %}$1{% endif %}",
-		"#\[answer\](.*?)\[/answer\]#si"         => "{% if (entry.answer != '') %}$1{% endif %}",
-		"#\[nocomments\](.*?)\[/nocomments\]#si" => "{% if (comnum == 0) %}$1{% endif %}",
-		//		"#\{l_([0-9a-zA-Z\-\_\.\#]+)}#"					=> "{{ lang['$1'] }}",
-	);
-	// Prepare conversion table
-	$conversionConfig = array(
-		'{tpl_url}'       => '{{ tpl_url }}',
-		'{link}'          => '{{ entry.link }}',
-		'{date}'          => '{{ entry.date }}',
-		'{author}'        => '{{ entry.author }}',
-		'{author_id}'     => '{{ entry.author_id }}',
-		'{title}'         => '{{ entry.title }}',
-		'{text}'          => '{{ entry.text }}',
-		'{category_link}' => '{{ entry.category_link }}',
-		'{comnum}'        => '{{ entry.comnum }}',
-		'{author_link}'   => '{{ entry.author_link }}',
-		'{avatar}'        => '{{ entry.avatar }}',
-		'{avatar_url}'    => '{{ entry.avatar_url }}',
-		'{answer}'        => '{{ entry.answer }}',
-		'{name}'          => '{{ entry.name }}',
-		'{alternating}'   => '{{ entry.alternating }}',
-		'{entries}'       => '{% for entry in entries %}{% include localPath(0) ~ "entries.tpl" %}{% endfor %}'
-	);
-	$twigLoader->setConversion($tpath[$tpl_prefix . 'lastcomments'] . $tpl_prefix . "lastcomments" . '.tpl', $conversionConfig, $conversionConfigRegex);
-	$twigLoader->setConversion($tpath[$tpl_prefix . 'entries'] . $tpl_prefix . "entries" . '.tpl', $conversionConfig, $conversionConfigRegex);
-	if (isset($tpath[$tpl_prefix . 'entries']))
-		$twig->loadTemplate($tpath[$tpl_prefix . 'entries'] . $tpl_prefix . 'entries' . '.tpl');
-	$xt = $twig->loadTemplate($tpath[$tpl_prefix . 'lastcomments'] . $tpl_prefix . "lastcomments" . '.tpl');
-	$tVars = array(
-		'comnum'  => $comm_num,
-		'entries' => $data,
-		'home_title'  => $config['home_title'],
-		'home_url'    => $config['home_url'],
-		'description' => $config['description'],
-		'generator' => 'Plugin Lastcomments (' . lastcomments_version . ') // Next Generation CMS (' . engineName . ' ' . engineVersion . ')',
-	);
-	$output = $xt->render($tVars);
-	if ($mode == 2) setlocale(LC_TIME, $old_locale);
-	if (pluginGetVariable('lastcomments', 'cache')) {
-		cacheStoreFile($cacheFileName, $output, 'lastcomments');
-	}
-
-	return $output;
+    return $output;
 }

--- a/lastcomments/uninstall.php
+++ b/lastcomments/uninstall.php
@@ -1,13 +1,16 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 $ULIB = new urlLibrary();
 $ULIB->loadConfig();
 $ULIB->removeCommand('lastcomments', '');
 $ULIB->removeCommand('lastcomments', 'rss');
 if ($_REQUEST['action'] == 'commit') {
-	plugin_mark_deinstalled('lastcomments');
-	$ULIB->saveConfig();
+    plugin_mark_deinstalled('lastcomments');
+    $ULIB->saveConfig();
 } else {
-	generate_install_page('lastcomments', "Bye-Bye!", 'deinstall');
+    generate_install_page('lastcomments', 'Bye-Bye!', 'deinstall');
 }

--- a/rss_export/config.php
+++ b/rss_export/config.php
@@ -1,58 +1,60 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
 // Preload config file
 plugins_load_config();
-$xfEnclosureValues = array('' => '');
+$xfEnclosureValues = ['' => ''];
 //
 // IF plugin 'XFIELDS' is enabled - load it to prepare `enclosure` integration
 if (getPluginStatusActive('xfields')) {
-	include_once(root . "/plugins/xfields/xfields.php");
-	// Load XFields config
-	if (is_array($xfc = xf_configLoad())) {
-		foreach ($xfc['news'] as $fid => $fdata) {
-			$xfEnclosureValues[$fid] = $fid . ' (' . $fdata['title'] . ')';
-		}
-	}
+    include_once root.'/plugins/xfields/xfields.php';
+    // Load XFields config
+    if (is_array($xfc = xf_configLoad())) {
+        foreach ($xfc['news'] as $fid => $fdata) {
+            $xfEnclosureValues[$fid] = $fid.' ('.$fdata['title'].')';
+        }
+    }
 }
 // For example - find 1st category with news for demo URL
 $demoCategory = '';
 foreach ($catz as $scanCat) {
-	if ($scanCat['posts'] > 0) {
-		$demoCategory = $scanCat['alt'];
-		break;
-	}
+    if ($scanCat['posts'] > 0) {
+        $demoCategory = $scanCat['alt'];
+        break;
+    }
 }
 // Fill configuration parameters
-$cfg = array();
-$cfgX = array();
-array_push($cfg, array('descr' => '<b>Плагин экспорта новостей в формате RSS</b><br>Полная лента новостей доступна по адресу: <b>' . generatePluginLink('rss_export', '', array(), array(), true, true) . (($demoCategory != '') ? '<br/>Лента новостей для категории <i>' . $catz[$demoCategory]['name'] . '</i>: ' . generatePluginLink('rss_export', 'category', array('category' => $demoCategory), array(), true, true) : '')));
-array_push($cfgX, array('type' => 'select', 'name' => 'feed_title_format', 'title' => 'Формат заголовка ленты новостей', 'descr' => '<b>Сайт</b> - использовать заголовок сайта<br><b>Сайт+Категория</b> - использовать заголовок сайта+название категории (при выводе новостей из конкретной категории)<br><b>Ручной</b> - заголовок определяется Вами', 'values' => array('site' => 'Сайт', 'site_title' => 'Сайт+Категория', 'handy' => 'Ручной'), value => pluginGetVariable('rss_export', 'feed_title_format')));
-array_push($cfgX, array('type' => 'input', 'name' => 'feed_title_value', 'title' => 'Ваш заголовок ленты новостей', 'descr' => 'Заголовок используется в случае выбора формата <b>"ручной"</b> в качестве заголовка ленты', 'html_flags' => 'style="width: 250px;"', 'value' => pluginGetVariable('rss_export', 'feed_title_value')));
-array_push($cfgX, array('type' => 'select', 'name' => 'news_title', 'title' => 'Формат заголовка новости', 'descr' => '<b>Название</b> - в заголовке указывается только название новости<br><b>Категория :: Название</b> - В заголовке указывается как категория так и название новости', 'values' => array('0' => 'Название', '1' => 'Категория :: Название'), value => pluginGetVariable('rss_export', 'news_title')));
-array_push($cfgX, array('type' => 'input', 'name' => 'news_count', 'title' => 'Кол-во новостей для публикации в ленте', value => pluginGetVariable('rss_export', 'news_count')));
-array_push($cfgX, array('type' => 'select', 'name' => 'use_hide', 'title' => 'Обрабатывать тег <b>[hide] ... [/hide]</b>', 'descr' => '<b>Да</b> - текст отмеченный тегом <b>hide</b> не отображается<br><b>Нет</b> - текст отмеченный тегом <b>hide</b> отображается', 'values' => array('0' => 'Нет', '1' => 'Да'), value => pluginGetVariable('rss_export', 'use_hide')));
-array_push($cfgX, array('type' => 'select', 'name' => 'content_show', 'title' => 'Вид отображения новости', 'descr' => 'Вам необходимо указать какая именно информация будет отображаться внутри новости, экспортируемой через RSS', 'values' => array('0' => 'короткая+длинная', '1' => 'только короткая', '2' => 'только длинная'), value => pluginGetVariable('rss_export', 'content_show')));
-array_push($cfgX, array('type' => 'input', 'name' => 'truncate', 'title' => 'Обрезать выводимую информацию', 'descr' => 'Кол-во символов до которых будет обрезаться выводимая в ленте информация.<br/>Значение по умолчанию: <b>0</b> - не обрезать', value => intval(pluginGetVariable('rss_export', 'truncate'))));
-array_push($cfgX, array('type' => 'input', 'name' => 'delay', 'title' => 'Отсрочка вывода новостей в ленту', 'descr' => 'Вы можете задать время (<b>в минутах</b>) на которое будет откладываться вывод новостей в RSS ленту', value => pluginGetVariable('rss_export', 'delay')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Общие настройки</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'xfEnclosureEnabled', 'title' => "Генерация поля 'Enclosure' используя данные плагина xfields", 'descr' => "<b>Да</b> - включить генерацию<br /><b>Нет</b> - отключить генерацию</small>", 'type' => 'select', 'values' => array('1' => 'Да', '0' => 'Нет'), 'value' => intval(pluginGetVariable($plugin, 'xfEnclosureEnabled'))));
-array_push($cfgX, array('name' => 'xfEnclosure', 'title' => "ID поля плагина <b>xfields</b>, которое будет использоваться для генерации поля <b>Enclosure</b>", 'type' => 'select', 'values' => $xfEnclosureValues, 'value' => pluginGetVariable($plugin, 'xfEnclosure')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Генерация поля <b>enclosure</b></b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'cache', 'title' => "Использовать кеширование данных<br /><small><b>Да</b> - кеширование используется<br /><b>Нет</b> - кеширование не используется</small>", 'type' => 'select', 'values' => array('1' => 'Да', '0' => 'Нет'), 'value' => intval(pluginGetVariable($plugin, 'cache'))));
-array_push($cfgX, array('name' => 'cacheExpire', 'title' => "Период обновления кеша<br /><small>(через сколько секунд происходит обновление кеша. Значение по умолчанию: <b>60</b>)</small>", 'type' => 'input', 'value' => intval(pluginGetVariable($plugin, 'cacheExpire')) ? pluginGetVariable($plugin, 'cacheExpire') : '60'));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>Настройки кеширования</b>', 'entries' => $cfgX));
+$cfg = [];
+$cfgX = [];
+array_push($cfg, ['descr' => '<b>Плагин экспорта новостей в формате RSS</b><br>Полная лента новостей доступна по адресу: <b>'.generatePluginLink('rss_export', '', [], [], true, true).(($demoCategory != '') ? '<br/>Лента новостей для категории <i>'.$catz[$demoCategory]['name'].'</i>: '.generatePluginLink('rss_export', 'category', ['category' => $demoCategory], [], true, true) : '')]);
+array_push($cfgX, ['type' => 'select', 'name' => 'feed_title_format', 'title' => 'Формат заголовка ленты новостей', 'descr' => '<b>Сайт</b> - использовать заголовок сайта<br><b>Сайт+Категория</b> - использовать заголовок сайта+название категории (при выводе новостей из конкретной категории)<br><b>Ручной</b> - заголовок определяется Вами', 'values' => ['site' => 'Сайт', 'site_title' => 'Сайт+Категория', 'handy' => 'Ручной'], value => pluginGetVariable('rss_export', 'feed_title_format')]);
+array_push($cfgX, ['type' => 'input', 'name' => 'feed_title_value', 'title' => 'Ваш заголовок ленты новостей', 'descr' => 'Заголовок используется в случае выбора формата <b>"ручной"</b> в качестве заголовка ленты', 'html_flags' => 'style="width: 250px;"', 'value' => pluginGetVariable('rss_export', 'feed_title_value')]);
+array_push($cfgX, ['type' => 'select', 'name' => 'news_title', 'title' => 'Формат заголовка новости', 'descr' => '<b>Название</b> - в заголовке указывается только название новости<br><b>Категория :: Название</b> - В заголовке указывается как категория так и название новости', 'values' => ['0' => 'Название', '1' => 'Категория :: Название'], value => pluginGetVariable('rss_export', 'news_title')]);
+array_push($cfgX, ['type' => 'input', 'name' => 'news_count', 'title' => 'Кол-во новостей для публикации в ленте', value => pluginGetVariable('rss_export', 'news_count')]);
+array_push($cfgX, ['type' => 'select', 'name' => 'use_hide', 'title' => 'Обрабатывать тег <b>[hide] ... [/hide]</b>', 'descr' => '<b>Да</b> - текст отмеченный тегом <b>hide</b> не отображается<br><b>Нет</b> - текст отмеченный тегом <b>hide</b> отображается', 'values' => ['0' => 'Нет', '1' => 'Да'], value => pluginGetVariable('rss_export', 'use_hide')]);
+array_push($cfgX, ['type' => 'select', 'name' => 'content_show', 'title' => 'Вид отображения новости', 'descr' => 'Вам необходимо указать какая именно информация будет отображаться внутри новости, экспортируемой через RSS', 'values' => ['0' => 'короткая+длинная', '1' => 'только короткая', '2' => 'только длинная'], value => pluginGetVariable('rss_export', 'content_show')]);
+array_push($cfgX, ['type' => 'input', 'name' => 'truncate', 'title' => 'Обрезать выводимую информацию', 'descr' => 'Кол-во символов до которых будет обрезаться выводимая в ленте информация.<br/>Значение по умолчанию: <b>0</b> - не обрезать', value => intval(pluginGetVariable('rss_export', 'truncate'))]);
+array_push($cfgX, ['type' => 'input', 'name' => 'delay', 'title' => 'Отсрочка вывода новостей в ленту', 'descr' => 'Вы можете задать время (<b>в минутах</b>) на которое будет откладываться вывод новостей в RSS ленту', value => pluginGetVariable('rss_export', 'delay')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Общие настройки</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'xfEnclosureEnabled', 'title' => "Генерация поля 'Enclosure' используя данные плагина xfields", 'descr' => '<b>Да</b> - включить генерацию<br /><b>Нет</b> - отключить генерацию</small>', 'type' => 'select', 'values' => ['1' => 'Да', '0' => 'Нет'], 'value' => intval(pluginGetVariable($plugin, 'xfEnclosureEnabled'))]);
+array_push($cfgX, ['name' => 'xfEnclosure', 'title' => 'ID поля плагина <b>xfields</b>, которое будет использоваться для генерации поля <b>Enclosure</b>', 'type' => 'select', 'values' => $xfEnclosureValues, 'value' => pluginGetVariable($plugin, 'xfEnclosure')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Генерация поля <b>enclosure</b></b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'cache', 'title' => 'Использовать кеширование данных<br /><small><b>Да</b> - кеширование используется<br /><b>Нет</b> - кеширование не используется</small>', 'type' => 'select', 'values' => ['1' => 'Да', '0' => 'Нет'], 'value' => intval(pluginGetVariable($plugin, 'cache'))]);
+array_push($cfgX, ['name' => 'cacheExpire', 'title' => 'Период обновления кеша<br /><small>(через сколько секунд происходит обновление кеша. Значение по умолчанию: <b>60</b>)</small>', 'type' => 'input', 'value' => intval(pluginGetVariable($plugin, 'cacheExpire')) ? pluginGetVariable($plugin, 'cacheExpire') : '60']);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>Настройки кеширования</b>', 'entries' => $cfgX]);
 // RUN
 if ($_REQUEST['action'] == 'commit') {
-	// If submit requested, do config save
-	commit_plugin_config_changes($plugin, $cfg);
-	print_commit_complete($plugin);
+    // If submit requested, do config save
+    commit_plugin_config_changes($plugin, $cfg);
+    print_commit_complete($plugin);
 } else {
-	generate_config_page($plugin, $cfg);
+    generate_config_page($plugin, $cfg);
 }
-?>

--- a/rss_export/rss_export.php
+++ b/rss_export/rss_export.php
@@ -1,165 +1,172 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
-include_once root . "/includes/news.php";
+if (!defined('NGCMS')) {
+    die('HAL');
+}
+include_once root.'/includes/news.php';
 register_plugin_page('rss_export', '', 'plugin_rss_export', 0);
 register_plugin_page('rss_export', 'category', 'plugin_rss_export_category', 0);
-function plugin_rss_export() {
-
-	plugin_rss_export_generate();
+function plugin_rss_export()
+{
+    plugin_rss_export_generate();
 }
 
-function plugin_rss_export_category($params) {
-
-	plugin_rss_export_generate($params['category']);
+function plugin_rss_export_category($params)
+{
+    plugin_rss_export_generate($params['category']);
 }
 
-function plugin_rss_export_generate($catname = '') {
+function plugin_rss_export_generate($catname = '')
+{
+    global $lang, $PFILTERS, $template, $config, $SUPRESS_TEMPLATE_SHOW, $SUPRESS_MAINBLOCK_SHOW, $mysql, $catz, $parse;
+    // Disable executing of `index` action (widget plugins and so on..)
+    actionDisable('index');
+    // Suppress templates
+    $SUPRESS_TEMPLATE_SHOW = 1;
+    $SUPRESS_MAINBLOCK_SHOW = 1;
+    // Break if category specified & doesn't exist
+    if (($catname != '') && (!isset($catz[$catname]))) {
+        header('HTTP/1.1 404 Not found');
+        exit;
+    }
+    // Generate header
+    $xcat = (($catname != '') && isset($catz[$catname])) ? $catz[$catname] : '';
+    // Generate cache file name [ we should take into account SWITCHER plugin ]
+    // Take into account: FLAG: use_hide, check if user is logged in
+    $cacheFileName = md5('rss_export'.$config['theme'].$config['home_url'].$config['default_lang'].(is_array($xcat) ? $xcat['id'] : '').pluginGetVariable('rss_export', 'use_hide').is_array($userROW)).'.txt';
+    if (pluginGetVariable('rss_export', 'cache')) {
+        $cacheData = cacheRetrieveFile($cacheFileName, pluginGetVariable('rss_export', 'cacheExpire'), 'rss_export');
+        if ($cacheData != false) {
+            // We got data from cache. Return it and stop
+            echo $cacheData;
 
-	global $lang, $PFILTERS, $template, $config, $SUPRESS_TEMPLATE_SHOW, $SUPRESS_MAINBLOCK_SHOW, $mysql, $catz, $parse;
-	// Disable executing of `index` action (widget plugins and so on..)
-	actionDisable('index');
-	// Suppress templates
-	$SUPRESS_TEMPLATE_SHOW = 1;
-	$SUPRESS_MAINBLOCK_SHOW = 1;
-	// Break if category specified & doesn't exist
-	if (($catname != '') && (!isset($catz[$catname]))) {
-		header('HTTP/1.1 404 Not found');
-		exit;
-	}
-	// Generate header
-	$xcat = (($catname != '') && isset($catz[$catname])) ? $catz[$catname] : '';
-	// Generate cache file name [ we should take into account SWITCHER plugin ]
-	// Take into account: FLAG: use_hide, check if user is logged in
-	$cacheFileName = md5('rss_export' . $config['theme'] . $config['home_url'] . $config['default_lang'] . (is_array($xcat) ? $xcat['id'] : '') . pluginGetVariable('rss_export', 'use_hide') . is_array($userROW)) . '.txt';
-	if (pluginGetVariable('rss_export', 'cache')) {
-		$cacheData = cacheRetrieveFile($cacheFileName, pluginGetVariable('rss_export', 'cacheExpire'), 'rss_export');
-		if ($cacheData != false) {
-			// We got data from cache. Return it and stop
-			print $cacheData;
-
-			return;
-		}
-	}
-	// Generate output
-	$output = plugin_rss_export_mk_header($xcat);
-	$limit = pluginGetVariable('rss_export', 'news_count');
-	$delay = intval(pluginGetVariable('rss_export', 'delay'));
-	if ((!is_numeric($limit)) || ($limit < 0) || ($limit > 500)) {
-		$limit = 50;
-	}
-	$old_locale = setlocale(LC_TIME, 0);
-	setlocale(LC_TIME, 'en_EN');
-	if (is_array($xcat)) {
-		$orderBy = ($xcat['orderby'] && in_array($xcat['orderby'], array('id desc', 'id asc', 'postdate desc', 'postdate asc', 'title desc', 'title asc'))) ? $xcat['orderby'] : 'id desc';
-		$query = "select * from " . prefix . "_news where catid regexp '[[:<:]](" . $xcat['id'] . ")[[:>:]]' and approve=1 " . (($delay > 0) ? (" and ((postdate + " . intval($delay * 60) . ") < unix_timestamp(now())) ") : '') . "order by " . $orderBy;
-	} else {
-		$query = "select * from " . prefix . "_news where approve=1" . (($delay > 0) ? (" and ((postdate + " . intval($delay * 60) . ") < unix_timestamp(now())) ") : '') . " order by id desc";
-	}
-	// Prepare hide template
-	if ($config['blocks_for_reg'] && pluginGetVariable('rss_export', 'use_hide')) {
-		LoadPluginLang('rss_export', 'main', '', 'rexport');
-		$hide_template = @file_get_contents(root . 'plugins/rss_export/templates/hide.tpl');
-		$hide_template = str_replace('{text}', $lang['rexport_hide'], $hide_template);
-	}
-	// Fetch SQL record
-	$sqlData = $mysql->select($query . " limit $limit");
-	// Check if enclosure is requested and used for "images" field
-	$xFList = array();
-	$encImages = array();
-	$enclosureIsImages = false;
-	if (pluginGetVariable('rss_export', 'xfEnclosureEnabled') && getPluginStatusActive('xfields')) {
-		$xFList = xf_configLoad();
-		$eFieldName = pluginGetVariable('rss_export', 'xfEnclosure');
-		if (isset($xFList['news'][$eFieldName]) && ($xFList['news'][$eFieldName]['type'] == 'images')) {
-			$enclosureIsImages = true;
-			// Prepare list of news with attached images
-			$nAList = array();
-			foreach ($sqlData as $row) {
-				if ($row['num_images'] > 0)
-					$nAList [] = $row['id'];
-			}
-			$iQuery = "select * from " . prefix . "_images where (linked_ds = 1) and (linked_id in (" . join(",", $nAList) . ")) and (plugin = 'xfields') and (pidentity = " . db_squote($eFieldName) . ")";
-			foreach ($mysql->select($iQuery) as $row) {
-				if (!isset($encImages[$row['linked_id']]))
-					$encImages[$row['linked_id']] = $row;
-			}
-		}
-	}
-	$truncateLen = intval(pluginGetVariable('rss_export', 'truncate'));
-	if ($truncateLen < 0)
-		$truncateLen = 0;
-	foreach ($sqlData as $row) {
-		// Make standart system call in 'export' mode
-		$export_mode = 'export_body';
-		switch (pluginGetVariable('rss_export', 'content_show')) {
-			case '1':
-				$export_mode = 'export_short';
-				break;
-			case '2':
-				$export_mode = 'export_full';
-				break;
-		}
-		$content = news_showone($row['id'], '', array('emulate' => $row, 'style' => $export_mode, 'plugin' => 'rss_export'));
-		if ($truncateLen > 0) {
-			$content = $parse->truncateHTML($content, $truncateLen, '...');
-		}
-		$enclosure = '';
-		// Check if Enclosure `xfields` integration is activated
-		if (pluginGetVariable('rss_export', 'xfEnclosureEnabled') && (true || getPluginStatusActive('xfields'))) {
-			// Load (if needed XFIELDS plugin
-			include_once(root . "/plugins/xfields/xfields.php");
-			if (is_array($xfd = xf_decode($row['xfields'])) && isset($xfd[pluginGetVariable('rss_export', 'xfEnclosure')])) {
-				// Check enclosure field type
-				if ($enclosureIsImages) {
-					// images
-					if (isset($encImages[$row['id']])) {
-						$enclosure = ($encImages[$row['id']]['storage'] ? $config['attach_url'] : $config['images_url']) . '/' . $encImages[$row['id']]['folder'] . '/' . $encImages[$row['id']]['name'];
-					}
-				} else {
-					// text
-					$enclosure = $xfd[pluginGetVariable('rss_export', 'xfEnclosure')];
-				}
-			}
-		}
-		$output .= "  <item>\n";
-		$output .= "   <title><![CDATA[" . ((pluginGetVariable('rss_export', 'news_title') == 1) && GetCategories($row['catid'], true) ? GetCategories($row['catid'], true) . ' :: ' : '') . secure_html($row['title']) . "]]></title>\n";
-		$output .= "   <link><![CDATA[" . newsGenerateLink($row, false, 0, true) . "]]></link>\n";
-		$output .= "   <description><![CDATA[" . $content . "]]></description>\n";
-		// Output enclosure URL (if configured & set
-		if ($enclosure != '')
-			$output .= '   <enclosure url="' . $enclosure . '" />' . "\n";
-		$output .= "   <category>" . GetCategories($row['catid'], true) . "</category>\n";
-		$output .= "   <guid isPermaLink=\"false\">" . home . "?id=" . $row['id'] . "</guid>\n";
-		$output .= "   <pubDate>" . gmstrftime('%a, %d %b %Y %H:%M:%S GMT', $row['postdate']) . "</pubDate>\n";
-		$output .= "  </item>\n";
-	}
-	setlocale(LC_TIME, $old_locale);
-	$output .= " </channel>\n</rss>\n";
-	// Print output
-	print $output;
-	if (pluginGetVariable('rss_export', 'cache')) {
-		cacheStoreFile($cacheFileName, $output, 'rss_export');
-	}
+            return;
+        }
+    }
+    // Generate output
+    $output = plugin_rss_export_mk_header($xcat);
+    $limit = pluginGetVariable('rss_export', 'news_count');
+    $delay = intval(pluginGetVariable('rss_export', 'delay'));
+    if ((!is_numeric($limit)) || ($limit < 0) || ($limit > 500)) {
+        $limit = 50;
+    }
+    $old_locale = setlocale(LC_TIME, 0);
+    setlocale(LC_TIME, 'en_EN');
+    if (is_array($xcat)) {
+        $orderBy = ($xcat['orderby'] && in_array($xcat['orderby'], ['id desc', 'id asc', 'postdate desc', 'postdate asc', 'title desc', 'title asc'])) ? $xcat['orderby'] : 'id desc';
+        $query = 'select * from '.prefix."_news where catid regexp '[[:<:]](".$xcat['id'].")[[:>:]]' and approve=1 ".(($delay > 0) ? (' and ((postdate + '.intval($delay * 60).') < unix_timestamp(now())) ') : '').'order by '.$orderBy;
+    } else {
+        $query = 'select * from '.prefix.'_news where approve=1'.(($delay > 0) ? (' and ((postdate + '.intval($delay * 60).') < unix_timestamp(now())) ') : '').' order by id desc';
+    }
+    // Prepare hide template
+    if ($config['blocks_for_reg'] && pluginGetVariable('rss_export', 'use_hide')) {
+        LoadPluginLang('rss_export', 'main', '', 'rexport');
+        $hide_template = @file_get_contents(root.'plugins/rss_export/templates/hide.tpl');
+        $hide_template = str_replace('{text}', $lang['rexport_hide'], $hide_template);
+    }
+    // Fetch SQL record
+    $sqlData = $mysql->select($query." limit $limit");
+    // Check if enclosure is requested and used for "images" field
+    $xFList = [];
+    $encImages = [];
+    $enclosureIsImages = false;
+    if (pluginGetVariable('rss_export', 'xfEnclosureEnabled') && getPluginStatusActive('xfields')) {
+        $xFList = xf_configLoad();
+        $eFieldName = pluginGetVariable('rss_export', 'xfEnclosure');
+        if (isset($xFList['news'][$eFieldName]) && ($xFList['news'][$eFieldName]['type'] == 'images')) {
+            $enclosureIsImages = true;
+            // Prepare list of news with attached images
+            $nAList = [];
+            foreach ($sqlData as $row) {
+                if ($row['num_images'] > 0) {
+                    $nAList[] = $row['id'];
+                }
+            }
+            $iQuery = 'select * from '.prefix.'_images where (linked_ds = 1) and (linked_id in ('.implode(',', $nAList).")) and (plugin = 'xfields') and (pidentity = ".db_squote($eFieldName).')';
+            foreach ($mysql->select($iQuery) as $row) {
+                if (!isset($encImages[$row['linked_id']])) {
+                    $encImages[$row['linked_id']] = $row;
+                }
+            }
+        }
+    }
+    $truncateLen = intval(pluginGetVariable('rss_export', 'truncate'));
+    if ($truncateLen < 0) {
+        $truncateLen = 0;
+    }
+    foreach ($sqlData as $row) {
+        // Make standart system call in 'export' mode
+        $export_mode = 'export_body';
+        switch (pluginGetVariable('rss_export', 'content_show')) {
+            case '1':
+                $export_mode = 'export_short';
+                break;
+            case '2':
+                $export_mode = 'export_full';
+                break;
+        }
+        $content = news_showone($row['id'], '', ['emulate' => $row, 'style' => $export_mode, 'plugin' => 'rss_export']);
+        if ($truncateLen > 0) {
+            $content = $parse->truncateHTML($content, $truncateLen, '...');
+        }
+        $enclosure = '';
+        // Check if Enclosure `xfields` integration is activated
+        if (pluginGetVariable('rss_export', 'xfEnclosureEnabled') && (true || getPluginStatusActive('xfields'))) {
+            // Load (if needed XFIELDS plugin
+            include_once root.'/plugins/xfields/xfields.php';
+            if (is_array($xfd = xf_decode($row['xfields'])) && isset($xfd[pluginGetVariable('rss_export', 'xfEnclosure')])) {
+                // Check enclosure field type
+                if ($enclosureIsImages) {
+                    // images
+                    if (isset($encImages[$row['id']])) {
+                        $enclosure = ($encImages[$row['id']]['storage'] ? $config['attach_url'] : $config['images_url']).'/'.$encImages[$row['id']]['folder'].'/'.$encImages[$row['id']]['name'];
+                    }
+                } else {
+                    // text
+                    $enclosure = $xfd[pluginGetVariable('rss_export', 'xfEnclosure')];
+                }
+            }
+        }
+        $output .= "  <item>\n";
+        $output .= '   <title><![CDATA['.((pluginGetVariable('rss_export', 'news_title') == 1) && GetCategories($row['catid'], true) ? GetCategories($row['catid'], true).' :: ' : '').secure_html($row['title'])."]]></title>\n";
+        $output .= '   <link><![CDATA['.newsGenerateLink($row, false, 0, true)."]]></link>\n";
+        $output .= '   <description><![CDATA['.$content."]]></description>\n";
+        // Output enclosure URL (if configured & set
+        if ($enclosure != '') {
+            $output .= '   <enclosure url="'.$enclosure.'" />'."\n";
+        }
+        $output .= '   <category>'.GetCategories($row['catid'], true)."</category>\n";
+        $output .= '   <guid isPermaLink="false">'.home.'?id='.$row['id']."</guid>\n";
+        $output .= '   <pubDate>'.gmstrftime('%a, %d %b %Y %H:%M:%S GMT', $row['postdate'])."</pubDate>\n";
+        $output .= "  </item>\n";
+    }
+    setlocale(LC_TIME, $old_locale);
+    $output .= " </channel>\n</rss>\n";
+    // Print output
+    echo $output;
+    if (pluginGetVariable('rss_export', 'cache')) {
+        cacheStoreFile($cacheFileName, $output, 'rss_export');
+    }
 }
 
-function plugin_rss_export_mk_header($xcat) {
+function plugin_rss_export_mk_header($xcat)
+{
+    global $config;
+    $line = '<?xml version="1.0" encoding="windows-1251"?>'."\n";
+    $line .= ' <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:wfw="http://wellformedweb.org/CommentAPI/">'."\n";
+    $line .= " <channel>\n";
+    if (pluginGetVariable('rss_export', 'feed_title_format') == 'handy') {
+        $line .= '  <title><![CDATA['.pluginGetVariable('rss_export', 'feed_title_value')."]]></title>\n";
+    } elseif ((pluginGetVariable('rss_export', 'feed_title_format') == 'site_title') && is_array($xcat)) {
+        $line .= '  <title><![CDATA['.$config['home_title'].(is_array($xcat) ? ' :: '.$xcat['name'] : '')."]]></title>\n";
+    } else {
+        $line .= '  <title><![CDATA['.$config['home_title']."]]></title>\n";
+    }
+    $line .= '  <link><![CDATA['.$config['home_url']."]]></link>\n";
+    $line .= "  <language>ru</language>\n";
+    $line .= '  <description><![CDATA['.$config['description']."]]></description>\n";
+    $line .= '  <generator><![CDATA[Plugin RSS_EXPORT (0.07) // Next Generation CMS ('.engineVersion.")]]></generator>\n";
 
-	global $config;
-	$line = '<?xml version="1.0" encoding="windows-1251"?>' . "\n";
-	$line .= ' <rss version="2.0" xmlns:content="http://purl.org/rss/1.0/modules/content/" xmlns:wfw="http://wellformedweb.org/CommentAPI/">' . "\n";
-	$line .= " <channel>\n";
-	if (pluginGetVariable('rss_export', 'feed_title_format') == 'handy') {
-		$line .= "  <title><![CDATA[" . pluginGetVariable('rss_export', 'feed_title_value') . "]]></title>\n";
-	} else if ((pluginGetVariable('rss_export', 'feed_title_format') == 'site_title') && is_array($xcat)) {
-		$line .= "  <title><![CDATA[" . $config['home_title'] . (is_array($xcat) ? ' :: ' . $xcat['name'] : '') . "]]></title>\n";
-	} else {
-		$line .= "  <title><![CDATA[" . $config['home_title'] . "]]></title>\n";
-	}
-	$line .= "  <link><![CDATA[" . $config['home_url'] . "]]></link>\n";
-	$line .= "  <language>ru</language>\n";
-	$line .= "  <description><![CDATA[" . $config['description'] . "]]></description>\n";
-	$line .= "  <generator><![CDATA[Plugin RSS_EXPORT (0.07) // Next Generation CMS (" . engineVersion . ")]]></generator>\n";
-
-	return $line;
+    return $line;
 }

--- a/show_comments/config.php
+++ b/show_comments/config.php
@@ -17,192 +17,202 @@
 
 
 <?php
-function show_comments() {
-
-	global $mysql, $config, $parse;
-	$perpage = extra_get_param('show_comments', 'perpage');
-	if ($perpage == '') {
-		$perpage = "5";
-	}
-	$order = extra_get_param('show_comments', 'order');
-	if ($order == 'desc') {
-		$order = "DESC";
-	} elseif ($order == 'asc') {
-		$order = "ASC";
-	} else {
-		$order = "ASC";
-	}
-	$comm_length = extra_get_param('show_comments', 'comm_length');
-	if (($comm_length < 10) || ($comm_length > 5000)) {
-		$comm_length = 50;
-	}
-	// Выбираем из БД общее количество записей
-	$query = "SELECT COUNT(*) as cnt FROM " . prefix . "_comments";
-	$res = $mysql->record($query, 1);
-	$total = $res['cnt'];
-	// Проверяем передан ли номер текущей страницы
-	if (isset($_GET['page'])) {
-		$page = (int)$_GET['page'];
-		if ($page < 1) $page = 1;
-	} else {
-		$page = 1;
-	}
-	// Сколько всего получится страниц
-	$cnt_pages = ceil($total / $perpage);
-	if ($page > $cnt_pages) $page = $cnt_pages;
-	// Начальная позиция
-	$start = ($page - 1) * $perpage;
-	if ($start < 0) {
-		$start = 0;
-	}
-	$query = "select c.id, c.postdate, c.author, c.author_id, c.mail, c.text, c.ip, n.id as nid, n.title, n.alt_name, n.catid, n.postdate as npostdate from " . prefix . "_comments c left join " . prefix . "_news n on c.post=n.id where n.approve=1 order by c.id " . $order . " limit " . $start . ", " . $perpage;
-	$result = $mysql->select($query);
-	// Выводим "шапку" таблицы
-	echo '<form action="" method="post" name="select_comments"><div id=ttr>';
-	echo '<table><tbody>';
-	echo '<tr>';
-	echo '<th>Дата</th>';
-	echo '<th>Комментарий</th>';
-	echo '<th>Новость</th>';
-	echo '<th style="width:14%;">Автор</th>';
-	echo '<th style="width:13%;">IP</th>';
-	echo '<th><input type="checkbox" name="master_box" title="Выбрать все" onclick="javascript:check_uncheck_all(select_comments)" ></th>';
-	echo '</tr>';
-	foreach ($result as $prd) {
-		// Parse comments
-		$text = $prd['text'];
-		if ($config['blocks_for_reg']) {
-			$text = $parse->userblocks($text);
-		}
-		if ($config['use_bbcodes']) {
-			$text = $parse->bbcodes($text);
-		}
-		if ($config['use_htmlformatter']) {
-			$text = $parse->htmlformatter($text);
-		}
-		if ($config['use_smilies']) {
-			$text = $parse->smilies($text);
-		}
-		if (strlen($text) > $comm_length) {
-			$text = $parse->truncateHTML($text, $comm_length);
-		}
-		if ($prd['author_id'] && getPluginStatusActive('uprofile')) {
-			$author_link = checkLinkAvailable('uprofile', 'show') ?
-				generateLink('uprofile', 'show', array('name' => $prd['author'], 'id' => $prd['author_id'])) :
-				generateLink('core', 'plugin', array('plugin' => 'uprofile', 'handler' => 'show'), array('id' => $prd['author_id']));
-			$tvars['regx']["'\[profile\](.*?)\[/profile\]'si"] = '$1';
-		} else {
-			$author_link = '';
-		}
-		echo '<tr>';
-		echo '<th>' . langdate('d.m.Y H:i:s', $prd['postdate']) . ' [<a href="/engine/admin.php?mod=editcomments&newsid=' . $prd['nid'] . '&comid=' . $prd['id'] . '" target="_blank">#</a>] [<a href="/engine/admin.php?mod=editcomments&subaction=deletecomment&newsid=' . $prd['nid'] . '&comid=' . $prd['id'] . '&poster=' . $prd['author'] . '" target="_blank">X</a>]</th>';
-		echo '<th>' . $text . '</th>';
-		echo '<th><a href="' . newsGenerateLink(array('id' => $prd['nid'], 'alt_name' => $prd['alt_name'], 'catid' => $prd['catid'], 'postdate' => $prd['npostdate'])) . '" target="_blank">' . str_replace('<', '&lt;', $prd['title']) . '</a> [<a href="/engine/admin.php?mod=news&action=edit&id=' . $prd['nid'] . '" target="_blank">E</a>]</th>';
-		if ($prd['author_id']) {
-			echo '<th><a href="/engine/admin.php?mod=users&action=editForm&id=' . $prd['author_id'] . '" target="_blank">' . str_replace('<', '&lt;', $prd['author']) . '</a><br/><small><a href="mailto:' . $prd['mail'] . '">' . $prd['mail'] . '</a></small></th>';
-		} else {
-			echo '<th>' . str_replace('<', '&lt;', $prd['author']) . '<br/><small><a href="mailto:' . $prd['mail'] . '">' . $prd['mail'] . '</a></small></th>';
-		}
-		echo '<th>[<a href="/engine/admin.php?mod=ipban&iplock=' . $prd['ip'] . '" target="_blank">' . $prd['ip'] . '</a>] [<a href="http://www.nic.ru/whois/?ip=' . $prd['ip'] . '" target="_blank">W</a>]</th>';
-		echo '<th><input type="checkbox" name="type[]" value="' . $prd['id'] . '"></th>';
-		echo '</tr>';
-	}
-	echo '</tbody></table></div>';
-	echo '<script>$("tr:odd").css("background-color", "#f7fbff");</script>';
-	$type = $_POST['type'];
-	if (!empty($type)) {
-		// Начинаем формировать переменную, содержащую список
-		// в формате "(3,5,6,7)"
-		$query = "(";
-		foreach ($type as $val) $query .= "$val,";
-		// Удаляем последнюю запятую, заменяя её закрывающей скобкой )
-		$query = substr($query, 0, strlen($query) - 1) . ")";
-		// Завершаем формирование SQL-запроса на удаление
-		$query = "DELETE FROM " . prefix . "_comments WHERE id IN " . $query;
-		// Выполняем запрос
-		if (!$mysql->query($query)) {
-			echo "<br>" . $mysql->db_error() . "<br>";
-			echo $query . "<br>";
-		} else {
-			foreach ($mysql->select("select n.id, count(c.id) as cid from " . prefix . "_news n left join " . prefix . "_comments c on c.post=n.id group by n.id") as $row) {
-				$mysql->query("update " . prefix . "_news set com=" . $row['cid'] . " where id = " . $row['id']);
-			}
-			// Обновляем счетчик постов у юзеров
-			foreach ($mysql->select("select author_id, count(*) as cnt from " . prefix . "_news group by author_id") as $row) {
-				$mysql->query("update " . uprefix . "_users set news=" . $row['cnt'] . " where id = " . $row['author_id']);
-			}
-			foreach ($mysql->select("select n.id, count(c.id) as cid from " . prefix . "_news n left join " . prefix . "_comments c on c.post=n.id group by n.id") as $row) {
-				$mysql->query("update " . prefix . "_news set com=" . $row['cid'] . " where id = " . $row['id']);
-			}
-			// Обновляем счетчик комментариев у юзеров
-			foreach ($mysql->select("select author_id, count(*) as cnt from " . prefix . "_comments group by author_id") as $row) {
-				$mysql->query("update " . uprefix . "_users set com=" . $row['cnt'] . " where id = " . $row['author_id']);
-			}
-			echo "<META HTTP-EQUIV='Refresh' Content='0'>";
-		}
-	}
-	$uri = strtok($_SERVER['REQUEST_URI'], "?") . "?";
-	if (count($_GET)) {
-		foreach ($_GET as $k => $v) {
-			if ($k != "page") $uri .= urlencode($k) . "=" . urlencode($v) . "&";
-		}
-	}
-	// Строим постраничную навигацию
-	if ($cnt_pages > 1) {
-		//   echo '<div style="margin:1em 0">&nbsp;Страницы:';
-		// Проверяем нужна ли стрелка "В начало"
-		if ($page > 3)
-			$startpage = '<a href="' . $uri . 'page=1"><</a> .. ';
-		else
-			$startpage = '';
-		// Проверяем нужна ли стрелка "В конец"
-		if ($page < ($cnt_pages - 2))
-			$endpage = ' .. <a href="' . $uri . 'page=' . $cnt_pages . '">></a>';
-		else
-			$endpage = '';
-		// Находим две ближайшие станицы с обоих краев, если они есть
-		if ($page - 2 > 0)
-			$page2left = ' <a href="' . $uri . 'page=' . ($page - 2) . '">' . ($page - 2) . '</a> | ';
-		else
-			$page2left = '';
-		if ($page - 1 > 0)
-			$page1left = ' <a href="' . $uri . 'page=' . ($page - 1) . '">' . ($page - 1) . '</a> | ';
-		else
-			$page1left = '';
-		if ($page + 2 <= $cnt_pages)
-			$page2right = ' | <a href="' . $uri . 'page=' . ($page + 2) . '">' . ($page + 2) . '</a>';
-		else
-			$page2right = '';
-		if ($page + 1 <= $cnt_pages)
-			$page1right = ' | <a href="' . $uri . 'page=' . ($page + 1) . '">' . ($page + 1) . '</a>';
-		else
-			$page1right = '';
-		// Выводим меню
-		// echo $startpage.$page2left.$page1left.'<strong>'.$page.'</strong>'.$page1right.$page2right.$endpage;
-		echo '</div>';
-	}
-	echo '<table><tr><td>' . $startpage . $page2left . $page1left . '<strong>' . $page . '</strong>' . $page1right . $page2right . $endpage . '&nbsp;&nbsp;&nbsp;&nbsp;</td><td style="align:right"><input class="button" type="submit" value="Удалить"></td></tr></table></form>';
+function show_comments()
+{
+    global $mysql, $config, $parse;
+    $perpage = extra_get_param('show_comments', 'perpage');
+    if ($perpage == '') {
+        $perpage = '5';
+    }
+    $order = extra_get_param('show_comments', 'order');
+    if ($order == 'desc') {
+        $order = 'DESC';
+    } elseif ($order == 'asc') {
+        $order = 'ASC';
+    } else {
+        $order = 'ASC';
+    }
+    $comm_length = extra_get_param('show_comments', 'comm_length');
+    if (($comm_length < 10) || ($comm_length > 5000)) {
+        $comm_length = 50;
+    }
+    // Выбираем из БД общее количество записей
+    $query = 'SELECT COUNT(*) as cnt FROM '.prefix.'_comments';
+    $res = $mysql->record($query, 1);
+    $total = $res['cnt'];
+    // Проверяем передан ли номер текущей страницы
+    if (isset($_GET['page'])) {
+        $page = (int) $_GET['page'];
+        if ($page < 1) {
+            $page = 1;
+        }
+    } else {
+        $page = 1;
+    }
+    // Сколько всего получится страниц
+    $cnt_pages = ceil($total / $perpage);
+    if ($page > $cnt_pages) {
+        $page = $cnt_pages;
+    }
+    // Начальная позиция
+    $start = ($page - 1) * $perpage;
+    if ($start < 0) {
+        $start = 0;
+    }
+    $query = 'select c.id, c.postdate, c.author, c.author_id, c.mail, c.text, c.ip, n.id as nid, n.title, n.alt_name, n.catid, n.postdate as npostdate from '.prefix.'_comments c left join '.prefix.'_news n on c.post=n.id where n.approve=1 order by c.id '.$order.' limit '.$start.', '.$perpage;
+    $result = $mysql->select($query);
+    // Выводим "шапку" таблицы
+    echo '<form action="" method="post" name="select_comments"><div id=ttr>';
+    echo '<table><tbody>';
+    echo '<tr>';
+    echo '<th>Дата</th>';
+    echo '<th>Комментарий</th>';
+    echo '<th>Новость</th>';
+    echo '<th style="width:14%;">Автор</th>';
+    echo '<th style="width:13%;">IP</th>';
+    echo '<th><input type="checkbox" name="master_box" title="Выбрать все" onclick="javascript:check_uncheck_all(select_comments)" ></th>';
+    echo '</tr>';
+    foreach ($result as $prd) {
+        // Parse comments
+        $text = $prd['text'];
+        if ($config['blocks_for_reg']) {
+            $text = $parse->userblocks($text);
+        }
+        if ($config['use_bbcodes']) {
+            $text = $parse->bbcodes($text);
+        }
+        if ($config['use_htmlformatter']) {
+            $text = $parse->htmlformatter($text);
+        }
+        if ($config['use_smilies']) {
+            $text = $parse->smilies($text);
+        }
+        if (strlen($text) > $comm_length) {
+            $text = $parse->truncateHTML($text, $comm_length);
+        }
+        if ($prd['author_id'] && getPluginStatusActive('uprofile')) {
+            $author_link = checkLinkAvailable('uprofile', 'show') ?
+                generateLink('uprofile', 'show', ['name' => $prd['author'], 'id' => $prd['author_id']]) :
+                generateLink('core', 'plugin', ['plugin' => 'uprofile', 'handler' => 'show'], ['id' => $prd['author_id']]);
+            $tvars['regx']["'\[profile\](.*?)\[/profile\]'si"] = '$1';
+        } else {
+            $author_link = '';
+        }
+        echo '<tr>';
+        echo '<th>'.langdate('d.m.Y H:i:s', $prd['postdate']).' [<a href="/engine/admin.php?mod=editcomments&newsid='.$prd['nid'].'&comid='.$prd['id'].'" target="_blank">#</a>] [<a href="/engine/admin.php?mod=editcomments&subaction=deletecomment&newsid='.$prd['nid'].'&comid='.$prd['id'].'&poster='.$prd['author'].'" target="_blank">X</a>]</th>';
+        echo '<th>'.$text.'</th>';
+        echo '<th><a href="'.newsGenerateLink(['id' => $prd['nid'], 'alt_name' => $prd['alt_name'], 'catid' => $prd['catid'], 'postdate' => $prd['npostdate']]).'" target="_blank">'.str_replace('<', '&lt;', $prd['title']).'</a> [<a href="/engine/admin.php?mod=news&action=edit&id='.$prd['nid'].'" target="_blank">E</a>]</th>';
+        if ($prd['author_id']) {
+            echo '<th><a href="/engine/admin.php?mod=users&action=editForm&id='.$prd['author_id'].'" target="_blank">'.str_replace('<', '&lt;', $prd['author']).'</a><br/><small><a href="mailto:'.$prd['mail'].'">'.$prd['mail'].'</a></small></th>';
+        } else {
+            echo '<th>'.str_replace('<', '&lt;', $prd['author']).'<br/><small><a href="mailto:'.$prd['mail'].'">'.$prd['mail'].'</a></small></th>';
+        }
+        echo '<th>[<a href="/engine/admin.php?mod=ipban&iplock='.$prd['ip'].'" target="_blank">'.$prd['ip'].'</a>] [<a href="http://www.nic.ru/whois/?ip='.$prd['ip'].'" target="_blank">W</a>]</th>';
+        echo '<th><input type="checkbox" name="type[]" value="'.$prd['id'].'"></th>';
+        echo '</tr>';
+    }
+    echo '</tbody></table></div>';
+    echo '<script>$("tr:odd").css("background-color", "#f7fbff");</script>';
+    $type = $_POST['type'];
+    if (!empty($type)) {
+        // Начинаем формировать переменную, содержащую список
+        // в формате "(3,5,6,7)"
+        $query = '(';
+        foreach ($type as $val) {
+            $query .= "$val,";
+        }
+        // Удаляем последнюю запятую, заменяя её закрывающей скобкой )
+        $query = substr($query, 0, strlen($query) - 1).')';
+        // Завершаем формирование SQL-запроса на удаление
+        $query = 'DELETE FROM '.prefix.'_comments WHERE id IN '.$query;
+        // Выполняем запрос
+        if (!$mysql->query($query)) {
+            echo '<br>'.$mysql->db_error().'<br>';
+            echo $query.'<br>';
+        } else {
+            foreach ($mysql->select('select n.id, count(c.id) as cid from '.prefix.'_news n left join '.prefix.'_comments c on c.post=n.id group by n.id') as $row) {
+                $mysql->query('update '.prefix.'_news set com='.$row['cid'].' where id = '.$row['id']);
+            }
+            // Обновляем счетчик постов у юзеров
+            foreach ($mysql->select('select author_id, count(*) as cnt from '.prefix.'_news group by author_id') as $row) {
+                $mysql->query('update '.uprefix.'_users set news='.$row['cnt'].' where id = '.$row['author_id']);
+            }
+            foreach ($mysql->select('select n.id, count(c.id) as cid from '.prefix.'_news n left join '.prefix.'_comments c on c.post=n.id group by n.id') as $row) {
+                $mysql->query('update '.prefix.'_news set com='.$row['cid'].' where id = '.$row['id']);
+            }
+            // Обновляем счетчик комментариев у юзеров
+            foreach ($mysql->select('select author_id, count(*) as cnt from '.prefix.'_comments group by author_id') as $row) {
+                $mysql->query('update '.uprefix.'_users set com='.$row['cnt'].' where id = '.$row['author_id']);
+            }
+            echo "<META HTTP-EQUIV='Refresh' Content='0'>";
+        }
+    }
+    $uri = strtok($_SERVER['REQUEST_URI'], '?').'?';
+    if (count($_GET)) {
+        foreach ($_GET as $k => $v) {
+            if ($k != 'page') {
+                $uri .= urlencode($k).'='.urlencode($v).'&';
+            }
+        }
+    }
+    // Строим постраничную навигацию
+    if ($cnt_pages > 1) {
+        //   echo '<div style="margin:1em 0">&nbsp;Страницы:';
+        // Проверяем нужна ли стрелка "В начало"
+        if ($page > 3) {
+            $startpage = '<a href="'.$uri.'page=1"><</a> .. ';
+        } else {
+            $startpage = '';
+        }
+        // Проверяем нужна ли стрелка "В конец"
+        if ($page < ($cnt_pages - 2)) {
+            $endpage = ' .. <a href="'.$uri.'page='.$cnt_pages.'">></a>';
+        } else {
+            $endpage = '';
+        }
+        // Находим две ближайшие станицы с обоих краев, если они есть
+        if ($page - 2 > 0) {
+            $page2left = ' <a href="'.$uri.'page='.($page - 2).'">'.($page - 2).'</a> | ';
+        } else {
+            $page2left = '';
+        }
+        if ($page - 1 > 0) {
+            $page1left = ' <a href="'.$uri.'page='.($page - 1).'">'.($page - 1).'</a> | ';
+        } else {
+            $page1left = '';
+        }
+        if ($page + 2 <= $cnt_pages) {
+            $page2right = ' | <a href="'.$uri.'page='.($page + 2).'">'.($page + 2).'</a>';
+        } else {
+            $page2right = '';
+        }
+        if ($page + 1 <= $cnt_pages) {
+            $page1right = ' | <a href="'.$uri.'page='.($page + 1).'">'.($page + 1).'</a>';
+        } else {
+            $page1right = '';
+        }
+        // Выводим меню
+        // echo $startpage.$page2left.$page1left.'<strong>'.$page.'</strong>'.$page1right.$page2right.$endpage;
+        echo '</div>';
+    }
+    echo '<table><tr><td>'.$startpage.$page2left.$page1left.'<strong>'.$page.'</strong>'.$page1right.$page2right.$endpage.'&nbsp;&nbsp;&nbsp;&nbsp;</td><td style="align:right"><input class="button" type="submit" value="Удалить"></td></tr></table></form>';
 }
 
 if (!getPluginStatusInstalled('comments')) {
-	echo 'Плагин comments не установлен!';
+    echo 'Плагин comments не установлен!';
 
-	return false;
+    return false;
 }
 plugins_load_config();
-$cfg = array();
-array_push($cfg, array('descr' => 'Плагин выводит список всех комментариев на сайте.'));
-array_push($cfg, array('name' => 'perpage', 'title' => 'Кол-во комментариев для отображения на одной странице', 'type' => 'input', 'value' => extra_get_param($plugin, 'perpage')));
-array_push($cfg, array('name' => 'comm_length', 'title' => 'Усечение длины комментария', 'descr' => 'Кол-во символов из комментария для отображения<br/>Значение по умолчанию: <b>50</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => extra_get_param($plugin, 'comm_length')));
-array_push($cfg, array('name' => 'order', 'title' => 'Упорядочить по:', 'descr' => 'Выберите порядок отображения комментариев.', 'type' => 'select', 'values' => array('asc' => 'Возрастанию', 'desc' => 'Убыванию'), 'value' => extra_get_param($plugin, 'order')));
+$cfg = [];
+array_push($cfg, ['descr' => 'Плагин выводит список всех комментариев на сайте.']);
+array_push($cfg, ['name' => 'perpage', 'title' => 'Кол-во комментариев для отображения на одной странице', 'type' => 'input', 'value' => extra_get_param($plugin, 'perpage')]);
+array_push($cfg, ['name' => 'comm_length', 'title' => 'Усечение длины комментария', 'descr' => 'Кол-во символов из комментария для отображения<br/>Значение по умолчанию: <b>50</b>', 'type' => 'input', 'html_flags' => 'size=5', 'value' => extra_get_param($plugin, 'comm_length')]);
+array_push($cfg, ['name' => 'order', 'title' => 'Упорядочить по:', 'descr' => 'Выберите порядок отображения комментариев.', 'type' => 'select', 'values' => ['asc' => 'Возрастанию', 'desc' => 'Убыванию'], 'value' => extra_get_param($plugin, 'order')]);
 if ($_REQUEST['action'] == 'commit') {
-	commit_plugin_config_changes($plugin, $cfg);
-	print_commit_complete('show_comments');
+    commit_plugin_config_changes($plugin, $cfg);
+    print_commit_complete('show_comments');
 } else {
-	show_comments();
-	generate_config_page('show_comments', $cfg);
+    show_comments();
+    generate_config_page('show_comments', $cfg);
 }
-
-	
-
-

--- a/subscribe_comments/config.php
+++ b/subscribe_comments/config.php
@@ -1,6 +1,7 @@
 <?php
+
 if (!defined('NGCMS')) {
-	exit('HAL');
+    exit('HAL');
 }
 plugins_load_config();
 LoadPluginLang('subscribe_comments', 'config', '', '', '#');
@@ -8,225 +9,241 @@ $get_params = parse_url($_SERVER['HTTP_REFERER']);
 $get_params = $get_params['query'];
 parse_str($get_params, $get_params);
 switch ($_REQUEST['action']) {
-	case 'list_subscribe':
-		show_list_subscribe();
-		break;
-	case 'list_subscribe_post':
-		show_list_subscribe_post();
-		break;
-	case 'edit_subscribe':
-		edit_subscribe();
-		break;
-	case 'modify':
-		modify();
-		if ($get_params['action'] == 'list_subscribe') show_list_subscribe(); else show_list_subscribe_post();
-		break;
-	default:
-		main();
+    case 'list_subscribe':
+        show_list_subscribe();
+        break;
+    case 'list_subscribe_post':
+        show_list_subscribe_post();
+        break;
+    case 'edit_subscribe':
+        edit_subscribe();
+        break;
+    case 'modify':
+        modify();
+        if ($get_params['action'] == 'list_subscribe') {
+            show_list_subscribe();
+        } else {
+            show_list_subscribe_post();
+        }
+        break;
+    default:
+        main();
 }
-function show_list_subscribe() {
-
-	global $tpl, $mysql, $lang, $config;
-	$tpath = locatePluginTemplates(array('config/main', 'config/list_subscribe', 'config/list_entries'), 'subscribe_comments', 1);
-	$news_per_page = pluginGetVariable('subscribe_comments', 'admin_count');
-	if (($news_per_page < 2) || ($news_per_page > 2000)) $news_per_page = 2;
-	$pageNo = intval($_REQUEST['page']) ? $_REQUEST['page'] : 0;
-	if ($pageNo < 1) $pageNo = 1;
-	if (!$start_from) $start_from = ($pageNo - 1) * $news_per_page;
-	$count = $mysql->result('SELECT count(id) from ' . prefix . '_subscribe_comments');
-	$countPages = ceil($count / $news_per_page);
-	foreach ($mysql->select('SELECT *, c.id as nid from ' . prefix . '_subscribe_comments AS c left join ' . prefix . '_news AS s on c.news_id=s.id ORDER BY c.id DESC LIMIT ' . $start_from . ', ' . $news_per_page) as $row) {
-		$url = admin_url . "/admin.php?mod=news&amp;action=edit&amp;id=" . $row['news_id'];
-		$gvars['vars'] = array(
-			'id'        => $row['nid'],
-			'page_name' => $row['title'],
-			'page_url'  => $url,
-			'email'     => $row['user_email'],
-		);
-		$tpl->template('list_entries', $tpath['config/list_entries'] . 'config');
-		$tpl->vars('list_entries', $gvars);
-		$entries .= $tpl->show('list_entries');
-	}
-	$delayed_send = pluginGetVariable('subscribe_comments', 'delayed_send');
-	if ($delayed_send == 1) {
-		$tvars['regx']["'\[hide_delayed\](.*?)\[/hide_delayed\]'si"] = '$1';
-	} else {
-		$tvars['regx']["'\[hide_delayed\](.*?)\[/hide_delayed\]'si"] = '';
-	}
-	$pvars['vars']['pagesss'] = generateAdminPagelist(array('current' => $pageNo, 'count' => $countPages, 'url' => admin_url . '/admin.php?mod=extra-config&plugin=subscribe_comments&action=list_subscribe' . ($_REQUEST['news_per_page'] ? '&news_per_page=' . $news_per_page : '') . ($_REQUEST['author'] ? '&author=' . $_REQUEST['author'] : '') . ($_REQUEST['sort'] ? '&sort=' . $_REQUEST['sort'] : '') . ($postdate ? '&postdate=' . $postdate : '') . ($author ? '&author=' . $author : '') . ($status ? '&status=' . $status : '') . '&page=%page%'));
-	$pvars['vars']['entries'] = $entries;
-	$tpl->template('list_subscribe', $tpath['config/list_subscribe'] . 'config');
-	$tpl->vars('list_subscribe', $pvars);
-	$tvars['vars'] = array(
-		'entries_cron' => '',
-		'entries'      => $tpl->show('list_subscribe'),
-		'global'       => 'Список подписок'
-	);
-	$tpl->template('main', $tpath['config/main'] . 'config');
-	$tpl->vars('main', $tvars);
-	print $tpl->show('main');
-}
-
-function show_list_subscribe_post() {
-
-	global $tpl, $mysql, $lang, $config;
-	$tpath = locatePluginTemplates(array('config/main', 'config/list_subscribe_post', 'config/list_entries_post'), 'subscribe_comments', 1);
-	$news_per_page = pluginGetVariable('subscribe_comments', 'admin_count');
-	if (($news_per_page < 2) || ($news_per_page > 2000)) $news_per_page = 2;
-	$pageNo = intval($_REQUEST['page']) ? $_REQUEST['page'] : 0;
-	if ($pageNo < 1) $pageNo = 1;
-	if (!$start_from) $start_from = ($pageNo - 1) * $news_per_page;
-	$count = $mysql->result('SELECT count(id) from ' . prefix . '_subscribe_comments_temp');
-	$countPages = ceil($count / $news_per_page);
-	foreach ($mysql->select('SELECT * from ' . prefix . '_subscribe_comments_temp ORDER BY id DESC LIMIT ' . $start_from . ', ' . $news_per_page) as $row) {
-		$url = admin_url . "/admin.php?mod=news&amp;action=edit&amp;id=" . $row['news_id'];
-		$gvars['vars'] = array(
-			'id'        => $row['id'],
-			'page_name' => $row['news_title'],
-			'page_url'  => $url,
-			'com_text'  => $row['com_text'],
-			'email'     => $row['user_email'],
-		);
-		$tpl->template('list_entries_post', $tpath['config/list_entries_post'] . 'config');
-		$tpl->vars('list_entries_post', $gvars);
-		$entries .= $tpl->show('list_entries_post');
-	}
-	$delayed_send = pluginGetVariable('subscribe_comments', 'delayed_send');
-	if ($delayed_send == 1) {
-		$tvars['regx']["'\[hide_delayed\](.*?)\[/hide_delayed\]'si"] = '$1';
-	} else {
-		$tvars['regx']["'\[hide_delayed\](.*?)\[/hide_delayed\]'si"] = '';
-	}
-	$pvars['vars']['pagesss'] = generateAdminPagelist(array('current' => $pageNo, 'count' => $countPages, 'url' => admin_url . '/admin.php?mod=extra-config&plugin=subscribe_comments&action=list_subscribe_post' . ($_REQUEST['news_per_page'] ? '&news_per_page=' . $news_per_page : '') . ($_REQUEST['author'] ? '&author=' . $_REQUEST['author'] : '') . ($_REQUEST['sort'] ? '&sort=' . $_REQUEST['sort'] : '') . ($postdate ? '&postdate=' . $postdate : '') . ($author ? '&author=' . $author : '') . ($status ? '&status=' . $status : '') . '&page=%page%'));
-	$pvars['vars']['entries'] = $entries;
-	$tpl->template('list_subscribe_post', $tpath['config/list_subscribe_post'] . 'config');
-	$tpl->vars('list_subscribe_post', $pvars);
-	$tvars['vars'] = array(
-		'entries_cron' => '',
-		'entries'      => $tpl->show('list_subscribe_post'),
-		'global'       => 'Сформированные письма'
-	);
-	$tpl->template('main', $tpath['config/main'] . 'config');
-	$tpl->vars('main', $tvars);
-	print $tpl->show('main');
+function show_list_subscribe()
+{
+    global $tpl, $mysql, $lang, $config;
+    $tpath = locatePluginTemplates(['config/main', 'config/list_subscribe', 'config/list_entries'], 'subscribe_comments', 1);
+    $news_per_page = pluginGetVariable('subscribe_comments', 'admin_count');
+    if (($news_per_page < 2) || ($news_per_page > 2000)) {
+        $news_per_page = 2;
+    }
+    $pageNo = intval($_REQUEST['page']) ? $_REQUEST['page'] : 0;
+    if ($pageNo < 1) {
+        $pageNo = 1;
+    }
+    if (!$start_from) {
+        $start_from = ($pageNo - 1) * $news_per_page;
+    }
+    $count = $mysql->result('SELECT count(id) from '.prefix.'_subscribe_comments');
+    $countPages = ceil($count / $news_per_page);
+    foreach ($mysql->select('SELECT *, c.id as nid from '.prefix.'_subscribe_comments AS c left join '.prefix.'_news AS s on c.news_id=s.id ORDER BY c.id DESC LIMIT '.$start_from.', '.$news_per_page) as $row) {
+        $url = admin_url.'/admin.php?mod=news&amp;action=edit&amp;id='.$row['news_id'];
+        $gvars['vars'] = [
+            'id'        => $row['nid'],
+            'page_name' => $row['title'],
+            'page_url'  => $url,
+            'email'     => $row['user_email'],
+        ];
+        $tpl->template('list_entries', $tpath['config/list_entries'].'config');
+        $tpl->vars('list_entries', $gvars);
+        $entries .= $tpl->show('list_entries');
+    }
+    $delayed_send = pluginGetVariable('subscribe_comments', 'delayed_send');
+    if ($delayed_send == 1) {
+        $tvars['regx']["'\[hide_delayed\](.*?)\[/hide_delayed\]'si"] = '$1';
+    } else {
+        $tvars['regx']["'\[hide_delayed\](.*?)\[/hide_delayed\]'si"] = '';
+    }
+    $pvars['vars']['pagesss'] = generateAdminPagelist(['current' => $pageNo, 'count' => $countPages, 'url' => admin_url.'/admin.php?mod=extra-config&plugin=subscribe_comments&action=list_subscribe'.($_REQUEST['news_per_page'] ? '&news_per_page='.$news_per_page : '').($_REQUEST['author'] ? '&author='.$_REQUEST['author'] : '').($_REQUEST['sort'] ? '&sort='.$_REQUEST['sort'] : '').($postdate ? '&postdate='.$postdate : '').($author ? '&author='.$author : '').($status ? '&status='.$status : '').'&page=%page%']);
+    $pvars['vars']['entries'] = $entries;
+    $tpl->template('list_subscribe', $tpath['config/list_subscribe'].'config');
+    $tpl->vars('list_subscribe', $pvars);
+    $tvars['vars'] = [
+        'entries_cron' => '',
+        'entries'      => $tpl->show('list_subscribe'),
+        'global'       => 'Список подписок',
+    ];
+    $tpl->template('main', $tpath['config/main'].'config');
+    $tpl->vars('main', $tvars);
+    echo $tpl->show('main');
 }
 
-function modify() {
-
-	global $mysql;
-	$selected_news = $_REQUEST['selected_subscribe_comments'];
-	$subaction = $_REQUEST['subaction'];
-	$id = implode(',', $selected_news);
-	if (empty($id)) {
-		return msg(array("type" => "error", "text" => "Вы не выбрали объектов"));
-	}
-	switch ($subaction) {
-		case 'mass_delete'       :
-			$del = true;
-			break;
-		case 'mass_delete_post'       :
-			$del_post = true;
-			break;
-	}
-	if (isset($del)) {
-		$mysql->query("delete from " . prefix . "_subscribe_comments where id in ({$id})");
-		msg(array("type" => "info", "info" => "Подписки с ID${id} удалены"));
-	}
-	if (isset($del_post)) {
-		$mysql->query("delete from " . prefix . "_subscribe_comments_temp where id in ({$id})");
-		msg(array("type" => "info", "info" => "Пиьсма с ID${id} удалены"));
-	}
+function show_list_subscribe_post()
+{
+    global $tpl, $mysql, $lang, $config;
+    $tpath = locatePluginTemplates(['config/main', 'config/list_subscribe_post', 'config/list_entries_post'], 'subscribe_comments', 1);
+    $news_per_page = pluginGetVariable('subscribe_comments', 'admin_count');
+    if (($news_per_page < 2) || ($news_per_page > 2000)) {
+        $news_per_page = 2;
+    }
+    $pageNo = intval($_REQUEST['page']) ? $_REQUEST['page'] : 0;
+    if ($pageNo < 1) {
+        $pageNo = 1;
+    }
+    if (!$start_from) {
+        $start_from = ($pageNo - 1) * $news_per_page;
+    }
+    $count = $mysql->result('SELECT count(id) from '.prefix.'_subscribe_comments_temp');
+    $countPages = ceil($count / $news_per_page);
+    foreach ($mysql->select('SELECT * from '.prefix.'_subscribe_comments_temp ORDER BY id DESC LIMIT '.$start_from.', '.$news_per_page) as $row) {
+        $url = admin_url.'/admin.php?mod=news&amp;action=edit&amp;id='.$row['news_id'];
+        $gvars['vars'] = [
+            'id'        => $row['id'],
+            'page_name' => $row['news_title'],
+            'page_url'  => $url,
+            'com_text'  => $row['com_text'],
+            'email'     => $row['user_email'],
+        ];
+        $tpl->template('list_entries_post', $tpath['config/list_entries_post'].'config');
+        $tpl->vars('list_entries_post', $gvars);
+        $entries .= $tpl->show('list_entries_post');
+    }
+    $delayed_send = pluginGetVariable('subscribe_comments', 'delayed_send');
+    if ($delayed_send == 1) {
+        $tvars['regx']["'\[hide_delayed\](.*?)\[/hide_delayed\]'si"] = '$1';
+    } else {
+        $tvars['regx']["'\[hide_delayed\](.*?)\[/hide_delayed\]'si"] = '';
+    }
+    $pvars['vars']['pagesss'] = generateAdminPagelist(['current' => $pageNo, 'count' => $countPages, 'url' => admin_url.'/admin.php?mod=extra-config&plugin=subscribe_comments&action=list_subscribe_post'.($_REQUEST['news_per_page'] ? '&news_per_page='.$news_per_page : '').($_REQUEST['author'] ? '&author='.$_REQUEST['author'] : '').($_REQUEST['sort'] ? '&sort='.$_REQUEST['sort'] : '').($postdate ? '&postdate='.$postdate : '').($author ? '&author='.$author : '').($status ? '&status='.$status : '').'&page=%page%']);
+    $pvars['vars']['entries'] = $entries;
+    $tpl->template('list_subscribe_post', $tpath['config/list_subscribe_post'].'config');
+    $tpl->vars('list_subscribe_post', $pvars);
+    $tvars['vars'] = [
+        'entries_cron' => '',
+        'entries'      => $tpl->show('list_subscribe_post'),
+        'global'       => 'Сформированные письма',
+    ];
+    $tpl->template('main', $tpath['config/main'].'config');
+    $tpl->vars('main', $tvars);
+    echo $tpl->show('main');
 }
 
-function main() {
-
-	global $tpl, $mysql, $config, $template, $cron;
-	$tpath = locatePluginTemplates(array('config/main', 'config/general.from', 'config/list_entries_cron', 'config/list_subscribe_cron'), 'subscribe_comments', 1);
-	$delayed_send = pluginGetVariable('subscribe_comments', 'delayed_send');
-	if ($delayed_send == 1) {
-		if ($config['syslog'] == '1') {
-			foreach ($mysql->select('SELECT * from ' . prefix . '_syslog where action = "subscribe_comments" ORDER BY id DESC LIMIT 5') as $row) {
-				$gvars['vars'] = array(
-					'dt'    => $row['dt'],
-					'stext' => $row['stext'],
-				);
-				$tpl->template('list_entries_cron', $tpath['config/list_entries_cron'] . 'config');
-				$tpl->vars('list_entries_cron', $gvars);
-				$entries_cron .= $tpl->show('list_entries_cron');
-			}
-			$pvars['vars']['entries_cron'] = $entries_cron;
-			$tpl->template('list_subscribe_cron', $tpath['config/list_subscribe_cron'] . 'config');
-			$tpl->vars('list_subscribe_cron', $pvars);
-		}
-		$cron_row = $cron->getConfig();
-		foreach ($cron_row as $key => $value) {
-			if ($value['plugin'] == 'subscribe_comments') {
-				$cron_min = $value['min'];
-				$cron_hour = $value['hour'];
-				$cron_day = $value['day'];
-				$cron_month = $value['month'];
-			}
-		}
-		if (!isset($cron_min)) {
-			$cron_min = '0,5,10,15,20,25,30,35,40,45,50,55';
-		}
-		if (!isset($cron_hour)) {
-			$cron_hour = '*';
-		}
-		if (!isset($cron_day)) {
-			$cron_day = '*';
-		}
-		if (!isset($cron_month)) {
-			$cron_month = '*';
-		}
-		$cron->unregisterTask('subscribe_comments');
-		$cron->registerTask('subscribe_comments', 'run', $cron_min, $cron_hour, $cron_day, $cron_month, '*');
-		$tvars['regx']["'\[hide_delayed\](.*?)\[/hide_delayed\]'si"] = '$1';
-	} else {
-		$tvars['regx']["'\[hide_delayed\](.*?)\[/hide_delayed\]'si"] = '';
-		$cron->unregisterTask('subscribe_comments');
-	}
-	if (isset($_REQUEST['submit'])) {
-		pluginSetVariable('subscribe_comments', 'admin_count', intval($_REQUEST['admin_count']));
-		pluginSetVariable('subscribe_comments', 'delayed_send', intval($_REQUEST['delayed_send']));
-		pluginsSaveConfig();
-		redirect_subscribe_comments('?mod=extra-config&plugin=subscribe_comments');
-	}
-	$admin_count = pluginGetVariable('subscribe_comments', 'admin_count');
-	$delayed_send = pluginGetVariable('subscribe_comments', 'delayed_send');
-	$delayed_send = '<option value="0" ' . (empty($delayed_send) ? 'selected' : '') . '>Нет</option><option value="1" ' . (!empty($delayed_send) ? 'selected' : '') . '>Да</option>';
-	$pvars['vars'] = array(
-		'admin_count'  => isset($admin_count) ? $admin_count : '10',
-		'delayed_send' => isset($delayed_send) ? $delayed_send : '10',
-	);
-	$tpl->template('general.from', $tpath['config/general.from'] . 'config');
-	$tpl->vars('general.from', $pvars);
-	$tvars['vars'] = array(
-		'entries_cron' => $tpl->show('list_subscribe_cron'),
-		'entries'      => $tpl->show('general.from'),
-		'global'       => 'Общие настройки'
-	);
-	$tpl->template('main', $tpath['config/main'] . 'config');
-	$tpl->vars('main', $tvars);
-	print $tpl->show('main');
+function modify()
+{
+    global $mysql;
+    $selected_news = $_REQUEST['selected_subscribe_comments'];
+    $subaction = $_REQUEST['subaction'];
+    $id = implode(',', $selected_news);
+    if (empty($id)) {
+        return msg(['type' => 'error', 'text' => 'Вы не выбрали объектов']);
+    }
+    switch ($subaction) {
+        case 'mass_delete':
+            $del = true;
+            break;
+        case 'mass_delete_post':
+            $del_post = true;
+            break;
+    }
+    if (isset($del)) {
+        $mysql->query('delete from '.prefix."_subscribe_comments where id in ({$id})");
+        msg(['type' => 'info', 'info' => "Подписки с ID${id} удалены"]);
+    }
+    if (isset($del_post)) {
+        $mysql->query('delete from '.prefix."_subscribe_comments_temp where id in ({$id})");
+        msg(['type' => 'info', 'info' => "Пиьсма с ID${id} удалены"]);
+    }
 }
 
-function redirect_subscribe_comments($url) {
-
-	if (headers_sent()) {
-		echo "<script>document.location.href='{$url}';</script>\n";
-	} else {
-		header('HTTP/1.1 302 Moved Permanently');
-		header("Location: {$url}");
-	}
+function main()
+{
+    global $tpl, $mysql, $config, $template, $cron;
+    $tpath = locatePluginTemplates(['config/main', 'config/general.from', 'config/list_entries_cron', 'config/list_subscribe_cron'], 'subscribe_comments', 1);
+    $delayed_send = pluginGetVariable('subscribe_comments', 'delayed_send');
+    if ($delayed_send == 1) {
+        if ($config['syslog'] == '1') {
+            foreach ($mysql->select('SELECT * from '.prefix.'_syslog where action = "subscribe_comments" ORDER BY id DESC LIMIT 5') as $row) {
+                $gvars['vars'] = [
+                    'dt'    => $row['dt'],
+                    'stext' => $row['stext'],
+                ];
+                $tpl->template('list_entries_cron', $tpath['config/list_entries_cron'].'config');
+                $tpl->vars('list_entries_cron', $gvars);
+                $entries_cron .= $tpl->show('list_entries_cron');
+            }
+            $pvars['vars']['entries_cron'] = $entries_cron;
+            $tpl->template('list_subscribe_cron', $tpath['config/list_subscribe_cron'].'config');
+            $tpl->vars('list_subscribe_cron', $pvars);
+        }
+        $cron_row = $cron->getConfig();
+        foreach ($cron_row as $key => $value) {
+            if ($value['plugin'] == 'subscribe_comments') {
+                $cron_min = $value['min'];
+                $cron_hour = $value['hour'];
+                $cron_day = $value['day'];
+                $cron_month = $value['month'];
+            }
+        }
+        if (!isset($cron_min)) {
+            $cron_min = '0,5,10,15,20,25,30,35,40,45,50,55';
+        }
+        if (!isset($cron_hour)) {
+            $cron_hour = '*';
+        }
+        if (!isset($cron_day)) {
+            $cron_day = '*';
+        }
+        if (!isset($cron_month)) {
+            $cron_month = '*';
+        }
+        $cron->unregisterTask('subscribe_comments');
+        $cron->registerTask('subscribe_comments', 'run', $cron_min, $cron_hour, $cron_day, $cron_month, '*');
+        $tvars['regx']["'\[hide_delayed\](.*?)\[/hide_delayed\]'si"] = '$1';
+    } else {
+        $tvars['regx']["'\[hide_delayed\](.*?)\[/hide_delayed\]'si"] = '';
+        $cron->unregisterTask('subscribe_comments');
+    }
+    if (isset($_REQUEST['submit'])) {
+        pluginSetVariable('subscribe_comments', 'admin_count', intval($_REQUEST['admin_count']));
+        pluginSetVariable('subscribe_comments', 'delayed_send', intval($_REQUEST['delayed_send']));
+        pluginsSaveConfig();
+        redirect_subscribe_comments('?mod=extra-config&plugin=subscribe_comments');
+    }
+    $admin_count = pluginGetVariable('subscribe_comments', 'admin_count');
+    $delayed_send = pluginGetVariable('subscribe_comments', 'delayed_send');
+    $delayed_send = '<option value="0" '.(empty($delayed_send) ? 'selected' : '').'>Нет</option><option value="1" '.(!empty($delayed_send) ? 'selected' : '').'>Да</option>';
+    $pvars['vars'] = [
+        'admin_count'  => isset($admin_count) ? $admin_count : '10',
+        'delayed_send' => isset($delayed_send) ? $delayed_send : '10',
+    ];
+    $tpl->template('general.from', $tpath['config/general.from'].'config');
+    $tpl->vars('general.from', $pvars);
+    $tvars['vars'] = [
+        'entries_cron' => $tpl->show('list_subscribe_cron'),
+        'entries'      => $tpl->show('general.from'),
+        'global'       => 'Общие настройки',
+    ];
+    $tpl->template('main', $tpath['config/main'].'config');
+    $tpl->vars('main', $tvars);
+    echo $tpl->show('main');
 }
 
-function input_filter_rev($text) {
+function redirect_subscribe_comments($url)
+{
+    if (headers_sent()) {
+        echo "<script>document.location.href='{$url}';</script>\n";
+    } else {
+        header('HTTP/1.1 302 Moved Permanently');
+        header("Location: {$url}");
+    }
+}
 
-	$text = trim($text);
-	$search = array("<", ">");
-	$replace = array("&lt;", "&gt;");
-	$text = preg_replace("/(&amp;)+(?=\#([0-9]{2,3});)/i", "&", str_replace($search, $replace, $text));
+function input_filter_rev($text)
+{
+    $text = trim($text);
+    $search = ['<', '>'];
+    $replace = ['&lt;', '&gt;'];
+    $text = preg_replace("/(&amp;)+(?=\#([0-9]{2,3});)/i", '&', str_replace($search, $replace, $text));
 
-	return $text;
+    return $text;
 }

--- a/subscribe_comments/install.php
+++ b/subscribe_comments/install.php
@@ -1,58 +1,65 @@
 <?php
-if (!defined('NGCMS')) die ('HAL');
-function plugin_subscribe_comments_install($action) {
 
-	global $mysql;
-	$install = true;
-	$db_update = array(
-		array(
-			'table'  => 'subscribe_comments',
-			'action' => 'cmodify',
-			'key'    => 'primary key(id)',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'),
-				array('action' => 'cmodify', 'name' => 'user_email', 'type' => 'char(80)', 'params' => "default ''"),
-				array('action' => 'cmodify', 'name' => 'news_id', 'type' => 'int', 'params' => "not null"),
-				array('action' => 'cmodify', 'name' => 'news_altname', 'type' => 'char(255)', 'params' => "default ''"),
-			)
-		),
-		array(
-			'table'  => 'subscribe_comments_temp',
-			'action' => 'cmodify',
-			'key'    => 'primary key(id)',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'),
-				array('action' => 'cmodify', 'name' => 'com_id', 'type' => 'int', 'params' => 'not null'),
-				array('action' => 'cmodify', 'name' => 'com_author', 'type' => 'char(100)', 'params' => "default ''"),
-				array('action' => 'cmodify', 'name' => 'com_author_id', 'type' => 'int', 'params' => "default '0'"),
-				array('action' => 'cmodify', 'name' => 'com_text', 'type' => 'text'),
-				array('action' => 'cmodify', 'name' => 'news_title', 'type' => 'char(255)', 'params' => "default ''"),
-				array('action' => 'cmodify', 'name' => 'news_id', 'type' => 'int', 'params' => "not null"),
-				array('action' => 'cmodify', 'name' => 'news_altname', 'type' => 'char(255)', 'params' => "default ''"),
-				array('action' => 'cmodify', 'name' => 'user_email', 'type' => 'char(80)', 'params' => "default ''"),
-			)
-		),
-	);
-	switch ($action) {
-		case 'confirm':
-			generate_install_page('subscribe_comments', 'Всё готово к установке.');
-			break;
-		case 'apply':
-			if ($install) {
-				if (fixdb_plugin_install('subscribe_comments', $db_update, 'install', ($action == 'autoapply') ? true : false)) {
-					plugin_mark_installed('subscribe_comments');
-				} else return false;
-			} else return false;
-			$params = array(
-				'admin_count'  => 10,
-				'delayed_send' => 0,
-			);
-			foreach ($params as $k => $v) {
-				extra_set_param('subscribe_comments', $k, $v);
-			}
-			extra_commit_changes();
-			break;
-	}
+if (!defined('NGCMS')) {
+    die('HAL');
+}
+function plugin_subscribe_comments_install($action)
+{
+    global $mysql;
+    $install = true;
+    $db_update = [
+        [
+            'table'  => 'subscribe_comments',
+            'action' => 'cmodify',
+            'key'    => 'primary key(id)',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'],
+                ['action' => 'cmodify', 'name' => 'user_email', 'type' => 'char(80)', 'params' => "default ''"],
+                ['action' => 'cmodify', 'name' => 'news_id', 'type' => 'int', 'params' => 'not null'],
+                ['action' => 'cmodify', 'name' => 'news_altname', 'type' => 'char(255)', 'params' => "default ''"],
+            ],
+        ],
+        [
+            'table'  => 'subscribe_comments_temp',
+            'action' => 'cmodify',
+            'key'    => 'primary key(id)',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'],
+                ['action' => 'cmodify', 'name' => 'com_id', 'type' => 'int', 'params' => 'not null'],
+                ['action' => 'cmodify', 'name' => 'com_author', 'type' => 'char(100)', 'params' => "default ''"],
+                ['action' => 'cmodify', 'name' => 'com_author_id', 'type' => 'int', 'params' => "default '0'"],
+                ['action' => 'cmodify', 'name' => 'com_text', 'type' => 'text'],
+                ['action' => 'cmodify', 'name' => 'news_title', 'type' => 'char(255)', 'params' => "default ''"],
+                ['action' => 'cmodify', 'name' => 'news_id', 'type' => 'int', 'params' => 'not null'],
+                ['action' => 'cmodify', 'name' => 'news_altname', 'type' => 'char(255)', 'params' => "default ''"],
+                ['action' => 'cmodify', 'name' => 'user_email', 'type' => 'char(80)', 'params' => "default ''"],
+            ],
+        ],
+    ];
+    switch ($action) {
+        case 'confirm':
+            generate_install_page('subscribe_comments', 'Всё готово к установке.');
+            break;
+        case 'apply':
+            if ($install) {
+                if (fixdb_plugin_install('subscribe_comments', $db_update, 'install', ($action == 'autoapply') ? true : false)) {
+                    plugin_mark_installed('subscribe_comments');
+                } else {
+                    return false;
+                }
+            } else {
+                return false;
+            }
+            $params = [
+                'admin_count'  => 10,
+                'delayed_send' => 0,
+            ];
+            foreach ($params as $k => $v) {
+                extra_set_param('subscribe_comments', $k, $v);
+            }
+            extra_commit_changes();
+            break;
+    }
 
-	return true;
+    return true;
 }

--- a/subscribe_comments/subscribe_comments.php
+++ b/subscribe_comments/subscribe_comments.php
@@ -1,249 +1,252 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 loadPluginLang('subscribe_comments', 'main', '', '', ':');
 loadPluginLibrary('comments', 'lib');
-function plugin_subscribe_comments_cron() {
-
-	global $tpl, $cron, $mysql, $config, $lang, $parse, $PFILTERS;
-	//var_dump($newsRec);
-	//$row = $mysql->record("select * from ".prefix."_news where id=".db_squote($newsRec['id']));
-	foreach ($mysql->select("select * from " . prefix . "_subscribe_comments_temp s left join " . prefix . "_news n on s.news_id=n.id") as $irow) {
-		//Email informer
-		$alink = ($irow['com_author_id']) ? generatePluginLink('uprofile', 'show', array('name' => $irow['com_author'], 'id' => $irow['com_author_id']), array(), false, true) : '';
-		$newsLink = newsGenerateLink($irow, false, 0, true);
-		$body = str_replace(
-			array(
-				'{username}',
-				'[userlink]',
-				'[/userlink]',
-				'{comment}',
-				'{newslink}',
-				'{newstitle}',
-				'{unsubscribelink}',
-				'{unsubscribelink_all}'
-			),
-			array(
-				$irow['com_author'],
-				($irow['com_author_id']) ? '<a href="' . $alink . '">' : '',
-				($irow['com_author_id']) ? '</a>' : '',
-				secure_html($irow['com_text']),
-				$newsLink,
-				$irow['title'],
-				home . generateLink('core', 'plugin', array('plugin' => 'subscribe_comments'), array('unsubscribe_me' => 1, 'subscribe_field' => $irow['user_email'], 'subscribe_news' => $irow['alt_name'])),
-				home . generateLink('core', 'plugin', array('plugin' => 'subscribe_comments'), array('unsubscribe_me' => 2, 'subscribe_field' => $irow['user_email'])),
-			),
-			$lang['subscribe_comments:msg.notice']
-		);
-		$dump[$irow['user_email']] .= $body;
-	}
-	foreach ($dump as $ekey => $prow) {
-		$ends = str_replace(
-			array('{unsubscribelink_all}'),
-			array(home . generateLink('core', 'plugin', array('plugin' => 'subscribe_comments'), array('unsubscribe_me' => 2, 'subscribe_field' => $ekey))),
-			$lang['subscribe_comments:msg.notice_end']
-		);
-		$prow = $prow . $ends;
-		zzMail($ekey, $lang['subscribe_comments:msg.newcomment'], $prow, 'html');
-	}
-	$mysql->query("DELETE FROM " . prefix . "_subscribe_comments_temp");
+function plugin_subscribe_comments_cron()
+{
+    global $tpl, $cron, $mysql, $config, $lang, $parse, $PFILTERS;
+    //var_dump($newsRec);
+    //$row = $mysql->record("select * from ".prefix."_news where id=".db_squote($newsRec['id']));
+    foreach ($mysql->select('select * from '.prefix.'_subscribe_comments_temp s left join '.prefix.'_news n on s.news_id=n.id') as $irow) {
+        //Email informer
+        $alink = ($irow['com_author_id']) ? generatePluginLink('uprofile', 'show', ['name' => $irow['com_author'], 'id' => $irow['com_author_id']], [], false, true) : '';
+        $newsLink = newsGenerateLink($irow, false, 0, true);
+        $body = str_replace(
+            [
+                '{username}',
+                '[userlink]',
+                '[/userlink]',
+                '{comment}',
+                '{newslink}',
+                '{newstitle}',
+                '{unsubscribelink}',
+                '{unsubscribelink_all}',
+            ],
+            [
+                $irow['com_author'],
+                ($irow['com_author_id']) ? '<a href="'.$alink.'">' : '',
+                ($irow['com_author_id']) ? '</a>' : '',
+                secure_html($irow['com_text']),
+                $newsLink,
+                $irow['title'],
+                home.generateLink('core', 'plugin', ['plugin' => 'subscribe_comments'], ['unsubscribe_me' => 1, 'subscribe_field' => $irow['user_email'], 'subscribe_news' => $irow['alt_name']]),
+                home.generateLink('core', 'plugin', ['plugin' => 'subscribe_comments'], ['unsubscribe_me' => 2, 'subscribe_field' => $irow['user_email']]),
+            ],
+            $lang['subscribe_comments:msg.notice']
+        );
+        $dump[$irow['user_email']] .= $body;
+    }
+    foreach ($dump as $ekey => $prow) {
+        $ends = str_replace(
+            ['{unsubscribelink_all}'],
+            [home.generateLink('core', 'plugin', ['plugin' => 'subscribe_comments'], ['unsubscribe_me' => 2, 'subscribe_field' => $ekey])],
+            $lang['subscribe_comments:msg.notice_end']
+        );
+        $prow = $prow.$ends;
+        zzMail($ekey, $lang['subscribe_comments:msg.newcomment'], $prow, 'html');
+    }
+    $mysql->query('DELETE FROM '.prefix.'_subscribe_comments_temp');
 }
 
-class ShowSubscribeForm extends NewsFilter {
-
-	function showNews($newsID, $SQLnews, &$tvars, $mode = array()) {
-
-		global $mysql, $tpl, $config;
-		//plugin_subscribe_comments_cron();
-		$subscribelink = generateLink('core', 'plugin', array('plugin' => 'subscribe_comments'));
-		$tvars['vars']['post_url_f'] = $subscribelink;
-	}
+class ShowSubscribeForm extends NewsFilter
+{
+    public function showNews($newsID, $SQLnews, &$tvars, $mode = [])
+    {
+        global $mysql, $tpl, $config;
+        //plugin_subscribe_comments_cron();
+        $subscribelink = generateLink('core', 'plugin', ['plugin' => 'subscribe_comments']);
+        $tvars['vars']['post_url_f'] = $subscribelink;
+    }
 }
 
-class SubscribeComments extends FilterComments {
+class SubscribeComments extends FilterComments
+{
+    public function addCommentsForm($newsID, &$tvars)
+    {
+        global $mysql;
+        if ($nrow = $mysql->record('select * from '.prefix."_subscribe_comments where news_id='".$newsID."' and user_email='".secure_html(urldecode($_COOKIE['com_usermail']))."'")) {
+            $subscribe_box = '1';
+            $subscribe_box_checked = 'checked';
+        } else {
+            $subscribe_box = '0';
+            $subscribe_box_checked = '';
+        }
+        $tvars['vars']['subscribe_box'] = $subscribe_box;
+        $tvars['vars']['subscribe_box_checked'] = $subscribe_box_checked;
+        $tvars['vars']['test_var'] = 'tested';
+    }
 
-	function addCommentsForm($newsID, &$tvars) {
-
-		global $mysql;
-		if ($nrow = $mysql->record("select * from " . prefix . "_subscribe_comments where news_id='" . $newsID . "' and user_email='" . secure_html(urldecode($_COOKIE['com_usermail'])) . "'")) {
-			$subscribe_box = '1';
-			$subscribe_box_checked = 'checked';
-		} else {
-			$subscribe_box = '0';
-			$subscribe_box_checked = '';
-		}
-		$tvars['vars']['subscribe_box'] = $subscribe_box;
-		$tvars['vars']['subscribe_box_checked'] = $subscribe_box_checked;
-		$tvars['vars']['test_var'] = 'tested';
-	}
-
-	function addCommentsNotify($userRec, $newsRec, &$tvars, $SQL, $commID) {
-
-		global $mysql, $lang;
-		//var_dump($newsRec);
-		if ($_REQUEST['subscribe_checked'] == 'true') {
-			if (!($nrow = $mysql->record("select * from " . prefix . "_subscribe_comments where news_id='" . $newsRec['id'] . "' and news_altname='" . $newsRec['alt_name'] . "' and user_email='" . $SQL['mail'] . "'"))) {
-				$mysql->query("insert into " . prefix . "_subscribe_comments (user_email, news_id, news_altname) values ('" . $SQL['mail'] . "', '" . $newsRec['id'] . "', '" . $newsRec['alt_name'] . "')");
-			}
-		} elseif ($_REQUEST['subscribe_checked'] == 'false') {
-			//var_dump($_REQUEST); 
-			if ($nrow = $mysql->record("select * from " . prefix . "_subscribe_comments where news_id='" . $newsRec['id'] . "' and news_altname='" . $newsRec['alt_name'] . "' and user_email='" . $SQL['mail'] . "'")) {
-				$mysql->query("delete from " . prefix . "_subscribe_comments where user_email='" . $SQL['mail'] . "' and news_id='" . $newsRec['id'] . "' and news_altname='" . $newsRec['alt_name'] . "'");
-				$mysql->query("delete from " . prefix . "_subscribe_comments_temp where user_email='" . $SQL['mail'] . "' and news_id='" . $newsRec['id'] . "' and news_altname='" . $newsRec['alt_name'] . "'");
-			}
-		}
-		$delayed_send = pluginGetVariable('subscribe_comments', 'delayed_send');
-		//var_dump($delayed_send);
-		if ($delayed_send == 1) {
-			foreach ($mysql->select("select * from " . prefix . "_subscribe_comments where news_id='" . $newsRec['id'] . "' and news_altname='" . $newsRec['alt_name'] . "'") as $srow) {
-				//var_dump($srow);
-				if (!($nrow = $mysql->record("select * from " . prefix . "_subscribe_comments_temp where com_id='" . $commID . "' and news_altname='" . $newsRec['alt_name'] . "' and user_email='" . $srow['user_email'] . "'"))) {
-					$mysql->query("insert into " . prefix . "_subscribe_comments_temp (com_id, com_author, com_author_id, com_text, news_title, news_id, news_altname, user_email) values ('" . $commID . "', '" . $SQL['author'] . "', '" . $SQL['author_id'] . "', '" . $SQL['text'] . "', '" . $newsRec['title'] . "', '" . $newsRec['id'] . "', '" . $newsRec['alt_name'] . "', '" . $srow['user_email'] . "')");
-				}
-			}
-		} else {
-			//var_dump($newsRec);
-			//$row = $mysql->record("select * from ".prefix."_news where id=".db_squote($newsRec['id']));
-			// Рассылаем сразу
-			$newsLink = newsGenerateLink($newsRec, false, 0, true);
-			foreach ($mysql->select("select * from " . prefix . "_subscribe_comments where news_id='" . $newsRec['id'] . "' and news_altname='" . $newsRec['alt_name'] . "'") as $srow) {
-				$alink = ($SQL['author_id']) ? generatePluginLink('uprofile', 'show', array('name' => $SQL['author'], 'id' => $SQL['author_id']), array(), false, true) : '';
-				$newsLink = newsGenerateLink($newsRec, false, 0, true);
-				$body = str_replace(
-					array(
-						'{username}',
-						'[userlink]',
-						'[/userlink]',
-						'{comment}',
-						'{newslink}',
-						'{newstitle}',
-						'{unsubscribelink}',
-						'{unsubscribelink_all}'
-					),
-					array(
-						$SQL['author'],
-						($SQL['author_id']) ? '<a href="' . $alink . '">' : '',
-						($SQL['author_id']) ? '</a>' : '',
-						secure_html($SQL['text']),
-						$newsLink,
-						$newsRec['title'],
-						home . generateLink('core', 'plugin', array('plugin' => 'subscribe_comments'), array('unsubscribe_me' => 1, 'subscribe_field' => $srow['user_email'], 'subscribe_news' => $newsRec['alt_name'])),
-						home . generateLink('core', 'plugin', array('plugin' => 'subscribe_comments'), array('unsubscribe_me' => 2, 'subscribe_field' => $srow['user_email'])),
-					),
-					$lang['subscribe_comments:msg.notice_one']
-				);
-				zzMail($srow['user_email'], $lang['subscribe_comments:msg.newcomment'], $body, 'html');
-			}
-		}
-	}
+    public function addCommentsNotify($userRec, $newsRec, &$tvars, $SQL, $commID)
+    {
+        global $mysql, $lang;
+        //var_dump($newsRec);
+        if ($_REQUEST['subscribe_checked'] == 'true') {
+            if (!($nrow = $mysql->record('select * from '.prefix."_subscribe_comments where news_id='".$newsRec['id']."' and news_altname='".$newsRec['alt_name']."' and user_email='".$SQL['mail']."'"))) {
+                $mysql->query('insert into '.prefix."_subscribe_comments (user_email, news_id, news_altname) values ('".$SQL['mail']."', '".$newsRec['id']."', '".$newsRec['alt_name']."')");
+            }
+        } elseif ($_REQUEST['subscribe_checked'] == 'false') {
+            //var_dump($_REQUEST);
+            if ($nrow = $mysql->record('select * from '.prefix."_subscribe_comments where news_id='".$newsRec['id']."' and news_altname='".$newsRec['alt_name']."' and user_email='".$SQL['mail']."'")) {
+                $mysql->query('delete from '.prefix."_subscribe_comments where user_email='".$SQL['mail']."' and news_id='".$newsRec['id']."' and news_altname='".$newsRec['alt_name']."'");
+                $mysql->query('delete from '.prefix."_subscribe_comments_temp where user_email='".$SQL['mail']."' and news_id='".$newsRec['id']."' and news_altname='".$newsRec['alt_name']."'");
+            }
+        }
+        $delayed_send = pluginGetVariable('subscribe_comments', 'delayed_send');
+        //var_dump($delayed_send);
+        if ($delayed_send == 1) {
+            foreach ($mysql->select('select * from '.prefix."_subscribe_comments where news_id='".$newsRec['id']."' and news_altname='".$newsRec['alt_name']."'") as $srow) {
+                //var_dump($srow);
+                if (!($nrow = $mysql->record('select * from '.prefix."_subscribe_comments_temp where com_id='".$commID."' and news_altname='".$newsRec['alt_name']."' and user_email='".$srow['user_email']."'"))) {
+                    $mysql->query('insert into '.prefix."_subscribe_comments_temp (com_id, com_author, com_author_id, com_text, news_title, news_id, news_altname, user_email) values ('".$commID."', '".$SQL['author']."', '".$SQL['author_id']."', '".$SQL['text']."', '".$newsRec['title']."', '".$newsRec['id']."', '".$newsRec['alt_name']."', '".$srow['user_email']."')");
+                }
+            }
+        } else {
+            //var_dump($newsRec);
+            //$row = $mysql->record("select * from ".prefix."_news where id=".db_squote($newsRec['id']));
+            // Рассылаем сразу
+            $newsLink = newsGenerateLink($newsRec, false, 0, true);
+            foreach ($mysql->select('select * from '.prefix."_subscribe_comments where news_id='".$newsRec['id']."' and news_altname='".$newsRec['alt_name']."'") as $srow) {
+                $alink = ($SQL['author_id']) ? generatePluginLink('uprofile', 'show', ['name' => $SQL['author'], 'id' => $SQL['author_id']], [], false, true) : '';
+                $newsLink = newsGenerateLink($newsRec, false, 0, true);
+                $body = str_replace(
+                    [
+                        '{username}',
+                        '[userlink]',
+                        '[/userlink]',
+                        '{comment}',
+                        '{newslink}',
+                        '{newstitle}',
+                        '{unsubscribelink}',
+                        '{unsubscribelink_all}',
+                    ],
+                    [
+                        $SQL['author'],
+                        ($SQL['author_id']) ? '<a href="'.$alink.'">' : '',
+                        ($SQL['author_id']) ? '</a>' : '',
+                        secure_html($SQL['text']),
+                        $newsLink,
+                        $newsRec['title'],
+                        home.generateLink('core', 'plugin', ['plugin' => 'subscribe_comments'], ['unsubscribe_me' => 1, 'subscribe_field' => $srow['user_email'], 'subscribe_news' => $newsRec['alt_name']]),
+                        home.generateLink('core', 'plugin', ['plugin' => 'subscribe_comments'], ['unsubscribe_me' => 2, 'subscribe_field' => $srow['user_email']]),
+                    ],
+                    $lang['subscribe_comments:msg.notice_one']
+                );
+                zzMail($srow['user_email'], $lang['subscribe_comments:msg.newcomment'], $body, 'html');
+            }
+        }
+    }
 }
 
-function plugin_subscribe_comments() {
+function plugin_subscribe_comments()
+{
+    global $template, $config, $mysql, $tpl, $lang, $CurrentHandler;
+    global $catmap, $catz, $config, $userROW, $template, $lang, $tpl;
+    $timeout = 3;
+    $altname = parse_url($_SERVER['HTTP_REFERER']);
+    $altname = preg_match('/^.*\/(.*)$/', $altname['path'], $matches);
+    $altname = secure_html(str_replace('.html', '', $matches['1']));
+    if (empty($altname)) {
+        $altname = secure_html($_REQUEST['subscribe_news']);
+    }
+    $email = secure_html($_REQUEST['subscribe_field']);
+    // msg(array("type" => "error", "text" => $lang['subscribe_comments:err.password']));
+    if (!(filter_var($email, FILTER_VALIDATE_EMAIL)) || empty($email)) {
+        msg(['type' => 'error', 'text' => $lang['subscribe_comments:err.wrongemail']]);
+        header('Refresh: '.$timeout.'; URL='.secure_html($_SERVER['HTTP_REFERER']).'');
 
-	global $template, $config, $mysql, $tpl, $lang, $CurrentHandler;
-	global $catmap, $catz, $config, $userROW, $template, $lang, $tpl;
-	$timeout = 3;
-	$altname = parse_url($_SERVER["HTTP_REFERER"]);
-	$altname = preg_match('/^.*\/(.*)$/', $altname['path'], $matches);
-	$altname = secure_html(str_replace('.html', '', $matches['1']));
-	if (empty($altname)) {
-		$altname = secure_html($_REQUEST['subscribe_news']);
-	}
-	$email = secure_html($_REQUEST['subscribe_field']);
-	// msg(array("type" => "error", "text" => $lang['subscribe_comments:err.password']));
-	if (!(filter_var($email, FILTER_VALIDATE_EMAIL)) || empty($email)) {
-		msg(array("type" => "error", "text" => $lang['subscribe_comments:err.wrongemail']));
-		header('Refresh: ' . $timeout . '; URL=' . secure_html($_SERVER["HTTP_REFERER"]) . '');
+        return;
+    }
+    $unsubscribe = secure_html($_REQUEST['unsubscribe_me']);
+    //var_dump($_REQUEST);
+    switch ($unsubscribe) {
+        case '1':
+            if (!empty($email) && !empty($altname)) {
+                if (empty($altname)) {
+                    msg(['type' => 'error', 'text' => $lang['subscribe_comments:err.wrongparams']]);
 
-		return;
-	}
-	$unsubscribe = secure_html($_REQUEST['unsubscribe_me']);
-	//var_dump($_REQUEST);
-	switch ($unsubscribe) {
-		case '1':
-			if (!empty($email) && !empty($altname)) {
-				if (empty($altname)) {
-					msg(array("type" => "error", "text" => $lang['subscribe_comments:err.wrongparams']));
+                    return;
+                }
+                $row = $mysql->record('select * from '.prefix."_news where alt_name='".$altname."'");
+                if (empty($row)) {
+                    msg(['type' => 'error', 'text' => $lang['subscribe_comments:err.wrongaltname']]);
 
-					return;
-				}
-				$row = $mysql->record("select * from " . prefix . "_news where alt_name='" . $altname . "'");
-				if (empty($row)) {
-					msg(array("type" => "error", "text" => $lang['subscribe_comments:err.wrongaltname']));
+                    return;
+                }
+                if ($nrow = $mysql->record('select * from '.prefix."_subscribe_comments where news_id='".$row['id']."' and news_altname='".$row['alt_name']."' and user_email='".$email."'")) {
+                    $mysql->query('DELETE FROM '.prefix."_subscribe_comments WHERE user_email='".$email."' and news_altname='".$altname."'");
+                    $mysql->query('DELETE FROM '.prefix."_subscribe_comments_temp where user_email='".$email."' and news_altname='".$altname."'");
+                    msg(['type' => 'message', 'text' => str_replace(['{title}'], [$row['title']], $lang['subscribe_comments:msg.unsubscribepageok'])]);
 
-					return;
-				}
-				if ($nrow = $mysql->record("select * from " . prefix . "_subscribe_comments where news_id='" . $row['id'] . "' and news_altname='" . $row['alt_name'] . "' and user_email='" . $email . "'")) {
-					$mysql->query("DELETE FROM " . prefix . "_subscribe_comments WHERE user_email='" . $email . "' and news_altname='" . $altname . "'");
-					$mysql->query("DELETE FROM " . prefix . "_subscribe_comments_temp where user_email='" . $email . "' and news_altname='" . $altname . "'");
-					msg(array("type" => "message", "text" => str_replace(array('{title}'), array($row['title']), $lang['subscribe_comments:msg.unsubscribepageok'])));
+                    return;
+                } else {
+                    msg(['type' => 'error', 'text' => $lang['subscribe_comments:err.unsubscribepageyet']]);
 
-					return;
-				} else {
-					msg(array("type" => "error", "text" => $lang['subscribe_comments:err.unsubscribepageyet']));
+                    return;
+                }
+            } else {
+                msg(['type' => 'error', 'text' => $lang['subscribe_comments:err.wrongparams']]);
 
-					return;
-				}
-			} else {
-				msg(array("type" => "error", "text" => $lang['subscribe_comments:err.wrongparams']));
+                return;
+            }
+            break;
+        case '2':
+            if (!empty($email)) {
+                if ($nrow = $mysql->record('select * from '.prefix."_subscribe_comments where user_email='".$email."'")) {
+                    $mysql->query('DELETE FROM '.prefix."_subscribe_comments WHERE user_email='".$email."'");
+                    $mysql->query('DELETE FROM '.prefix."_subscribe_comments_temp where user_email='".$email."'");
+                    msg(['type' => 'message', 'text' => $lang['subscribe_comments:msg.unsubscribeall']]);
 
-				return;
-			}
-			break;
-		case '2':
-			if (!empty($email)) {
-				if ($nrow = $mysql->record("select * from " . prefix . "_subscribe_comments where user_email='" . $email . "'")) {
-					$mysql->query("DELETE FROM " . prefix . "_subscribe_comments WHERE user_email='" . $email . "'");
-					$mysql->query("DELETE FROM " . prefix . "_subscribe_comments_temp where user_email='" . $email . "'");
-					msg(array("type" => "message", "text" => $lang['subscribe_comments:msg.unsubscribeall']));
+                    return;
+                } else {
+                    msg(['type' => 'error', 'text' => $lang['subscribe_comments:err.unsubscribeall']]);
 
-					return;
-				} else {
-					msg(array("type" => "error", "text" => $lang['subscribe_comments:err.unsubscribeall']));
+                    return;
+                }
+            } else {
+                msg(['type' => 'error', 'text' => $lang['subscribe_comments:err.wrongparams']]);
 
-					return;
-				}
-			} else {
-				msg(array("type" => "error", "text" => $lang['subscribe_comments:err.wrongparams']));
+                return;
+            }
+            break;
+        default:
+            if (empty($altname)) {
+                msg(['type' => 'error', 'text' => $lang['subscribe_comments:err.wrongparams']]);
+                header('Refresh: '.$timeout.'; URL='.secure_html($_SERVER['HTTP_REFERER']).'');
 
-				return;
-			}
-			break;
-		default:
-			if (empty($altname)) {
-				msg(array("type" => "error", "text" => $lang['subscribe_comments:err.wrongparams']));
-				header('Refresh: ' . $timeout . '; URL=' . secure_html($_SERVER["HTTP_REFERER"]) . '');
+                return;
+            }
+            $row = $mysql->record('select * from '.prefix."_news where alt_name='".$altname."'");
+            if (empty($row)) {
+                msg(['type' => 'error', 'text' => $lang['subscribe_comments:err.wrongaltname']]);
+                header('Refresh: '.$timeout.'; URL='.secure_html($_SERVER['HTTP_REFERER']).'');
 
-				return;
-			}
-			$row = $mysql->record("select * from " . prefix . "_news where alt_name='" . $altname . "'");
-			if (empty($row)) {
-				msg(array("type" => "error", "text" => $lang['subscribe_comments:err.wrongaltname']));
-				header('Refresh: ' . $timeout . '; URL=' . secure_html($_SERVER["HTTP_REFERER"]) . '');
+                return;
+            }
+            if (!($nrow = $mysql->record('select * from '.prefix."_subscribe_comments where news_id='".$row['id']."' and news_altname='".$row['alt_name']."' and user_email='".$email."'"))) {
+                $mysql->query('insert into '.prefix."_subscribe_comments (user_email, news_id, news_altname) values ('".$email."', '".$row['id']."', '".$row['alt_name']."')");
+                msg(['type' => 'message', 'text' => $lang['subscribe_comments:msg.subscribepageok']]);
+                header('Refresh: '.$timeout.'; URL='.secure_html($_SERVER['HTTP_REFERER']).'');
 
-				return;
-			}
-			if (!($nrow = $mysql->record("select * from " . prefix . "_subscribe_comments where news_id='" . $row['id'] . "' and news_altname='" . $row['alt_name'] . "' and user_email='" . $email . "'"))) {
-				$mysql->query("insert into " . prefix . "_subscribe_comments (user_email, news_id, news_altname) values ('" . $email . "', '" . $row['id'] . "', '" . $row['alt_name'] . "')");
-				msg(array("type" => "message", "text" => $lang['subscribe_comments:msg.subscribepageok']));
-				header('Refresh: ' . $timeout . '; URL=' . secure_html($_SERVER["HTTP_REFERER"]) . '');
+                return;
+            } else {
+                msg(['type' => 'message', 'text' => $lang['subscribe_comments:err.subscribepageyet']]);
+                header('Refresh: '.$timeout.'; URL='.secure_html($_SERVER['HTTP_REFERER']).'');
 
-				return;
-			} else {
-				msg(array("type" => "message", "text" => $lang['subscribe_comments:err.subscribepageyet']));
-				header('Refresh: ' . $timeout . '; URL=' . secure_html($_SERVER["HTTP_REFERER"]) . '');
-
-				return;
-			}
-			break;
-	}
-	/*
-		$tpl->template('subscribe_comments', tpl_site.'plugins/subscribe_comments');
-		$tpl->vars('subscribe_comments', $tcvars);
-		$template['vars']['mainblock'] = $tpl->show('comments.subscribe');
-	*/
+                return;
+            }
+            break;
+    }
+    /*
+        $tpl->template('subscribe_comments', tpl_site.'plugins/subscribe_comments');
+        $tpl->vars('subscribe_comments', $tcvars);
+        $template['vars']['mainblock'] = $tpl->show('comments.subscribe');
+    */
 }
 
-register_filter('comments', 'subscribe_comments', new SubscribeComments);
-register_filter('news', 'subscribe_comments', new ShowSubscribeForm);
+register_filter('comments', 'subscribe_comments', new SubscribeComments());
+register_filter('news', 'subscribe_comments', new ShowSubscribeForm());
 register_plugin_page('subscribe_comments', '', 'plugin_subscribe_comments', 0);

--- a/subscribe_comments/uninstall.php
+++ b/subscribe_comments/uninstall.php
@@ -1,25 +1,27 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
 plugins_load_config();
-$db_update = array(
-	array(
-		'table'  => 'subscribe_comments',
-		'action' => 'drop',
-	),
-	array(
-		'table'  => 'subscribe_comments_temp',
-		'action' => 'drop',
-	),
-);
+$db_update = [
+    [
+        'table'  => 'subscribe_comments',
+        'action' => 'drop',
+    ],
+    [
+        'table'  => 'subscribe_comments_temp',
+        'action' => 'drop',
+    ],
+];
 if ($_REQUEST['action'] == 'commit') {
-	if (fixdb_plugin_install($plugin, $db_update, 'deinstall')) {
-		plugin_mark_deinstalled($plugin);
-	}
+    if (fixdb_plugin_install($plugin, $db_update, 'deinstall')) {
+        plugin_mark_deinstalled($plugin);
+    }
 } else {
-	generate_install_page($plugin, 'Удаление плагина', 'deinstall');
+    generate_install_page($plugin, 'Удаление плагина', 'deinstall');
 }
-?>

--- a/tags/config.php
+++ b/tags/config.php
@@ -1,100 +1,106 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
 plugins_load_config();
 LoadPluginLang('tags', 'config', '', '', ':');
 // Fill configuration parameters
-$skList = array();
-if ($skDir = opendir(extras_dir . '/tags/tpl/skins')) {
-	while ($skFile = readdir($skDir)) {
-		if (!preg_match('/^\./', $skFile)) {
-			$skList[$skFile] = $skFile;
-		}
-	}
-	closedir($skDir);
+$skList = [];
+if ($skDir = opendir(extras_dir.'/tags/tpl/skins')) {
+    while ($skFile = readdir($skDir)) {
+        if (!preg_match('/^\./', $skFile)) {
+            $skList[$skFile] = $skFile;
+        }
+    }
+    closedir($skDir);
 }
-$cfg = array();
+$cfg = [];
 //array_push($cfg, array('descr' => $lang['tags:descr']));
-array_push($cfg, array('name' => 'rebuild', 'title' => $lang['tags:cmd.rebuild'], 'descr' => $lang['tags:cmd.rebuild#desc'], 'type' => 'select', 'value' => 0, 'values' => array(0 => $lang['noa'], 1 => $lang['yesa']), 'nosave' => 1));
-$cfgX = array();
-array_push($cfgX, array('name' => 'limit', 'title' => $lang['tags:sidebar.limit'], 'descr' => $lang['tags:sidebar.limit#desc'], 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'limit')));
-array_push($cfgX, array('name' => 'orderby', 'title' => $lang['tags:ppage.orderby'], 'descr' => $lang['tags:ppage.orderby#desc'], 'type' => 'select', 'values' => array('0' => $lang['tags:ppage.order.rand'], '1' => $lang['tags:ppage.order.tag_asc'], '2' => $lang['tags:ppage.order.tag_desc'], '3' => $lang['tags:ppage.order.pop_asc'], '4' => $lang['tags:ppage.order.pop_desc']), 'value' => pluginGetVariable($plugin, 'orderby')));
-array_push($cfgX, array('name' => 'catfilter', 'title' => $lang['tags:sidebar.catfilter'], 'descr' => $lang['tags:sidebar.catfilter#desc'], 'type' => 'select', 'values' => array('0' => $lang['tags:sidebar.filter.all'], '1' => $lang['tags:sidebar.filter.category']), 'value' => pluginGetVariable($plugin, 'catfilter')));
-array_push($cfgX, array('name' => 'newsfilter', 'title' => $lang['tags:sidebar.newsfilter'], 'descr' => $lang['tags:sidebar.newsfilter#desc'], 'type' => 'select', 'values' => array('0' => $lang['tags:sidebar.filter.all'], '1' => $lang['tags:sidebar.filter.news']), 'value' => pluginGetVariable($plugin, 'newsfilter')));
-array_push($cfgX, array('name' => 'age', 'title' => $lang['tags:sidebar.age'], 'descr' => $lang['tags:sidebar.age#desc'], 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'age')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>' . $lang['tags:block.sidebar'] . '</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'ppage_orderby', 'title' => $lang['tags:ppage.orderby'], 'descr' => $lang['tags:ppage.orderby#desc'], 'type' => 'select', 'values' => array('0' => $lang['tags:ppage.order.rand'], '1' => $lang['tags:ppage.order.tag_asc'], '2' => $lang['tags:ppage.order.tag_desc'], '3' => $lang['tags:ppage.order.pop_asc'], '4' => $lang['tags:ppage.order.pop_desc']), 'value' => pluginGetVariable($plugin, 'ppage_orderby')));
-array_push($cfgX, array('name' => 'ppage_paginator', 'title' => $lang['tags:ppage.paginator'], 'descr' => $lang['tags:ppage.paginator#desc'], 'type' => 'select', 'values' => array('1' => $lang['yesa'], '0' => $lang['noa']), 'value' => (pluginGetVariable($plugin, 'ppage_paginator')) ? pluginGetVariable($plugin, 'ppage_paginator') : 0));
-array_push($cfgX, array('name' => 'ppage_limit', 'title' => $lang['tags:ppage.limit'], 'descr' => $lang['tags:ppage.limit#desc'], 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'ppage_limit')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>' . $lang['tags:block.ppage'] . '</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'tpage_paginator', 'title' => $lang['tags:tpage.paginator'], 'descr' => $lang['tags:tpage.paginator#desc'], 'type' => 'select', 'values' => array('1' => $lang['yesa'], '0' => $lang['noa']), 'value' => (pluginGetVariable($plugin, 'tpage_paginator')) ? pluginGetVariable($plugin, 'tpage_paginator') : 0));
-array_push($cfgX, array('name' => 'tpage_limit', 'title' => $lang['tags:tpage.limit'], 'descr' => $lang['tags:tpage.limit#desc'], 'type' => 'input', 'value' => (pluginGetVariable($plugin, 'tpage_limit')) ? pluginGetVariable($plugin, 'tpage_limit') : 0));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>' . $lang['tags:block.tpage'] . '</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'manualstyle', 'title' => $lang['tags:manualstyle'], 'descr' => $lang['tags:manualstyle#desc'], 'type' => 'select', 'values' => array('1' => $lang['yesa'], '0' => $lang['noa']), 'value' => (pluginGetVariable($plugin, 'manualstyle')) ? pluginGetVariable($plugin, 'manualstyle') : 0));
-array_push($cfgX, array('name' => 'styles', 'title' => $lang['tags:styles'], 'descr' => $lang['tags:styles#desc'], 'type' => 'input', 'html_flags' => 'size=70', 'value' => pluginGetVariable('tags', 'styles')));
-array_push($cfgX, array('name' => 'styles_weight', 'title' => $lang['tags:styles.weight'], 'descr' => $lang['tags:styles.weight#desc'], 'type' => 'text', 'html_flags' => 'cols=65 rows=4', 'value' => pluginGetVariable('tags', 'styles_weight')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>' . $lang['tags:block.stylecontrol'] . '</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'localsource', 'title' => $lang['tags:localsource'], 'descr' => $lang['tags:localsource#desc'], 'type' => 'select', 'values' => array('0' => $lang['tags:lsrc_site'], '1' => $lang['tags:lsrc_plugin']), 'value' => intval(pluginGetVariable($plugin, 'localsource'))));
-array_push($cfgX, array('name' => 'skin', 'title' => $lang['tags:skin'], 'descr' => $lang['tags:skin#desc'], 'type' => 'select', 'values' => $skList, 'value' => pluginGetVariable('tags', 'skin')));
-array_push($cfgX, array('name' => 'cloud3d', 'title' => $lang['tags:cloud3d'], 'descr' => $lang['tags:cloud3d#desc'], 'type' => 'select', 'values' => array('0' => $lang['noa'], '1' => $lang['yesa']), 'value' => pluginGetVariable('tags', 'cloud3d')));
-array_push($cfgX, array('name' => 'show_always', 'title' => $lang['tags:show_always'], 'descr' => $lang['tags:show_always#desc'], 'type' => 'select', 'values' => array('0' => $lang['noa'], '1' => $lang['yesa']), 'value' => pluginGetVariable('tags', 'show_always')));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>' . $lang['tags:block.display'] . '</b>', 'entries' => $cfgX));
-$cfgX = array();
-array_push($cfgX, array('name' => 'cache', 'title' => $lang['tags:cache.use'], 'descr' => $lang['tags:cache.use#desc'], 'type' => 'select', 'values' => array('1' => $lang['yesa'], '0' => $lang['noa']), 'value' => intval(pluginGetVariable($plugin, 'cache'))));
-array_push($cfgX, array('name' => 'cacheExpire', 'title' => $lang['tags:cache.expire'], 'descr' => $lang['tags:cache.expire#desc'], 'type' => 'input', 'value' => intval(pluginGetVariable($plugin, 'cacheExpire')) ? pluginGetVariable($plugin, 'cacheExpire') : '60'));
-array_push($cfg, array('mode' => 'group', 'title' => '<b>' . $lang['tags:cfg_cache'] . '</b>', 'entries' => $cfgX));
+array_push($cfg, ['name' => 'rebuild', 'title' => $lang['tags:cmd.rebuild'], 'descr' => $lang['tags:cmd.rebuild#desc'], 'type' => 'select', 'value' => 0, 'values' => [0 => $lang['noa'], 1 => $lang['yesa']], 'nosave' => 1]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'limit', 'title' => $lang['tags:sidebar.limit'], 'descr' => $lang['tags:sidebar.limit#desc'], 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'limit')]);
+array_push($cfgX, ['name' => 'orderby', 'title' => $lang['tags:ppage.orderby'], 'descr' => $lang['tags:ppage.orderby#desc'], 'type' => 'select', 'values' => ['0' => $lang['tags:ppage.order.rand'], '1' => $lang['tags:ppage.order.tag_asc'], '2' => $lang['tags:ppage.order.tag_desc'], '3' => $lang['tags:ppage.order.pop_asc'], '4' => $lang['tags:ppage.order.pop_desc']], 'value' => pluginGetVariable($plugin, 'orderby')]);
+array_push($cfgX, ['name' => 'catfilter', 'title' => $lang['tags:sidebar.catfilter'], 'descr' => $lang['tags:sidebar.catfilter#desc'], 'type' => 'select', 'values' => ['0' => $lang['tags:sidebar.filter.all'], '1' => $lang['tags:sidebar.filter.category']], 'value' => pluginGetVariable($plugin, 'catfilter')]);
+array_push($cfgX, ['name' => 'newsfilter', 'title' => $lang['tags:sidebar.newsfilter'], 'descr' => $lang['tags:sidebar.newsfilter#desc'], 'type' => 'select', 'values' => ['0' => $lang['tags:sidebar.filter.all'], '1' => $lang['tags:sidebar.filter.news']], 'value' => pluginGetVariable($plugin, 'newsfilter')]);
+array_push($cfgX, ['name' => 'age', 'title' => $lang['tags:sidebar.age'], 'descr' => $lang['tags:sidebar.age#desc'], 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'age')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>'.$lang['tags:block.sidebar'].'</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'ppage_orderby', 'title' => $lang['tags:ppage.orderby'], 'descr' => $lang['tags:ppage.orderby#desc'], 'type' => 'select', 'values' => ['0' => $lang['tags:ppage.order.rand'], '1' => $lang['tags:ppage.order.tag_asc'], '2' => $lang['tags:ppage.order.tag_desc'], '3' => $lang['tags:ppage.order.pop_asc'], '4' => $lang['tags:ppage.order.pop_desc']], 'value' => pluginGetVariable($plugin, 'ppage_orderby')]);
+array_push($cfgX, ['name' => 'ppage_paginator', 'title' => $lang['tags:ppage.paginator'], 'descr' => $lang['tags:ppage.paginator#desc'], 'type' => 'select', 'values' => ['1' => $lang['yesa'], '0' => $lang['noa']], 'value' => (pluginGetVariable($plugin, 'ppage_paginator')) ? pluginGetVariable($plugin, 'ppage_paginator') : 0]);
+array_push($cfgX, ['name' => 'ppage_limit', 'title' => $lang['tags:ppage.limit'], 'descr' => $lang['tags:ppage.limit#desc'], 'type' => 'input', 'html_flags' => 'size="4"', 'value' => pluginGetVariable($plugin, 'ppage_limit')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>'.$lang['tags:block.ppage'].'</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'tpage_paginator', 'title' => $lang['tags:tpage.paginator'], 'descr' => $lang['tags:tpage.paginator#desc'], 'type' => 'select', 'values' => ['1' => $lang['yesa'], '0' => $lang['noa']], 'value' => (pluginGetVariable($plugin, 'tpage_paginator')) ? pluginGetVariable($plugin, 'tpage_paginator') : 0]);
+array_push($cfgX, ['name' => 'tpage_limit', 'title' => $lang['tags:tpage.limit'], 'descr' => $lang['tags:tpage.limit#desc'], 'type' => 'input', 'value' => (pluginGetVariable($plugin, 'tpage_limit')) ? pluginGetVariable($plugin, 'tpage_limit') : 0]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>'.$lang['tags:block.tpage'].'</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'manualstyle', 'title' => $lang['tags:manualstyle'], 'descr' => $lang['tags:manualstyle#desc'], 'type' => 'select', 'values' => ['1' => $lang['yesa'], '0' => $lang['noa']], 'value' => (pluginGetVariable($plugin, 'manualstyle')) ? pluginGetVariable($plugin, 'manualstyle') : 0]);
+array_push($cfgX, ['name' => 'styles', 'title' => $lang['tags:styles'], 'descr' => $lang['tags:styles#desc'], 'type' => 'input', 'html_flags' => 'size=70', 'value' => pluginGetVariable('tags', 'styles')]);
+array_push($cfgX, ['name' => 'styles_weight', 'title' => $lang['tags:styles.weight'], 'descr' => $lang['tags:styles.weight#desc'], 'type' => 'text', 'html_flags' => 'cols=65 rows=4', 'value' => pluginGetVariable('tags', 'styles_weight')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>'.$lang['tags:block.stylecontrol'].'</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'localsource', 'title' => $lang['tags:localsource'], 'descr' => $lang['tags:localsource#desc'], 'type' => 'select', 'values' => ['0' => $lang['tags:lsrc_site'], '1' => $lang['tags:lsrc_plugin']], 'value' => intval(pluginGetVariable($plugin, 'localsource'))]);
+array_push($cfgX, ['name' => 'skin', 'title' => $lang['tags:skin'], 'descr' => $lang['tags:skin#desc'], 'type' => 'select', 'values' => $skList, 'value' => pluginGetVariable('tags', 'skin')]);
+array_push($cfgX, ['name' => 'cloud3d', 'title' => $lang['tags:cloud3d'], 'descr' => $lang['tags:cloud3d#desc'], 'type' => 'select', 'values' => ['0' => $lang['noa'], '1' => $lang['yesa']], 'value' => pluginGetVariable('tags', 'cloud3d')]);
+array_push($cfgX, ['name' => 'show_always', 'title' => $lang['tags:show_always'], 'descr' => $lang['tags:show_always#desc'], 'type' => 'select', 'values' => ['0' => $lang['noa'], '1' => $lang['yesa']], 'value' => pluginGetVariable('tags', 'show_always')]);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>'.$lang['tags:block.display'].'</b>', 'entries' => $cfgX]);
+$cfgX = [];
+array_push($cfgX, ['name' => 'cache', 'title' => $lang['tags:cache.use'], 'descr' => $lang['tags:cache.use#desc'], 'type' => 'select', 'values' => ['1' => $lang['yesa'], '0' => $lang['noa']], 'value' => intval(pluginGetVariable($plugin, 'cache'))]);
+array_push($cfgX, ['name' => 'cacheExpire', 'title' => $lang['tags:cache.expire'], 'descr' => $lang['tags:cache.expire#desc'], 'type' => 'input', 'value' => intval(pluginGetVariable($plugin, 'cacheExpire')) ? pluginGetVariable($plugin, 'cacheExpire') : '60']);
+array_push($cfg, ['mode' => 'group', 'title' => '<b>'.$lang['tags:cfg_cache'].'</b>', 'entries' => $cfgX]);
 if (!$_REQUEST['action']) {
-	generate_config_page($plugin, $cfg);
+    generate_config_page($plugin, $cfg);
 } elseif ($_REQUEST['action'] == 'commit') {
-	if ($_REQUEST['rebuild']) {
-		// Rebuild index table
-		// * Truncate index
-		$mysql->query("truncate table " . prefix . "_tags_index");
-		// * LOCK
-		$mysql->query("lock tables " . prefix . "_tags write, " . prefix . "_tags_index write, " . prefix . "_tags_index i write, " . prefix . "_news read, " . prefix . "_news n read");
-		// * Zero counters
-		$mysql->query("update " . prefix . "_tags set posts = 0");
-		// * Scan news [ FILL TAGS ARRAY IN MEMORY ] [ FILL NEWS with tags ARRAY IN MEMORY ]
-		$tags = array();
-		$tagIndexSQL = $mysql->select("select id, tags from " . prefix . "_news where (tags is not NULL) and (tags <> '') and (approve = 1)");
-		foreach ($tagIndexSQL as $row) {
-			$ntags = preg_split("/, */", trim($row['tags']));
-			foreach ($ntags as $ntag) {
-				$ntag = trim($ntag);
-				if (!strlen($ntag))
-					continue;
-				$tags[$ntag] = $tags[$ntag] + 1;
-			}
-		}
-		// * Process counters
-		foreach ($tags as $tag => $cnt) {
-			$mysql->query("insert into " . prefix . "_tags (tag, posts) values (" . db_squote($tag) . "," . intval($cnt) . ") on duplicate key update posts = posts + " . intval($cnt));
-		}
-		// * Regenerate counters
-		foreach ($tagIndexSQL as $row) {
-			$ntags = preg_split("/, */", trim($row['tags']));
-			$ntagsQ = array();
-			foreach ($ntags as $tag) {
-				$tag = trim($tag);
-				if (!strlen($tag))
-					continue;
-				$ntagsQ[] = db_squote($tag);
-			}
-			if (sizeof($ntagsQ))
-				$mysql->query("insert into " . prefix . "_tags_index (newsID, tagID) select " . db_squote($row['id']) . ", id from " . prefix . "_tags where tag in (" . join(",", $ntagsQ) . ")");
-		}
-		// * DELETE unused tags
-		$mysql->query("delete from " . prefix . "_tags where posts = 0");
-		$mysql->query("unlock tables");
-		print $lang['tags:cmd.rebuild.done'] . "<br/>";
-	}
-	commit_plugin_config_changes($plugin, $cfg);
-	print_commit_complete($plugin);
+    if ($_REQUEST['rebuild']) {
+        // Rebuild index table
+        // * Truncate index
+        $mysql->query('truncate table '.prefix.'_tags_index');
+        // * LOCK
+        $mysql->query('lock tables '.prefix.'_tags write, '.prefix.'_tags_index write, '.prefix.'_tags_index i write, '.prefix.'_news read, '.prefix.'_news n read');
+        // * Zero counters
+        $mysql->query('update '.prefix.'_tags set posts = 0');
+        // * Scan news [ FILL TAGS ARRAY IN MEMORY ] [ FILL NEWS with tags ARRAY IN MEMORY ]
+        $tags = [];
+        $tagIndexSQL = $mysql->select('select id, tags from '.prefix."_news where (tags is not NULL) and (tags <> '') and (approve = 1)");
+        foreach ($tagIndexSQL as $row) {
+            $ntags = preg_split('/, */', trim($row['tags']));
+            foreach ($ntags as $ntag) {
+                $ntag = trim($ntag);
+                if (!strlen($ntag)) {
+                    continue;
+                }
+                $tags[$ntag] = $tags[$ntag] + 1;
+            }
+        }
+        // * Process counters
+        foreach ($tags as $tag => $cnt) {
+            $mysql->query('insert into '.prefix.'_tags (tag, posts) values ('.db_squote($tag).','.intval($cnt).') on duplicate key update posts = posts + '.intval($cnt));
+        }
+        // * Regenerate counters
+        foreach ($tagIndexSQL as $row) {
+            $ntags = preg_split('/, */', trim($row['tags']));
+            $ntagsQ = [];
+            foreach ($ntags as $tag) {
+                $tag = trim($tag);
+                if (!strlen($tag)) {
+                    continue;
+                }
+                $ntagsQ[] = db_squote($tag);
+            }
+            if (count($ntagsQ)) {
+                $mysql->query('insert into '.prefix.'_tags_index (newsID, tagID) select '.db_squote($row['id']).', id from '.prefix.'_tags where tag in ('.implode(',', $ntagsQ).')');
+            }
+        }
+        // * DELETE unused tags
+        $mysql->query('delete from '.prefix.'_tags where posts = 0');
+        $mysql->query('unlock tables');
+        echo $lang['tags:cmd.rebuild.done'].'<br/>';
+    }
+    commit_plugin_config_changes($plugin, $cfg);
+    print_commit_complete($plugin);
 }

--- a/tags/deinstall.php
+++ b/tags/deinstall.php
@@ -1,33 +1,35 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
 plugins_load_config();
 LoadPluginLang($plugin, 'main');
-$db_update = array(
-	array(
-		'table'  => 'tags',
-		'action' => 'drop',
-	),
-	array(
-		'table'  => 'tags_index',
-		'action' => 'drop',
-	),
-	//	array(
-	//		'table'		=>	'news',
-	//		'action'	=>	'modify',
-	//		'fields'	=>	array(
-	//			array('action' => 'drop', 'name' => 'tags')
-	//		)
-	//	)
-);
+$db_update = [
+    [
+        'table'  => 'tags',
+        'action' => 'drop',
+    ],
+    [
+        'table'  => 'tags_index',
+        'action' => 'drop',
+    ],
+    //	array(
+    //		'table'		=>	'news',
+    //		'action'	=>	'modify',
+    //		'fields'	=>	array(
+    //			array('action' => 'drop', 'name' => 'tags')
+    //		)
+    //	)
+];
 if ($_REQUEST['action'] == 'commit') {
-	if (fixdb_plugin_install($plugin, $db_update, 'deinstall')) {
-		plugin_mark_deinstalled($plugin);
-	}
+    if (fixdb_plugin_install($plugin, $db_update, 'deinstall')) {
+        plugin_mark_deinstalled($plugin);
+    }
 } else {
-	generate_install_page($plugin, '', 'deinstall');
+    generate_install_page($plugin, '', 'deinstall');
 }
-?>

--- a/tags/install.php
+++ b/tags/install.php
@@ -1,6 +1,9 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
@@ -11,70 +14,70 @@ if (!defined('NGCMS')) die ('HAL');
 //	apply		- apply installation, with handy confirmation
 //	autoapply       - apply installation in automatic mode [INSTALL script]
 //
-function plugin_tags_install($action) {
+function plugin_tags_install($action)
+{
+    global $lang;
+    if ($action != 'autoapply') {
+        loadPluginLang('tags', 'config', '', '', ':');
+    }
+    // Fill DB_UPDATE configuration scheme
+    $db_update = [
+        [
+            'table'  => 'news',
+            'action' => 'modify',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'tags', 'type' => 'varchar(255)', 'params' => ''],
+            ],
+        ],
+        [
+            'table'  => 'tags',
+            'action' => 'cmodify',
+            'key'    => 'primary key(`id`), unique key `tag` (`tag`)',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'],
+                ['action' => 'cmodify', 'name' => 'tag', 'type' => 'varchar(60)', 'params' => ''],
+                ['action' => 'cmodify', 'name' => 'posts', 'type' => 'int', 'params' => 'default 1'],
+            ],
+        ],
+        [
+            'table'  => 'tags_index',
+            'action' => 'cmodify',
+            'key'    => 'primary key(`id`), key `tagID` (`tagID`), key `newsID` (`newsID`) ',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'],
+                ['action' => 'cmodify', 'name' => 'newsID', 'type' => 'int'],
+                ['action' => 'cmodify', 'name' => 'tagID', 'type' => 'varchar(60)', 'params' => ''],
+            ],
+        ],
+    ];
+    // Apply requested action
+    switch ($action) {
+        case 'confirm':
+            generate_install_page('tags', $lang['tags:desc_install']);
+            break;
+        case 'autoapply':
+        case 'apply':
+            if (fixdb_plugin_install('tags', $db_update, 'install', ($action == 'autoapply') ? true : false)) {
+                plugin_mark_installed('tags');
+            } else {
+                return false;
+            }
+            // Now we need to set some default params
+            $params = [
+                'limit'         => 20,
+                'orderby'       => 4,
+                'ppage_limit'   => 0,
+                'ppage_orderby' => 1,
+                'localsource'   => 0,
+                'cache'         => 1,
+                'cacheExpire'   => 120,
+            ];
+            foreach ($params as $k => $v) {
+                extra_set_param('tags', $k, $v);
+            }
+            extra_commit_changes();
+            break;
+    }
 
-	global $lang;
-	if ($action != 'autoapply')
-		loadPluginLang('tags', 'config', '', '', ':');
-	// Fill DB_UPDATE configuration scheme
-	$db_update = array(
-		array(
-			'table'  => 'news',
-			'action' => 'modify',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'tags', 'type' => 'varchar(255)', 'params' => ''),
-			)
-		),
-		array(
-			'table'  => 'tags',
-			'action' => 'cmodify',
-			'key'    => 'primary key(`id`), unique key `tag` (`tag`)',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'),
-				array('action' => 'cmodify', 'name' => 'tag', 'type' => 'varchar(60)', 'params' => ''),
-				array('action' => 'cmodify', 'name' => 'posts', 'type' => 'int', 'params' => 'default 1'),
-			)
-		),
-		array(
-			'table'  => 'tags_index',
-			'action' => 'cmodify',
-			'key'    => 'primary key(`id`), key `tagID` (`tagID`), key `newsID` (`newsID`) ',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'),
-				array('action' => 'cmodify', 'name' => 'newsID', 'type' => 'int'),
-				array('action' => 'cmodify', 'name' => 'tagID', 'type' => 'varchar(60)', 'params' => ''),
-			)
-		),
-	);
-	// Apply requested action
-	switch ($action) {
-		case 'confirm':
-			generate_install_page('tags', $lang['tags:desc_install']);
-			break;
-		case 'autoapply':
-		case 'apply':
-			if (fixdb_plugin_install('tags', $db_update, 'install', ($action == 'autoapply') ? true : false)) {
-				plugin_mark_installed('tags');
-			} else {
-				return false;
-			}
-			// Now we need to set some default params
-			$params = array(
-				'limit'         => 20,
-				'orderby'       => 4,
-				'ppage_limit'   => 0,
-				'ppage_orderby' => 1,
-				'localsource'   => 0,
-				'cache'         => 1,
-				'cacheExpire'   => 120,
-			);
-			foreach ($params as $k => $v) {
-				extra_set_param('tags', $k, $v);
-			}
-			extra_commit_changes();
-			break;
-	}
-
-	return true;
+    return true;
 }
-

--- a/tags/lib/librpc.php
+++ b/tags/lib/librpc.php
@@ -9,7 +9,7 @@ rpcRegisterFunction('plugin.tags.suggest', function (string $params): array {
     // Only registered users can use suggest
     if (!is_array($userROW)) {
         return [
-            'status' => 0,
+            'status'    => 0,
             'errorCode' => 1,
             'errorText' => 'Permission denied',
 
@@ -19,7 +19,7 @@ rpcRegisterFunction('plugin.tags.suggest', function (string $params): array {
     // Check if suggest module is enabled
     if (pluginGetVariable('tags', 'suggestHelper')) {
         return [
-            'status' => 0,
+            'status'    => 0,
             'errorCode' => 2,
             'errorText' => 'Suggest helper is not enabled',
 
@@ -32,20 +32,20 @@ rpcRegisterFunction('plugin.tags.suggest', function (string $params): array {
     if ($params) {
         $searchTag = db_squote($params.'%');
 
-        $sql = "select * from ".prefix."_tags where tag like ".$searchTag." order by posts desc limit 20";
+        $sql = 'select * from '.prefix.'_tags where tag like '.$searchTag.' order by posts desc limit 20';
 
         foreach ($mysql->select($sql) as $row) {
             $output[] = [
                 $row['tag'],
-                $row['posts'].' постов'
+                $row['posts'].' постов',
             ];
         }
     }
 
     return [
-        'status' => 1,
+        'status'    => 1,
         'errorCode' => 0,
-        'data' => [
+        'data'      => [
             $params,
             $output,
 

--- a/tags/tags.php
+++ b/tags/tags.php
@@ -1,290 +1,328 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
-
-class TagsNewsfilter extends NewsFilter {
-
-	function addNewsForm(&$tvars) {
-
-		global $tpl;
-		$tpath = locatePluginTemplates(array('tags_addnews'), 'tags', pluginGetVariable('tags', 'localsource'), pluginGetVariable('tags', 'skin') ? pluginGetVariable('tags', 'skin') : 'default');
-		$tpl->template('tags_addnews', $tpath['tags_addnews']);
-		$tpl->vars('tags_addnews', array('vars' => array('localPrefix' => localPrefix)));
-		$tvars['plugin']['tags'] = $tpl->show('tags_addnews');
-
-		return 1;
-	}
-
-	function addNews(&$tvars, &$SQL) {
-
-		// Scan tags, delete dups
-		$tags = array();
-		foreach (explode(",", $_REQUEST['tags']) as $tag) {
-			$tag = trim($tag);
-			if (!strlen($tag)) continue;
-			$tags[$tag] = 1;
-		}
-		// Make a resulting line
-		$SQL['tags'] = sizeof($tags) ? join(", ", array_keys($tags)) : '';
-
-		return 1;
-	}
-
-	function addNewsNotify(&$tvars, $SQL, $newsid) {
-
-		global $mysql;
-		// Make activities only in case when news is marked as 'published'
-		if (!$SQL['approve'])
-			return 1;
-		if (!isset($SQL['tags']))
-			return 1;
-		// New Tags
-		$tagsNew = array();
-		$tagsNewQ = array();
-		foreach (explode(",", $SQL['tags']) as $tag) {
-			$tag = trim($tag);
-			if (!strlen($tag)) continue;
-			$tagsNew[] = $tag;
-			$tagsNewQ[] = db_squote($tag);
-		}
-		// Update counters for TAGS - add
-		if (sizeof($tagsNewQ))
-			foreach ($tagsNewQ as $tag)
-				$mysql->query("insert into " . prefix . "_tags (tag) values (" . $tag . ") on duplicate key update posts = posts + 1");
-		// Recreate indexes for this news
-		if (sizeof($tagsNewQ))
-			$mysql->query("insert into " . prefix . "_tags_index (newsID, tagID) select " . db_squote($newsid) . ", id from " . prefix . "_tags where tag in (" . join(",", $tagsNewQ) . ")");
-
-		return 1;
-	}
-
-	function editNewsForm($newsID, $SQLold, &$tvars) {
-
-		global $tpl;
-		$tpath = locatePluginTemplates(array('tags_editnews'), 'tags', pluginGetVariable('tags', 'localsource'), pluginGetVariable('tags', 'skin') ? pluginGetVariable('tags', 'skin') : 'default');
-		$tpl->template('tags_editnews', $tpath['tags_editnews']);
-		$tpl->vars('tags_editnews', array('vars' => array('tags' => secure_html($SQLold['tags']), 'localPrefix' => localPrefix)));
-		$tvars['plugin']['tags'] = $tpl->show('tags_editnews');
-
-		return 1;
-	}
-
-	function editNews($newsID, $SQLold, &$SQLnew, &$tvars) {
-
-		// Scan tags, delete dups
-		$tags = array();
-		// Activate only if tags parameter is passed
-		if (!isset($_REQUEST['tags'])) {
-			$SQLnew['tags'] = $SQLold['tags'];
-
-			return 1;
-		}
-		foreach (explode(",", $_REQUEST['tags']) as $tag) {
-			$tag = trim($tag);
-			if (!strlen($tag)) continue;
-			$tags[$tag] = 1;
-		}
-		// Make a resulting line
-		$SQLnew['tags'] = sizeof($tags) ? join(", ", array_keys($tags)) : '';
-
-		return 1;
-	}
-
-	// Make changes in DB after EditNews was successfully executed
-	function editNewsNotify($newsID, $SQLnews, &$SQLnew, &$tvars) {
-
-		global $mysql;
-		// If we edit unpublished news - no action
-		if ((!$SQLnews['approve']) && (!$SQLnew['approve']))
-			return 1;
-		// OLD Tags
-		$tagsOld = array();
-		$tagsOldQ = array();
-		// Mark OLD tags only if news was published before
-		if ($SQLnews['approve'])
-			foreach (explode(",", $SQLnews['tags']) as $tag) {
-				$tag = trim($tag);
-				if (!strlen($tag)) continue;
-				$tagsOld[] = $tag;
-				$tagsOldQ[] = db_squote($tag);
-			}
-		// New Tags
-		$tagsNew = array();
-		$tagsNewQ = array();
-		// Mark NEW tags only if news will stay/become published
-		if ($SQLnew['approve'])
-			foreach (explode(",", $SQLnew['tags']) as $tag) {
-				$tag = trim($tag);
-				if (!strlen($tag)) continue;
-				$tagsNew[] = $tag;
-				$tagsNewQ[] = db_squote($tag);
-			}
-		// List of deleted tags
-		$tagsDelQ = array_diff($tagsOldQ, $tagsNewQ);
-		$tagsAddQ = array_diff($tagsNewQ, $tagsOldQ);
-		$tagsDiffQ = array_merge($tagsDelQ, $tagsAddQ);
-		// Delete tag indexes for news
-		$mysql->query("delete from " . prefix . "_tags_index where newsID = " . $newsID);
-		// Update conters for TAGS - delete old tags
-		if (sizeof($tagsDelQ))
-			$mysql->query("update " . prefix . "_tags set posts = posts - 1 where tag in (" . join(",", $tagsDelQ) . ")");
-		// Delete unused tags
-		$mysql->query("delete from " . prefix . "_tags where posts = 0");
-		// Update counters for TAGS - add
-		if (sizeof($tagsAddQ))
-			foreach ($tagsAddQ as $tag)
-				$mysql->query("insert into " . prefix . "_tags (tag) values (" . $tag . ") on duplicate key update posts = posts + 1");
-		// Recreate indexes for this news
-		if (sizeof($tagsNewQ))
-			$mysql->query("insert into " . prefix . "_tags_index (newsID, tagID) select " . db_squote($newsID) . ", id from " . prefix . "_tags where tag in (" . join(",", $tagsNewQ) . ")");
-
-		return 1;
-	}
-
-	// Add {plugin_tags_news} variable into news
-	function showNews($newsID, $SQLnews, &$tvars, $mode = array()) {
-
-		global $mysql, $tpl;
-		// Check if we have tags in news
-		if (!$SQLnews['tags'] && !pluginGetVariable('tags', 'show_always')) {
-			$tvars['vars']['p']['tags']['flags']['haveTags'] = false;
-			$tvars['regx']["'\[tags\](.*?)\[/tags\]'si"] = '';
-			$tvars['vars']['tags'] = '';
-
-			return 1;
-		}
-		// Load params for display (if needed)
-		if (!isset($this->displayParams) || !is_array($this->displayParams)) {
-			$tpath = locatePluginTemplates(array(':params.ini'), 'tags', pluginGetVariable('tags', 'localsource'), pluginGetVariable('tags', 'skin') ? pluginGetVariable('tags', 'skin') : 'default');
-			$this->displayParams = parse_ini_file($tpath[':params.ini'] . 'params.ini');
-		}
-		// Make a line for display
-		$twigTags = array();
-		$tags = array();
-		foreach (explode(",", $SQLnews['tags']) as $tag) {
-			$tag = trim($tag);
-			if (!$tag) continue;
-			$link = checkLinkAvailable('tags', 'tag') ?
-				generateLink('tags', 'tag', array('tag' => $tag)) :
-				generateLink('core', 'plugin', array('plugin' => 'tags', 'handler' => 'tag'), array('tag' => $tag));
-			$tagValue = str_replace(array('{url}', '{tag}'), array($link, $tag), $this->displayParams['news.tag']);
-			$twigTags [] = array(
-				'name'  => $tag,
-				'link'  => $link,
-				'value' => $tagValue,
-			);
-			$tags[] = $tagValue;
-		}
-		if (count($twigTags)) {
-			$tvars['vars']['p']['tags']['flags']['haveTags'] = true;
-			$tvars['vars']['p']['tags']['count'] = count($twigTags);
-			$tvars['vars']['p']['tags']['list'] = $twigTags;
-			$tvars['vars']['p']['tags']['value'] = count($tags) ? (join($this->displayParams['news.tag.delimiter'], $tags)) : $this->displayParams['news.notags'];;
-		} else {
-			$tvars['vars']['p']['tags']['flags']['haveTags'] = false;
-		}
-		$tvars['vars']['tags'] = count($tags) ? (join($this->displayParams['news.tag.delimiter'], $tags)) : $this->displayParams['news.notags'];
-		$tvars['vars']['[tags]'] = '';
-		$tvars['vars']['[/tags]'] = '';
-
-		return 1;
-	}
-
-	// Delete news call
-	function deleteNews($newsID, $SQLnews) {
-
-		global $mysql;
-		$mysql->query("update " . prefix . "_tags set posts = posts-1 where id in (select tagID from " . prefix . "_tags_index where newsID=" . intval($newsID) . ")");
-		$mysql->query("delete from " . prefix . "_tags_index where newsID = " . intval($newsID));
-		$mysql->query("delete from " . prefix . "_tags where posts = 0");
-
-		return 1;
-	}
-
-	// Mass news modify
-	function massModifyNewsNotify($idList, $setValue, $currentData) {
-
-		global $mysql;
-		// We are interested only in 'approve' field modification
-		if (!isset($setValue['approve']))
-			return 1;
-		// Catch a list of changed news
-		$modList = array();
-		foreach ($currentData as $newsID => $newsData)
-			if ($newsData['approve'] != $setValue['approve'])
-				$modList [] = $newsID;
-		// If no news was changed - exit
-		if (!count($modList))
-			return 1;
-		// Now we have a list of modified news. Let's process this news
-		if ($setValue['approve']) {
-			// * APPROVE NEWS ACTION
-			foreach ($mysql->select("select id, tags from " . prefix . "_news where id in (" . join(", ", $modList) . ")") as $SQL) {
-				$newsid = $SQL['id'];
-				// New Tags
-				$tagsNew = array();
-				$tagsNewQ = array();
-				foreach (explode(",", $SQL['tags']) as $tag) {
-					$tag = trim($tag);
-					if (!$tag) continue;
-					$tagsNew[] = $tag;
-					$tagsNewQ[] = db_squote($tag);
-				}
-				// Update counters for TAGS - add
-				if (sizeof($tagsNewQ))
-					foreach ($tagsNewQ as $tag)
-						$mysql->query("insert into " . prefix . "_tags (tag) values (" . $tag . ") on duplicate key update posts = posts + 1");
-				// Recreate indexes for this news
-				if (sizeof($tagsNewQ))
-					$mysql->query("insert into " . prefix . "_tags_index (newsID, tagID) select " . db_squote($newsid) . ", id from " . prefix . "_tags where tag in (" . join(",", $tagsNewQ) . ")");
-			}
-		} else {
-			// * UNAPPROVE NEWS ACTION
-			foreach ($modList as $newsID) {
-				$mysql->query("update " . prefix . "_tags set posts = posts-1 where id in (select tagID from " . prefix . "_tags_index where newsID=" . intval($newsID) . ")");
-			}
-			$mysql->query("delete from " . prefix . "_tags_index where newsID in (" . join(", ", $modList) . ")");
-			$mysql->query("delete from " . prefix . "_tags where posts = 0");
-		}
-
-		return 1;
-	}
+if (!defined('NGCMS')) {
+    die('HAL');
 }
 
-register_filter('news', 'tags', new TagsNewsFilter);
+class TagsNewsfilter extends NewsFilter
+{
+    public function addNewsForm(&$tvars)
+    {
+        global $tpl;
+        $tpath = locatePluginTemplates(['tags_addnews'], 'tags', pluginGetVariable('tags', 'localsource'), pluginGetVariable('tags', 'skin') ? pluginGetVariable('tags', 'skin') : 'default');
+        $tpl->template('tags_addnews', $tpath['tags_addnews']);
+        $tpl->vars('tags_addnews', ['vars' => ['localPrefix' => localPrefix]]);
+        $tvars['plugin']['tags'] = $tpl->show('tags_addnews');
+
+        return 1;
+    }
+
+    public function addNews(&$tvars, &$SQL)
+    {
+
+        // Scan tags, delete dups
+        $tags = [];
+        foreach (explode(',', $_REQUEST['tags']) as $tag) {
+            $tag = trim($tag);
+            if (!strlen($tag)) {
+                continue;
+            }
+            $tags[$tag] = 1;
+        }
+        // Make a resulting line
+        $SQL['tags'] = count($tags) ? implode(', ', array_keys($tags)) : '';
+
+        return 1;
+    }
+
+    public function addNewsNotify(&$tvars, $SQL, $newsid)
+    {
+        global $mysql;
+        // Make activities only in case when news is marked as 'published'
+        if (!$SQL['approve']) {
+            return 1;
+        }
+        if (!isset($SQL['tags'])) {
+            return 1;
+        }
+        // New Tags
+        $tagsNew = [];
+        $tagsNewQ = [];
+        foreach (explode(',', $SQL['tags']) as $tag) {
+            $tag = trim($tag);
+            if (!strlen($tag)) {
+                continue;
+            }
+            $tagsNew[] = $tag;
+            $tagsNewQ[] = db_squote($tag);
+        }
+        // Update counters for TAGS - add
+        if (count($tagsNewQ)) {
+            foreach ($tagsNewQ as $tag) {
+                $mysql->query('insert into '.prefix.'_tags (tag) values ('.$tag.') on duplicate key update posts = posts + 1');
+            }
+        }
+        // Recreate indexes for this news
+        if (count($tagsNewQ)) {
+            $mysql->query('insert into '.prefix.'_tags_index (newsID, tagID) select '.db_squote($newsid).', id from '.prefix.'_tags where tag in ('.implode(',', $tagsNewQ).')');
+        }
+
+        return 1;
+    }
+
+    public function editNewsForm($newsID, $SQLold, &$tvars)
+    {
+        global $tpl;
+        $tpath = locatePluginTemplates(['tags_editnews'], 'tags', pluginGetVariable('tags', 'localsource'), pluginGetVariable('tags', 'skin') ? pluginGetVariable('tags', 'skin') : 'default');
+        $tpl->template('tags_editnews', $tpath['tags_editnews']);
+        $tpl->vars('tags_editnews', ['vars' => ['tags' => secure_html($SQLold['tags']), 'localPrefix' => localPrefix]]);
+        $tvars['plugin']['tags'] = $tpl->show('tags_editnews');
+
+        return 1;
+    }
+
+    public function editNews($newsID, $SQLold, &$SQLnew, &$tvars)
+    {
+
+        // Scan tags, delete dups
+        $tags = [];
+        // Activate only if tags parameter is passed
+        if (!isset($_REQUEST['tags'])) {
+            $SQLnew['tags'] = $SQLold['tags'];
+
+            return 1;
+        }
+        foreach (explode(',', $_REQUEST['tags']) as $tag) {
+            $tag = trim($tag);
+            if (!strlen($tag)) {
+                continue;
+            }
+            $tags[$tag] = 1;
+        }
+        // Make a resulting line
+        $SQLnew['tags'] = count($tags) ? implode(', ', array_keys($tags)) : '';
+
+        return 1;
+    }
+
+    // Make changes in DB after EditNews was successfully executed
+    public function editNewsNotify($newsID, $SQLnews, &$SQLnew, &$tvars)
+    {
+        global $mysql;
+        // If we edit unpublished news - no action
+        if ((!$SQLnews['approve']) && (!$SQLnew['approve'])) {
+            return 1;
+        }
+        // OLD Tags
+        $tagsOld = [];
+        $tagsOldQ = [];
+        // Mark OLD tags only if news was published before
+        if ($SQLnews['approve']) {
+            foreach (explode(',', $SQLnews['tags']) as $tag) {
+                $tag = trim($tag);
+                if (!strlen($tag)) {
+                    continue;
+                }
+                $tagsOld[] = $tag;
+                $tagsOldQ[] = db_squote($tag);
+            }
+        }
+        // New Tags
+        $tagsNew = [];
+        $tagsNewQ = [];
+        // Mark NEW tags only if news will stay/become published
+        if ($SQLnew['approve']) {
+            foreach (explode(',', $SQLnew['tags']) as $tag) {
+                $tag = trim($tag);
+                if (!strlen($tag)) {
+                    continue;
+                }
+                $tagsNew[] = $tag;
+                $tagsNewQ[] = db_squote($tag);
+            }
+        }
+        // List of deleted tags
+        $tagsDelQ = array_diff($tagsOldQ, $tagsNewQ);
+        $tagsAddQ = array_diff($tagsNewQ, $tagsOldQ);
+        $tagsDiffQ = array_merge($tagsDelQ, $tagsAddQ);
+        // Delete tag indexes for news
+        $mysql->query('delete from '.prefix.'_tags_index where newsID = '.$newsID);
+        // Update conters for TAGS - delete old tags
+        if (count($tagsDelQ)) {
+            $mysql->query('update '.prefix.'_tags set posts = posts - 1 where tag in ('.implode(',', $tagsDelQ).')');
+        }
+        // Delete unused tags
+        $mysql->query('delete from '.prefix.'_tags where posts = 0');
+        // Update counters for TAGS - add
+        if (count($tagsAddQ)) {
+            foreach ($tagsAddQ as $tag) {
+                $mysql->query('insert into '.prefix.'_tags (tag) values ('.$tag.') on duplicate key update posts = posts + 1');
+            }
+        }
+        // Recreate indexes for this news
+        if (count($tagsNewQ)) {
+            $mysql->query('insert into '.prefix.'_tags_index (newsID, tagID) select '.db_squote($newsID).', id from '.prefix.'_tags where tag in ('.implode(',', $tagsNewQ).')');
+        }
+
+        return 1;
+    }
+
+    // Add {plugin_tags_news} variable into news
+    public function showNews($newsID, $SQLnews, &$tvars, $mode = [])
+    {
+        global $mysql, $tpl;
+        // Check if we have tags in news
+        if (!$SQLnews['tags'] && !pluginGetVariable('tags', 'show_always')) {
+            $tvars['vars']['p']['tags']['flags']['haveTags'] = false;
+            $tvars['regx']["'\[tags\](.*?)\[/tags\]'si"] = '';
+            $tvars['vars']['tags'] = '';
+
+            return 1;
+        }
+        // Load params for display (if needed)
+        if (!isset($this->displayParams) || !is_array($this->displayParams)) {
+            $tpath = locatePluginTemplates([':params.ini'], 'tags', pluginGetVariable('tags', 'localsource'), pluginGetVariable('tags', 'skin') ? pluginGetVariable('tags', 'skin') : 'default');
+            $this->displayParams = parse_ini_file($tpath[':params.ini'].'params.ini');
+        }
+        // Make a line for display
+        $twigTags = [];
+        $tags = [];
+        foreach (explode(',', $SQLnews['tags']) as $tag) {
+            $tag = trim($tag);
+            if (!$tag) {
+                continue;
+            }
+            $link = checkLinkAvailable('tags', 'tag') ?
+                generateLink('tags', 'tag', ['tag' => $tag]) :
+                generateLink('core', 'plugin', ['plugin' => 'tags', 'handler' => 'tag'], ['tag' => $tag]);
+            $tagValue = str_replace(['{url}', '{tag}'], [$link, $tag], $this->displayParams['news.tag']);
+            $twigTags[] = [
+                'name'  => $tag,
+                'link'  => $link,
+                'value' => $tagValue,
+            ];
+            $tags[] = $tagValue;
+        }
+        if (count($twigTags)) {
+            $tvars['vars']['p']['tags']['flags']['haveTags'] = true;
+            $tvars['vars']['p']['tags']['count'] = count($twigTags);
+            $tvars['vars']['p']['tags']['list'] = $twigTags;
+            $tvars['vars']['p']['tags']['value'] = count($tags) ? (implode($this->displayParams['news.tag.delimiter'], $tags)) : $this->displayParams['news.notags'];
+        } else {
+            $tvars['vars']['p']['tags']['flags']['haveTags'] = false;
+        }
+        $tvars['vars']['tags'] = count($tags) ? (implode($this->displayParams['news.tag.delimiter'], $tags)) : $this->displayParams['news.notags'];
+        $tvars['vars']['[tags]'] = '';
+        $tvars['vars']['[/tags]'] = '';
+
+        return 1;
+    }
+
+    // Delete news call
+    public function deleteNews($newsID, $SQLnews)
+    {
+        global $mysql;
+        $mysql->query('update '.prefix.'_tags set posts = posts-1 where id in (select tagID from '.prefix.'_tags_index where newsID='.intval($newsID).')');
+        $mysql->query('delete from '.prefix.'_tags_index where newsID = '.intval($newsID));
+        $mysql->query('delete from '.prefix.'_tags where posts = 0');
+
+        return 1;
+    }
+
+    // Mass news modify
+    public function massModifyNewsNotify($idList, $setValue, $currentData)
+    {
+        global $mysql;
+        // We are interested only in 'approve' field modification
+        if (!isset($setValue['approve'])) {
+            return 1;
+        }
+        // Catch a list of changed news
+        $modList = [];
+        foreach ($currentData as $newsID => $newsData) {
+            if ($newsData['approve'] != $setValue['approve']) {
+                $modList[] = $newsID;
+            }
+        }
+        // If no news was changed - exit
+        if (!count($modList)) {
+            return 1;
+        }
+        // Now we have a list of modified news. Let's process this news
+        if ($setValue['approve']) {
+            // * APPROVE NEWS ACTION
+            foreach ($mysql->select('select id, tags from '.prefix.'_news where id in ('.implode(', ', $modList).')') as $SQL) {
+                $newsid = $SQL['id'];
+                // New Tags
+                $tagsNew = [];
+                $tagsNewQ = [];
+                foreach (explode(',', $SQL['tags']) as $tag) {
+                    $tag = trim($tag);
+                    if (!$tag) {
+                        continue;
+                    }
+                    $tagsNew[] = $tag;
+                    $tagsNewQ[] = db_squote($tag);
+                }
+                // Update counters for TAGS - add
+                if (count($tagsNewQ)) {
+                    foreach ($tagsNewQ as $tag) {
+                        $mysql->query('insert into '.prefix.'_tags (tag) values ('.$tag.') on duplicate key update posts = posts + 1');
+                    }
+                }
+                // Recreate indexes for this news
+                if (count($tagsNewQ)) {
+                    $mysql->query('insert into '.prefix.'_tags_index (newsID, tagID) select '.db_squote($newsid).', id from '.prefix.'_tags where tag in ('.implode(',', $tagsNewQ).')');
+                }
+            }
+        } else {
+            // * UNAPPROVE NEWS ACTION
+            foreach ($modList as $newsID) {
+                $mysql->query('update '.prefix.'_tags set posts = posts-1 where id in (select tagID from '.prefix.'_tags_index where newsID='.intval($newsID).')');
+            }
+            $mysql->query('delete from '.prefix.'_tags_index where newsID in ('.implode(', ', $modList).')');
+            $mysql->query('delete from '.prefix.'_tags where posts = 0');
+        }
+
+        return 1;
+    }
+}
+
+register_filter('news', 'tags', new TagsNewsFilter());
 register_plugin_page('tags', '', 'plugin_tags_cloud');
 register_plugin_page('tags', 'tag', 'plugin_tags_tag');
 add_act('index', 'plugin_tags_cloudblock');
 //
 // Show tags cloud
-function plugin_tags_cloud() {
-
-	global $tpl, $template, $mysql, $lang, $SYSTEM_FLAGS;
-	plugin_tags_generatecloud(1, '', intval(pluginGetVariable('tags', 'age')));
+function plugin_tags_cloud()
+{
+    global $tpl, $template, $mysql, $lang, $SYSTEM_FLAGS;
+    plugin_tags_generatecloud(1, '', intval(pluginGetVariable('tags', 'age')));
 }
 
 //
 // Show side cloud block
-function plugin_tags_cloudblock() {
-
-	global $CurrentHandler, $SYSTEM_FLAGS, $catz, $catmap;
-	// Check if we need to limit list of categories with tags
-	$cl = '';
-	if (pluginGetVariable('tags', 'catfilter') && ($CurrentHandler['pluginName'] == 'news') && ($CurrentHandler['handlerName'] == 'by.category')) {
-		// Try to determine category ID
-		if (isset($CurrentHandler['params']['catid']) && isset($catmap[$CurrentHandler['params']['catid']])) {
-			$cl = array(intval($CurrentHandler['params']['catid']));
-		} else if (isset($CurrentHandler['params']['category']) && isset($catz[$CurrentHandler['params']['category']])) {
-			$cl = array($catz[$CurrentHandler['params']['category']]['id']);
-		}
-	} else if (pluginGetVariable('tags', 'newsfilter') && ($CurrentHandler['pluginName'] == 'news') && ($CurrentHandler['handlerName'] == 'news')) {
-		if (is_array($SYSTEM_FLAGS['news']['db.categories']) && (count($SYSTEM_FLAGS['news']['db.categories']) > 0)) {
-			$cl = $SYSTEM_FLAGS['news']['db.categories'];
-		}
-		//	print "<pre>".var_export($CurrentHandler['params'], true)."</pre>";
-		//	print "<pre>".var_export($SYSTEM_FLAGS['news'], true)."</pre>";
-	}
-	plugin_tags_generatecloud(0, $cl, intval(pluginGetVariable('tags', 'age')));
+function plugin_tags_cloudblock()
+{
+    global $CurrentHandler, $SYSTEM_FLAGS, $catz, $catmap;
+    // Check if we need to limit list of categories with tags
+    $cl = '';
+    if (pluginGetVariable('tags', 'catfilter') && ($CurrentHandler['pluginName'] == 'news') && ($CurrentHandler['handlerName'] == 'by.category')) {
+        // Try to determine category ID
+        if (isset($CurrentHandler['params']['catid']) && isset($catmap[$CurrentHandler['params']['catid']])) {
+            $cl = [intval($CurrentHandler['params']['catid'])];
+        } elseif (isset($CurrentHandler['params']['category']) && isset($catz[$CurrentHandler['params']['category']])) {
+            $cl = [$catz[$CurrentHandler['params']['category']]['id']];
+        }
+    } elseif (pluginGetVariable('tags', 'newsfilter') && ($CurrentHandler['pluginName'] == 'news') && ($CurrentHandler['handlerName'] == 'news')) {
+        if (is_array($SYSTEM_FLAGS['news']['db.categories']) && (count($SYSTEM_FLAGS['news']['db.categories']) > 0)) {
+            $cl = $SYSTEM_FLAGS['news']['db.categories'];
+        }
+        //	print "<pre>".var_export($CurrentHandler['params'], true)."</pre>";
+        //	print "<pre>".var_export($SYSTEM_FLAGS['news'], true)."</pre>";
+    }
+    plugin_tags_generatecloud(0, $cl, intval(pluginGetVariable('tags', 'age')));
 }
 
 //
@@ -292,80 +330,83 @@ function plugin_tags_cloudblock() {
 // $params - array with override params
 //		tag		- if set (defined) function will be runned for specified tag
 //
-function plugin_tags_tag($params = array()) {
+function plugin_tags_tag($params = [])
+{
+    global $tpl, $template, $mysql, $lang, $SYSTEM_FLAGS, $CurrentHandler, $TemplateCache;
+    // Determine TAG that will be used for output
+    if (isset($params['tag'])) {
+        $tag = $params['tag'];
+    } else {
+        if (($CurrentHandler['pluginName'] == 'tags') &&
+            ($CurrentHandler['handlerName'] == 'tag') &&
+            isset($CurrentHandler['params']['tag'])
+        ) {
+            $tag = $CurrentHandler['params']['tag'];
+        } else {
+            $tag = $_REQUEST['tag'];
+        }
+    }
+    $tag = str_replace(['&', '<'], ['&amp;', '&lt;'], $tag);
+    // IF no tag is specified - show cloud
+    if (!$tag) {
+        if (!isset($params['tag'])) {
+            plugin_tags_cloud();
+        }
 
-	global $tpl, $template, $mysql, $lang, $SYSTEM_FLAGS, $CurrentHandler, $TemplateCache;
-	// Determine TAG that will be used for output
-	if (isset($params['tag'])) {
-		$tag = $params['tag'];
-	} else {
-		if (($CurrentHandler['pluginName'] == 'tags') &&
-			($CurrentHandler['handlerName'] == 'tag') &&
-			isset($CurrentHandler['params']['tag'])
-		) {
-			$tag = $CurrentHandler['params']['tag'];
-		} else {
-			$tag = $_REQUEST['tag'];
-		}
-	}
-	$tag = str_replace(array('&', '<'), array('&amp;', '&lt;'), $tag);
-	// IF no tag is specified - show cloud
-	if (!$tag) {
-		if (!isset($params['tag']))
-			plugin_tags_cloud();
-
-		return;
-	}
-	LoadPluginLang('tags', 'main', '', '', ':');
-	$SYSTEM_FLAGS['info']['title']['group'] = $lang['tags:header.tag.title'];
-	$tpath = locatePluginTemplates(array('cloud', 'cloud.tag', 'pages', 'cloud.tag.entry'), 'tags', pluginGetVariable('tags', 'localsource'), pluginGetVariable('tags', 'skin') ? pluginGetVariable('tags', 'skin') : 'default');
-	include_once root . 'includes/news.php';
-	// Search for tag in tags table
-	if (!($rec = $mysql->record("select * from " . prefix . "_tags where tag=" . db_squote($tag)))) {
-		// Unknown tag
-		$entries = $lang['tags:nonews'];
-	} else {
-		$SYSTEM_FLAGS['info']['title']['secure_html'] = secure_html($tag);
-		// Set page display limit
-		$perPage = intval(pluginGetVariable('tags', 'tpage_limit'));
-		if (($perPage < 1) || ($perPage > 1000))
-			$perPage = 1000;
-		// Manage pagination
-		if (pluginGetVariable('tags', 'tpage_paginator')) {
-			$tagCount = $mysql->result("select count(*) as cnt from " . prefix . "_tags_index where tagID = " . db_squote($rec['id']));
-			$pagesCount = ceil($tagCount / $perPage);
-			$pageNo = intval($_REQUEST['page']);
-			if ($pageNo < 1)
-				$pageNo = 1;
-			$limit = 'limit ' . (intval($pageNo - 1) * $perPage) . ", " . $perPage;
-			// If we have more than 1 page or current page != 1, we should generate paginator
-			// Load navigation bar
-			templateLoadVariables(true);
-			$navigations = $TemplateCache['site']['#variables']['navigation'];
-			$paginationParams = array('pluginName' => 'core', 'pluginHandler' => 'plugin', 'params' => array('plugin' => 'tags', 'handler' => 'tag'), 'xparams' => array('tag' => $tag), 'paginator' => array('page', 1, false));
-			//
-			$tvars = array();
-			$tvars['regx']["'\[prev-link\](.*?)\[/prev-link\]'si"] = ($pageNo > 1) ? str_replace('%page%', "$1", str_replace('%link%', generatePageLink($paginationParams, $pageNo - 1), $navigations['prevlink'])) : '';
-			$tvars['regx']["'\[next-link\](.*?)\[/next-link\]'si"] = ($pageNo < $pagesCount) ? str_replace('%page%', "$1", str_replace('%link%', generatePageLink($paginationParams, $pageNo + 1), $navigations['nextlink'])) : '';
-			$tvars['vars']['pages'] = generatePagination($pageNo, 1, $pagesCount, 10, $paginationParams, $navigations);
-			$tpl->template('pages', $tpath['pages']);
-			$tpl->vars('pages', $tvars);
-			$pages = $tpl->show('pages');
-		} else {
-			$limit = 'limit ' . $perPage;
-			$pagesCount = 1;
-		}
-		foreach ($mysql->select("select n.* from " . prefix . "_tags_index i left join " . prefix . "_news n on n.id = i.newsID where i.tagID =" . db_squote($rec['id']) . " order by n.postdate desc " . $limit) as $row) {
-			$entries .= news_showone(0, '', array('overrideTemplateName' => 'cloud.tag.entry', 'overrideTemplatePath' => $tpath['cloud.tag.entry'], 'emulate' => $row, 'style' => 'export', 'plugin' => 'tags'));
-		}
-	}
-	$tvars = array('vars' => array('entries' => $entries, 'tag' => $tag, 'pages' => $pages));
-	$tvars['regx']['#\[paginator\](.*?)\[\/paginator\]#is'] = ($pagesCount > 1) ? '$1' : '';
-	// Check if we have template `tag`
-	$tplName = isset($tpath['cloud.tag']) ? 'cloud.tag' : 'cloud';
-	$tpl->template($tplName, $tpath[$tplName]);
-	$tpl->vars($tplName, $tvars);
-	$template['vars']['mainblock'] = $tpl->show($tplName);
+        return;
+    }
+    LoadPluginLang('tags', 'main', '', '', ':');
+    $SYSTEM_FLAGS['info']['title']['group'] = $lang['tags:header.tag.title'];
+    $tpath = locatePluginTemplates(['cloud', 'cloud.tag', 'pages', 'cloud.tag.entry'], 'tags', pluginGetVariable('tags', 'localsource'), pluginGetVariable('tags', 'skin') ? pluginGetVariable('tags', 'skin') : 'default');
+    include_once root.'includes/news.php';
+    // Search for tag in tags table
+    if (!($rec = $mysql->record('select * from '.prefix.'_tags where tag='.db_squote($tag)))) {
+        // Unknown tag
+        $entries = $lang['tags:nonews'];
+    } else {
+        $SYSTEM_FLAGS['info']['title']['secure_html'] = secure_html($tag);
+        // Set page display limit
+        $perPage = intval(pluginGetVariable('tags', 'tpage_limit'));
+        if (($perPage < 1) || ($perPage > 1000)) {
+            $perPage = 1000;
+        }
+        // Manage pagination
+        if (pluginGetVariable('tags', 'tpage_paginator')) {
+            $tagCount = $mysql->result('select count(*) as cnt from '.prefix.'_tags_index where tagID = '.db_squote($rec['id']));
+            $pagesCount = ceil($tagCount / $perPage);
+            $pageNo = intval($_REQUEST['page']);
+            if ($pageNo < 1) {
+                $pageNo = 1;
+            }
+            $limit = 'limit '.(intval($pageNo - 1) * $perPage).', '.$perPage;
+            // If we have more than 1 page or current page != 1, we should generate paginator
+            // Load navigation bar
+            templateLoadVariables(true);
+            $navigations = $TemplateCache['site']['#variables']['navigation'];
+            $paginationParams = ['pluginName' => 'core', 'pluginHandler' => 'plugin', 'params' => ['plugin' => 'tags', 'handler' => 'tag'], 'xparams' => ['tag' => $tag], 'paginator' => ['page', 1, false]];
+            //
+            $tvars = [];
+            $tvars['regx']["'\[prev-link\](.*?)\[/prev-link\]'si"] = ($pageNo > 1) ? str_replace('%page%', '$1', str_replace('%link%', generatePageLink($paginationParams, $pageNo - 1), $navigations['prevlink'])) : '';
+            $tvars['regx']["'\[next-link\](.*?)\[/next-link\]'si"] = ($pageNo < $pagesCount) ? str_replace('%page%', '$1', str_replace('%link%', generatePageLink($paginationParams, $pageNo + 1), $navigations['nextlink'])) : '';
+            $tvars['vars']['pages'] = generatePagination($pageNo, 1, $pagesCount, 10, $paginationParams, $navigations);
+            $tpl->template('pages', $tpath['pages']);
+            $tpl->vars('pages', $tvars);
+            $pages = $tpl->show('pages');
+        } else {
+            $limit = 'limit '.$perPage;
+            $pagesCount = 1;
+        }
+        foreach ($mysql->select('select n.* from '.prefix.'_tags_index i left join '.prefix.'_news n on n.id = i.newsID where i.tagID ='.db_squote($rec['id']).' order by n.postdate desc '.$limit) as $row) {
+            $entries .= news_showone(0, '', ['overrideTemplateName' => 'cloud.tag.entry', 'overrideTemplatePath' => $tpath['cloud.tag.entry'], 'emulate' => $row, 'style' => 'export', 'plugin' => 'tags']);
+        }
+    }
+    $tvars = ['vars' => ['entries' => $entries, 'tag' => $tag, 'pages' => $pages]];
+    $tvars['regx']['#\[paginator\](.*?)\[\/paginator\]#is'] = ($pagesCount > 1) ? '$1' : '';
+    // Check if we have template `tag`
+    $tplName = isset($tpath['cloud.tag']) ? 'cloud.tag' : 'cloud';
+    $tpl->template($tplName, $tpath[$tplName]);
+    $tpl->vars($tplName, $tvars);
+    $template['vars']['mainblock'] = $tpl->show($tplName);
 }
 
 // Generate tags cloud
@@ -373,158 +414,176 @@ function plugin_tags_tag($params = array()) {
 // - $ppage - flag if separate plugin page should be generated (0 - no, 1 - yes)
 // - $catlist - array with list of categories for tag show (will not be filtered if variable is not an array)
 // - $age - if specified, cloud will be build only for news not older than $age days
-function plugin_tags_generatecloud($ppage = 0, $catlist = '', $age = 0) {
+function plugin_tags_generatecloud($ppage = 0, $catlist = '', $age = 0)
+{
+    global $tpl, $template, $mysql, $lang, $config, $SYSTEM_FLAGS, $TemplateCache;
+    LoadPluginLang('tags', 'main', '', '', ':');
+    if ($ppage) {
+        $SYSTEM_FLAGS['info']['title']['group'] = $lang['tags:header.tags.title'];
+    }
+    $masterTPL = $ppage ? 'cloud' : 'sidebar';
+    // Check if we need to limit a list of categories or can load full list of tags from cloud
+    $cl = [];
+    if (is_array($catlist)) {
+        foreach ($catlist as $cat) {
+            if (intval($cat) > 0) {
+                $cl[] = intval($cat);
+            }
+        }
+    }
+    // Generate cache file name [ we should take into account SWITCHER plugin ]
+    $cacheFileName = md5('tags'.$config['home_url'].$config['theme'].$config['default_lang'].$masterTPL.('page'.isset($_REQUEST['page']) ? $_REQUEST['page'] : '').'age'.$age.'cat'.(is_array($cl) ? implode(',', $cl) : $cl)).'.txt';
+    if (pluginGetVariable('tags', 'cache')) {
+        $cacheData = cacheRetrieveFile($cacheFileName, pluginGetVariable('tags', 'cacheExpire'), 'tags');
+        if ($cacheData != false) {
+            // We got data from cache. Return it and stop
+            $template['vars'][$ppage ? 'mainblock' : 'plugin_tags'] = $cacheData;
 
-	global $tpl, $template, $mysql, $lang, $config, $SYSTEM_FLAGS, $TemplateCache;
-	LoadPluginLang('tags', 'main', '', '', ':');
-	if ($ppage)
-		$SYSTEM_FLAGS['info']['title']['group'] = $lang['tags:header.tags.title'];
-	$masterTPL = $ppage ? 'cloud' : 'sidebar';
-	// Check if we need to limit a list of categories or can load full list of tags from cloud
-	$cl = array();
-	if (is_array($catlist)) {
-		foreach ($catlist as $cat) {
-			if (intval($cat) > 0)
-				$cl[] = intval($cat);
-		}
-	}
-	// Generate cache file name [ we should take into account SWITCHER plugin ]
-	$cacheFileName = md5('tags' . $config['home_url'] . $config['theme'] . $config['default_lang'] . $masterTPL . ('page' . isset($_REQUEST['page']) ? $_REQUEST['page'] : '') . 'age' . $age . 'cat' . (is_array($cl) ? join(",", $cl) : $cl)) . '.txt';
-	if (pluginGetVariable('tags', 'cache')) {
-		$cacheData = cacheRetrieveFile($cacheFileName, pluginGetVariable('tags', 'cacheExpire'), 'tags');
-		if ($cacheData != false) {
-			// We got data from cache. Return it and stop
-			$template['vars'][$ppage ? 'mainblock' : 'plugin_tags'] = $cacheData;
-
-			return;
-		}
-	}
-	// Load params for display (if needed)
-	$tpath = locatePluginTemplates(array(':params.ini', 'pages', $masterTPL), 'tags', pluginGetVariable('tags', 'localsource'), pluginGetVariable('tags', 'skin') ? pluginGetVariable('tags', 'skin') : 'default');
-	$displayParams = parse_ini_file($tpath[':params.ini'] . 'params.ini');
-	$tags = array();
-	// Get tags list from SQL
-	switch (pluginGetVariable('tags', ($ppage ? 'ppage_' : '') . 'orderby')) {
-		case 1:
-			$orderby = 'tag';
-			break;
-		case 2:
-			$orderby = 'tag desc';
-			break;
-		case 3:
-			$orderby = 'posts';
-			break;
-		case 4:
-			$orderby = 'posts desc';
-			break;
-		default:
-			$orderby = 'rand()';
-	}
-	// Set page display limit
-	$perPage = intval(pluginGetVariable('tags', ($ppage ? 'ppage_' : '') . 'limit'));
-	if (($perPage < 1) || ($perPage > 1000))
-		$perPage = 1000;
-	if ($ppage) {
-		if (pluginGetVariable('tags', 'ppage_paginator')) {
-			$tagCount = $mysql->result("select count(*) as cnt from " . prefix . "_tags");
-			$pagesCount = ceil($tagCount / $perPage);
-			$pageNo = intval($_REQUEST['page']);
-			if ($pageNo < 1)
-				$pageNo = 1;
-			$limit = 'limit ' . (intval($pageNo - 1) * $perPage) . ", " . $perPage;
-			if ($orderby == 'rand()')
-				$orderby = 'tag';
-		} else {
-			$limit = 'limit ' . $perPage;
-		}
-	} else {
-		$limit = 'limit ' . $perPage;
-	}
-	$rows = $mysql->select(
-		(count($cl) > 0) ?
-			("select DISTINCTROW nt.* from " . prefix . "_tags nt left join " . prefix . "_tags_index ti on nt.id = ti.tagID left join " . prefix . "_news_map nm using(newsID) where nm.categoryID in (" . join(",", $cl) . ")" . (($age > 0) ? " and to_days(nm.dt) + " . intval($age) . " >= to_days(now())" : '') . " order by " . $orderby . ' ' . $limit) :
-			(($age == 0) ?
-				("select * from " . prefix . "_tags order by " . $orderby . ' ' . $limit) :
-				("select DISTINCTROW nt.* from " . prefix . "_tags nt left join " . prefix . "_tags_index ti on nt.id = ti.tagID left join " . prefix . "_news_map nm using(newsID) where to_days(nm.dt) + " . intval($age) . " >= to_days(now()) order by " . $orderby . ' ' . $limit)
-			));
-	// Prepare style definition
-	$wlist = array();
-	if ($manualstyle = intval(pluginGetVariable('tags', 'manualstyle'))) {
-		foreach (explode("\n", pluginGetVariable('tags', 'styles_weight')) as $wrow) {
-			if (preg_match('#^ *(\d+) *\| *(\d+) *\|(.+?) *$#', trim($wrow), $m))
-				array_push($wlist, array($m[1], $m[2], $m[3]));
-		}
-		$stylelist = preg_split("/\, */", trim(pluginGetVariable('tags', 'styles')));
-		if ((($styleListCount = count($stylelist)) < 2) && (($styleWeightListCount = count($wlist)) < 1))
-			$manualstyle = 0;
-	}
-	// Calculate min/max if we have any rows
-	$min = -1;
-	$max = 0;
-	foreach ($rows as $row) {
-		if ($row['posts'] > $max) $max = $row['posts'];
-		if (($min == -1) || ($row['posts'] < $min)) $min = $row['posts'];
-	}
-	// Init variables for 3D cloud
-	$cloud3d = array();
-	$cloudMin = (isset($displayParams['size3d.min']) && (intval($displayParams['size3d.min']) > 0)) ? intval($displayParams['size3d.min']) : 10;
-	$cloudMax = (isset($displayParams['size3d.max']) && (intval($displayParams['size3d.max']) > 0)) ? intval($displayParams['size3d.max']) : 18;
-	if ($cloudMax == $cloudMin) {
-		$cloudMin = 10;
-		$cloudMax = 18;
-	}
-	$cloudStep = abs(round(($max - $min) / ($cloudMax - $cloudMin), 2));
-	if ($cloudStep < 0.01) $cloudStep = 1;
-	// Prepare output rows
-	$tagCount = 0;
-	foreach ($rows as $row) {
-		$tagCount++;
-		$link = checkLinkAvailable('tags', 'tag') ?
-			generateLink('tags', 'tag', array('tag' => $row['tag'])) :
-			generateLink('core', 'plugin', array('plugin' => 'tags', 'handler' => 'tag'), array('tag' => $row['tag']));
-		$cloud3d[] = '<a href="' . $link . '" style="font-size: ' . (round(($row['posts'] - $min) / $cloudStep) + $cloudMin) . 'pt">' . iconv('Windows-1251', 'UTF-8', $row['tag']) . '</a>';
-		if ($manualstyle) {
-			$mmatch = 0;
-			foreach ($wlist as $wrow) {
-				if (($row['posts'] >= $wrow[0]) && ($row['posts'] <= $wrow[1])) {
-					$params = 'class ="' . $wrow[2] . '"';
-					$mmatch = 1;
-					break;
-				}
-			}
-			if (!$mmatch)
-				$params = 'class ="' . ($stylelist[$styleListCount - round($row['posts'] / $max * $styleListCount)]) . '"';
-		} else {
-			$params = 'style ="font-size: ' . (round(($row['posts'] / $max) * 100 + 100)) . '%;"';
-		}
-		$tags[] = str_replace(array('{url}', '{tag}', '{posts}', '{params}'), array($link, $row['tag'], $row['posts'], $params), $displayParams[($ppage ? 'cloud' : 'sidebar') . '.tag']);
-	}
-	$tagList = $tagCount ? (join($displayParams[($ppage ? 'cloud' : 'sidebar') . '.tag.delimiter'] . "\n", $tags)) : ($displayParams[($ppage ? 'cloud' : 'sidebar') . '.notags']);
-	// If we have more than 1 page or current page != 1, we should generate paginator
-	if ($ppage && (($pagesCount > 1) || ($pageNo != 1))) {
-		// Load navigation bar
-		templateLoadVariables(true);
-		$navigations = $TemplateCache['site']['#variables']['navigation'];
-		$paginationParams = array('pluginName' => 'core', 'pluginHandler' => 'plugin', 'params' => array('plugin' => 'tags'), 'xparams' => array(), 'paginator' => array('page', 1, false));
-		//
-		$tvars = array();
-		$tvars['regx']["'\[prev-link\](.*?)\[/prev-link\]'si"] = ($pageNo > 1) ? str_replace('%page%', "$1", str_replace('%link%', generatePageLink($paginationParams, $pageNo - 1), $navigations['prevlink'])) : '';
-		$tvars['regx']["'\[next-link\](.*?)\[/next-link\]'si"] = ($pageNo < $pagesCount) ? str_replace('%page%', "$1", str_replace('%link%', generatePageLink($paginationParams, $pageNo + 1), $navigations['nextlink'])) : '';
-		$tvars['vars']['pages'] = generatePagination($pageNo, 1, $pagesCount, 10, $paginationParams, $navigations);
-		$tpl->template('pages', $tpath['pages']);
-		$tpl->vars('pages', $tvars);
-		$pages = $tpl->show('pages');
-	} else {
-		$pages = '';
-	}
-	$tvars = array('vars' => array('entries' => $tagList, 'tag' => $lang['tags:taglist'], 'pages' => $pages));
-	if (pluginGetVariable('tags', 'cloud3d'))
-		$tvars['vars']['cloud3d'] = urlencode('<tags>' . join(' ', $cloud3d) . '</tags>');
-	$tvars['regx']['#\[paginator\](.*?)\[\/paginator\]#is'] = ($pages != '') ? '$1' : '';
-	$tpl->template($masterTPL, $tpath[$masterTPL]);
-	$tpl->vars($masterTPL, $tvars);
-	$output = $tpl->show($masterTPL);
-	$template['vars'][$ppage ? 'mainblock' : 'plugin_tags'] = $output;
-	if (pluginGetVariable('tags', 'cache'))
-		cacheStoreFile($cacheFileName, $output, 'tags');
+            return;
+        }
+    }
+    // Load params for display (if needed)
+    $tpath = locatePluginTemplates([':params.ini', 'pages', $masterTPL], 'tags', pluginGetVariable('tags', 'localsource'), pluginGetVariable('tags', 'skin') ? pluginGetVariable('tags', 'skin') : 'default');
+    $displayParams = parse_ini_file($tpath[':params.ini'].'params.ini');
+    $tags = [];
+    // Get tags list from SQL
+    switch (pluginGetVariable('tags', ($ppage ? 'ppage_' : '').'orderby')) {
+        case 1:
+            $orderby = 'tag';
+            break;
+        case 2:
+            $orderby = 'tag desc';
+            break;
+        case 3:
+            $orderby = 'posts';
+            break;
+        case 4:
+            $orderby = 'posts desc';
+            break;
+        default:
+            $orderby = 'rand()';
+    }
+    // Set page display limit
+    $perPage = intval(pluginGetVariable('tags', ($ppage ? 'ppage_' : '').'limit'));
+    if (($perPage < 1) || ($perPage > 1000)) {
+        $perPage = 1000;
+    }
+    if ($ppage) {
+        if (pluginGetVariable('tags', 'ppage_paginator')) {
+            $tagCount = $mysql->result('select count(*) as cnt from '.prefix.'_tags');
+            $pagesCount = ceil($tagCount / $perPage);
+            $pageNo = intval($_REQUEST['page']);
+            if ($pageNo < 1) {
+                $pageNo = 1;
+            }
+            $limit = 'limit '.(intval($pageNo - 1) * $perPage).', '.$perPage;
+            if ($orderby == 'rand()') {
+                $orderby = 'tag';
+            }
+        } else {
+            $limit = 'limit '.$perPage;
+        }
+    } else {
+        $limit = 'limit '.$perPage;
+    }
+    $rows = $mysql->select(
+        (count($cl) > 0) ?
+            ('select DISTINCTROW nt.* from '.prefix.'_tags nt left join '.prefix.'_tags_index ti on nt.id = ti.tagID left join '.prefix.'_news_map nm using(newsID) where nm.categoryID in ('.implode(',', $cl).')'.(($age > 0) ? ' and to_days(nm.dt) + '.intval($age).' >= to_days(now())' : '').' order by '.$orderby.' '.$limit) :
+            (
+                ($age == 0) ?
+                ('select * from '.prefix.'_tags order by '.$orderby.' '.$limit) :
+                ('select DISTINCTROW nt.* from '.prefix.'_tags nt left join '.prefix.'_tags_index ti on nt.id = ti.tagID left join '.prefix.'_news_map nm using(newsID) where to_days(nm.dt) + '.intval($age).' >= to_days(now()) order by '.$orderby.' '.$limit)
+            )
+    );
+    // Prepare style definition
+    $wlist = [];
+    if ($manualstyle = intval(pluginGetVariable('tags', 'manualstyle'))) {
+        foreach (explode("\n", pluginGetVariable('tags', 'styles_weight')) as $wrow) {
+            if (preg_match('#^ *(\d+) *\| *(\d+) *\|(.+?) *$#', trim($wrow), $m)) {
+                array_push($wlist, [$m[1], $m[2], $m[3]]);
+            }
+        }
+        $stylelist = preg_split("/\, */", trim(pluginGetVariable('tags', 'styles')));
+        if ((($styleListCount = count($stylelist)) < 2) && (($styleWeightListCount = count($wlist)) < 1)) {
+            $manualstyle = 0;
+        }
+    }
+    // Calculate min/max if we have any rows
+    $min = -1;
+    $max = 0;
+    foreach ($rows as $row) {
+        if ($row['posts'] > $max) {
+            $max = $row['posts'];
+        }
+        if (($min == -1) || ($row['posts'] < $min)) {
+            $min = $row['posts'];
+        }
+    }
+    // Init variables for 3D cloud
+    $cloud3d = [];
+    $cloudMin = (isset($displayParams['size3d.min']) && (intval($displayParams['size3d.min']) > 0)) ? intval($displayParams['size3d.min']) : 10;
+    $cloudMax = (isset($displayParams['size3d.max']) && (intval($displayParams['size3d.max']) > 0)) ? intval($displayParams['size3d.max']) : 18;
+    if ($cloudMax == $cloudMin) {
+        $cloudMin = 10;
+        $cloudMax = 18;
+    }
+    $cloudStep = abs(round(($max - $min) / ($cloudMax - $cloudMin), 2));
+    if ($cloudStep < 0.01) {
+        $cloudStep = 1;
+    }
+    // Prepare output rows
+    $tagCount = 0;
+    foreach ($rows as $row) {
+        $tagCount++;
+        $link = checkLinkAvailable('tags', 'tag') ?
+            generateLink('tags', 'tag', ['tag' => $row['tag']]) :
+            generateLink('core', 'plugin', ['plugin' => 'tags', 'handler' => 'tag'], ['tag' => $row['tag']]);
+        $cloud3d[] = '<a href="'.$link.'" style="font-size: '.(round(($row['posts'] - $min) / $cloudStep) + $cloudMin).'pt">'.iconv('Windows-1251', 'UTF-8', $row['tag']).'</a>';
+        if ($manualstyle) {
+            $mmatch = 0;
+            foreach ($wlist as $wrow) {
+                if (($row['posts'] >= $wrow[0]) && ($row['posts'] <= $wrow[1])) {
+                    $params = 'class ="'.$wrow[2].'"';
+                    $mmatch = 1;
+                    break;
+                }
+            }
+            if (!$mmatch) {
+                $params = 'class ="'.($stylelist[$styleListCount - round($row['posts'] / $max * $styleListCount)]).'"';
+            }
+        } else {
+            $params = 'style ="font-size: '.(round(($row['posts'] / $max) * 100 + 100)).'%;"';
+        }
+        $tags[] = str_replace(['{url}', '{tag}', '{posts}', '{params}'], [$link, $row['tag'], $row['posts'], $params], $displayParams[($ppage ? 'cloud' : 'sidebar').'.tag']);
+    }
+    $tagList = $tagCount ? (implode($displayParams[($ppage ? 'cloud' : 'sidebar').'.tag.delimiter']."\n", $tags)) : ($displayParams[($ppage ? 'cloud' : 'sidebar').'.notags']);
+    // If we have more than 1 page or current page != 1, we should generate paginator
+    if ($ppage && (($pagesCount > 1) || ($pageNo != 1))) {
+        // Load navigation bar
+        templateLoadVariables(true);
+        $navigations = $TemplateCache['site']['#variables']['navigation'];
+        $paginationParams = ['pluginName' => 'core', 'pluginHandler' => 'plugin', 'params' => ['plugin' => 'tags'], 'xparams' => [], 'paginator' => ['page', 1, false]];
+        //
+        $tvars = [];
+        $tvars['regx']["'\[prev-link\](.*?)\[/prev-link\]'si"] = ($pageNo > 1) ? str_replace('%page%', '$1', str_replace('%link%', generatePageLink($paginationParams, $pageNo - 1), $navigations['prevlink'])) : '';
+        $tvars['regx']["'\[next-link\](.*?)\[/next-link\]'si"] = ($pageNo < $pagesCount) ? str_replace('%page%', '$1', str_replace('%link%', generatePageLink($paginationParams, $pageNo + 1), $navigations['nextlink'])) : '';
+        $tvars['vars']['pages'] = generatePagination($pageNo, 1, $pagesCount, 10, $paginationParams, $navigations);
+        $tpl->template('pages', $tpath['pages']);
+        $tpl->vars('pages', $tvars);
+        $pages = $tpl->show('pages');
+    } else {
+        $pages = '';
+    }
+    $tvars = ['vars' => ['entries' => $tagList, 'tag' => $lang['tags:taglist'], 'pages' => $pages]];
+    if (pluginGetVariable('tags', 'cloud3d')) {
+        $tvars['vars']['cloud3d'] = urlencode('<tags>'.implode(' ', $cloud3d).'</tags>');
+    }
+    $tvars['regx']['#\[paginator\](.*?)\[\/paginator\]#is'] = ($pages != '') ? '$1' : '';
+    $tpl->template($masterTPL, $tpath[$masterTPL]);
+    $tpl->vars($masterTPL, $tvars);
+    $output = $tpl->show($masterTPL);
+    $template['vars'][$ppage ? 'mainblock' : 'plugin_tags'] = $output;
+    if (pluginGetVariable('tags', 'cache')) {
+        cacheStoreFile($cacheFileName, $output, 'tags');
+    }
 }

--- a/voting/config.php
+++ b/voting/config.php
@@ -1,6 +1,9 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
@@ -8,152 +11,152 @@ if (!defined('NGCMS')) die ('HAL');
 plugins_load_config();
 loadPluginLang('voting', 'config', '', '', ':');
 // Fill configuration parameters
-$skList = array();
-if ($skDir = opendir(extras_dir . '/voting/tpl/skins')) {
-	while ($skFile = readdir($skDir)) {
-		if (!preg_match('/^\./', $skFile)) {
-			$skList[$skFile] = $skFile;
-		}
-	}
-	closedir($skDir);
+$skList = [];
+if ($skDir = opendir(extras_dir.'/voting/tpl/skins')) {
+    while ($skFile = readdir($skDir)) {
+        if (!preg_match('/^\./', $skFile)) {
+            $skList[$skFile] = $skFile;
+        }
+    }
+    closedir($skDir);
 }
-$cfg = array();
-array_push($cfg, array('descr' => $lang['voting:desc']));
-array_push($cfg, array('name' => 'rotate', 'title' => $lang['voting:rotate'], 'descr' => $lang['voting:rotate#desc'], 'type' => 'select', 'values' => array('1' => $lang['yesa'], '0' => $lang['noa']), 'value' => pluginGetVariable('voting', 'rotate')));
-array_push($cfg, array('name' => 'active', 'title' => $lang['voting:active'], 'descr' => $lang['voting:active#desc'], 'type' => 'select', 'values' => (array('0' => ' -- ') + mkVoteList()), 'value' => pluginGetVariable('voting', 'active')));
-array_push($cfg, array('name' => 'secure', 'title' => $lang['voting:secure'], 'descr' => $lang['voting:secure#desc'], 'type' => 'select', 'values' => array('1' => 'БД', '0' => 'Cookie'), 'value' => pluginGetVariable('voting', 'secure')));
-array_push($cfg, array('name' => 'localsource', 'title' => $lang['voting:localsource'], 'descr' => $lang['voting:localsource#desc'], 'type' => 'select', 'values' => array('0' => $lang['voting:lsrc.site'], '1' => $lang['voting:lsrc.plugin']), 'value' => intval(pluginGetVariable($plugin, 'localsource'))));
-array_push($cfg, array('name' => 'skin', 'title' => $lang['voting:skin'], 'descr' => $lang['voting:skin#desc'], 'type' => 'select', 'values' => $skList, 'value' => pluginGetVariable('voting', 'skin')));
-array_push($cfg, array('name' => 'vpp', 'title' => $lang['voting:vpp'], 'descr' => $lang['voting:vpp#desc'], 'type' => 'input', 'value' => intval(pluginGetVariable('voting', 'vpp'))));
-function mkVoteList() {
+$cfg = [];
+array_push($cfg, ['descr' => $lang['voting:desc']]);
+array_push($cfg, ['name' => 'rotate', 'title' => $lang['voting:rotate'], 'descr' => $lang['voting:rotate#desc'], 'type' => 'select', 'values' => ['1' => $lang['yesa'], '0' => $lang['noa']], 'value' => pluginGetVariable('voting', 'rotate')]);
+array_push($cfg, ['name' => 'active', 'title' => $lang['voting:active'], 'descr' => $lang['voting:active#desc'], 'type' => 'select', 'values' => (['0' => ' -- '] + mkVoteList()), 'value' => pluginGetVariable('voting', 'active')]);
+array_push($cfg, ['name' => 'secure', 'title' => $lang['voting:secure'], 'descr' => $lang['voting:secure#desc'], 'type' => 'select', 'values' => ['1' => 'БД', '0' => 'Cookie'], 'value' => pluginGetVariable('voting', 'secure')]);
+array_push($cfg, ['name' => 'localsource', 'title' => $lang['voting:localsource'], 'descr' => $lang['voting:localsource#desc'], 'type' => 'select', 'values' => ['0' => $lang['voting:lsrc.site'], '1' => $lang['voting:lsrc.plugin']], 'value' => intval(pluginGetVariable($plugin, 'localsource'))]);
+array_push($cfg, ['name' => 'skin', 'title' => $lang['voting:skin'], 'descr' => $lang['voting:skin#desc'], 'type' => 'select', 'values' => $skList, 'value' => pluginGetVariable('voting', 'skin')]);
+array_push($cfg, ['name' => 'vpp', 'title' => $lang['voting:vpp'], 'descr' => $lang['voting:vpp#desc'], 'type' => 'input', 'value' => intval(pluginGetVariable('voting', 'vpp'))]);
+function mkVoteList()
+{
+    global $mysql;
+    $res = [];
+    foreach ($mysql->select('select * from '.prefix.'_vote where active = 1') as $row) {
+        $res[$row['id']] = $row['name'];
+    }
 
-	global $mysql;
-	$res = array();
-	foreach ($mysql->select("select * from " . prefix . "_vote where active = 1") as $row) {
-		$res[$row['id']] = $row['name'];
-	}
-
-	return $res;
+    return $res;
 }
 
-function mkVoteSkinList() {
-
-	$dir = opendir();
+function mkVoteSkinList()
+{
+    $dir = opendir();
 }
 
 if ($_REQUEST['action'] == 'newvote') {
-	$mysql->query("insert into " . prefix . "_vote (name) values (" . db_squote('** новое голосование **') . ")");
-	print "Новый опрос создан. <a href='$PHP_SELF?mod=extra-config&plugin=voting'>переход к редактированию</a>";
-} else if ($_REQUEST['action'] == 'delvote') {
-	$voteid = intval($_REQUEST['id']);
-	if ($row = $mysql->record("select * from " . prefix . "_vote where id = $voteid")) {
-		$mysql->query("delete from " . prefix . "_voteline where voteid = $voteid");
-		$mysql->query("delete from " . prefix . "_vote where id = $voteid");
-		print "Опрос удалён. ";
-	} else {
-		print "Такого опроса не существует. ";
-	}
-	print "<a href='$PHP_SELF?mod=extra-config&plugin=voting'>переход к редактированию</a>";
-} else if ($_REQUEST['action'] == 'commit') {
-	// Let's look what do we need to do.
-	// First - process voteline updates/deletes
-	foreach ($_REQUEST as $rq => $rv) {
-		if (preg_match('/^vename_(\d+)$/', $rq, $match)) {
-			$lid = $match[1];
-			$vecnt = (strlen($_REQUEST['vecount_' . $lid])) ? ", cnt = " . intval($_REQUEST['vecount_' . $lid]) : '';
-			$vename = $_REQUEST['vename_' . $lid];
-			$veactive = intval($_REQUEST['veactive_' . $lid]);
-			$vedel = $_REQUEST['vedel_' . $lid];
-			if ($vedel) {
-				$mysql->query("delete from " . prefix . "_voteline where id = $lid");
-			} else {
-				$mysql->query("update " . prefix . "_voteline set name = " . db_squote($vename) . " $vecnt, active = $veactive where id = $lid");
-			}
-		}
-	}
-	// Next, process voteline inserts
-	foreach ($_REQUEST as $rq => $rv) {
-		if (preg_match('/^viname_(\d+)_(\d+)$/', $rq, $match)) {
-			$vid = $match[1];
-			$lid = $vid . '_' . $match[2];
-			$vecnt = intval($_REQUEST['vicount_' . $lid]);
-			$vename = $_REQUEST['viname_' . $lid];
-			$veactive = intval($_REQUEST['viactive_' . $lid]);
-			$vedel = $_REQUEST['videl_' . $lid];
-			if (!$vedel) {
-				$mysql->query("insert into " . prefix . "_voteline(voteid, name, cnt, active) values($vid," . db_squote($vename) . ",$vecnt, $veactive)");
-			}
-		}
-	}
-	// Next, process vote updates
-	foreach ($_REQUEST as $rq => $rv) {
-		if (preg_match('/^vname_(\d+)$/', $rq, $match)) {
-			$lid = $match[1];
-			$vname = $_REQUEST['vname_' . $lid];
-			$vdescr = $_REQUEST['vdescr_' . $lid];
-			$vactive = intval($_REQUEST['vactive_' . $lid]);
-			$vclosed = intval($_REQUEST['vclosed_' . $lid]);
-			$vregonly = intval($_REQUEST['vregonly_' . $lid]);
-			$mysql->query("update " . prefix . "_vote set name=" . db_squote($vname) . ", descr=" . db_squote($vdescr) . ", active=$vactive, closed=$vclosed, regonly=$vregonly where id =  $lid");
-		}
-	}
-	// Next, process inserts
-	//var_dump($_REQUEST);
-	commit_plugin_config_changes($plugin, $cfg);
-	print_commit_complete($plugin);
+    $mysql->query('insert into '.prefix.'_vote (name) values ('.db_squote('** новое голосование **').')');
+    echo "Новый опрос создан. <a href='$PHP_SELF?mod=extra-config&plugin=voting'>переход к редактированию</a>";
+} elseif ($_REQUEST['action'] == 'delvote') {
+    $voteid = intval($_REQUEST['id']);
+    if ($row = $mysql->record('select * from '.prefix."_vote where id = $voteid")) {
+        $mysql->query('delete from '.prefix."_voteline where voteid = $voteid");
+        $mysql->query('delete from '.prefix."_vote where id = $voteid");
+        echo 'Опрос удалён. ';
+    } else {
+        echo 'Такого опроса не существует. ';
+    }
+    echo "<a href='$PHP_SELF?mod=extra-config&plugin=voting'>переход к редактированию</a>";
+} elseif ($_REQUEST['action'] == 'commit') {
+    // Let's look what do we need to do.
+    // First - process voteline updates/deletes
+    foreach ($_REQUEST as $rq => $rv) {
+        if (preg_match('/^vename_(\d+)$/', $rq, $match)) {
+            $lid = $match[1];
+            $vecnt = (strlen($_REQUEST['vecount_'.$lid])) ? ', cnt = '.intval($_REQUEST['vecount_'.$lid]) : '';
+            $vename = $_REQUEST['vename_'.$lid];
+            $veactive = intval($_REQUEST['veactive_'.$lid]);
+            $vedel = $_REQUEST['vedel_'.$lid];
+            if ($vedel) {
+                $mysql->query('delete from '.prefix."_voteline where id = $lid");
+            } else {
+                $mysql->query('update '.prefix.'_voteline set name = '.db_squote($vename)." $vecnt, active = $veactive where id = $lid");
+            }
+        }
+    }
+    // Next, process voteline inserts
+    foreach ($_REQUEST as $rq => $rv) {
+        if (preg_match('/^viname_(\d+)_(\d+)$/', $rq, $match)) {
+            $vid = $match[1];
+            $lid = $vid.'_'.$match[2];
+            $vecnt = intval($_REQUEST['vicount_'.$lid]);
+            $vename = $_REQUEST['viname_'.$lid];
+            $veactive = intval($_REQUEST['viactive_'.$lid]);
+            $vedel = $_REQUEST['videl_'.$lid];
+            if (!$vedel) {
+                $mysql->query('insert into '.prefix."_voteline(voteid, name, cnt, active) values($vid,".db_squote($vename).",$vecnt, $veactive)");
+            }
+        }
+    }
+    // Next, process vote updates
+    foreach ($_REQUEST as $rq => $rv) {
+        if (preg_match('/^vname_(\d+)$/', $rq, $match)) {
+            $lid = $match[1];
+            $vname = $_REQUEST['vname_'.$lid];
+            $vdescr = $_REQUEST['vdescr_'.$lid];
+            $vactive = intval($_REQUEST['vactive_'.$lid]);
+            $vclosed = intval($_REQUEST['vclosed_'.$lid]);
+            $vregonly = intval($_REQUEST['vregonly_'.$lid]);
+            $mysql->query('update '.prefix.'_vote set name='.db_squote($vname).', descr='.db_squote($vdescr).", active=$vactive, closed=$vclosed, regonly=$vregonly where id =  $lid");
+        }
+    }
+    // Next, process inserts
+    //var_dump($_REQUEST);
+    commit_plugin_config_changes($plugin, $cfg);
+    print_commit_complete($plugin);
 } else {
-	array_push($cfg, array('type' => 'flat', 'input' => '<tr><td colspan=2 style="background-color: #FFFF00;font : normal 14px verdana, sans-serif; padding: 4px;">' . $lang['voting:hdr.votelist'] . '</td></tr>'));
-	array_push($cfg, array('type' => 'flat', 'input' => '<tr><td align=left style="padding-left: 14px;"><input type=button value="' . $lang['voting:button.create'] . '" style="width:343px;" onclick="document.location=' . "'" . $PHP_SELF . "?mod=extra-config&plugin=voting&action=newvote'" . ';"/></td><td align=right style="padding-top: 8px; padding-bottom: 8px;"> <input type=button value="' . $lang['voting:button.show_all'] . '" style="width:170px;" onclick="showHide(1);"/> <input type=button value="' . $lang['voting:button.hide_all'] . '" style="width:170px;" onclick="showHide(0);"/>'));
-	$tpl->template('sheader', extras_dir . '/voting/tpl');
-	$tpl->vars('sheader', array());
-	array_push($cfg, array('type' => 'flat', 'input' => $tpl->show('sheader')));
-	$tpl->template('vote', extras_dir . '/voting/tpl');
-	$tpl->template('ventry', extras_dir . '/voting/tpl');
-	$flag_nonactive = 0;
-	$flag_active = 0;
-	$flag_closed = 0;
-	foreach ($mysql->select("select * from " . prefix . "_vote order by active,closed") as $vrow) {
-		$cfgX = array();
-		if (!$vrow['active'] && !$vrow['closed'] && !$flag_nonactive) {
-			$flag_nonactive = 1;
-			array_push($cfg, array('type' => 'flat', 'input' => '<tr><td colspan=2 style="background-color: #AAAAAA;font : normal 10px verdana, sans-serif; padding: 4px;"><b>' . $lang['voting:hdr.inactive'] . '</b></td></tr>'));
-		}
-		if ($vrow['active'] && !$vrow['closed'] && !$flag_active) {
-			$flag_active = 1;
-			array_push($cfg, array('type' => 'flat', 'input' => '<tr><td colspan=2 style="background-color: #99BB88;font : normal 10px verdana, sans-serif; padding: 4px;"><b>' . $lang['voting:hdr.active'] . '</b></td></tr>'));
-		}
-		if ($vrow['active'] && $vrow['closed'] && !$flag_closed) {
-			$flag_closed = 1;
-			array_push($cfg, array('type' => 'flat', 'input' => '<tr><td colspan=2 style="background-color: #77BB44;font : normal 10px verdana, sans-serif; padding: 4px;"><b>' . $lang['voting:hdr.closed'] . '</b></td></tr>'));
-		}
-		$ll = '';
-		$allcnt = 0;
-		foreach ($mysql->select("select * from " . prefix . "_voteline where voteid=" . $vrow['id'] . " order by id") as $row) {
-			$tvars['vars'] = array(
-				'name'     => secure_html($row['name']),
-				'count'    => $row['cnt'],
-				'id'       => $row['id'],
-				'veactive' => $row['active'] ? 'checked' : ''
-			);
-			$allcnt += $row['cnt'];
-			$tpl->vars('ventry', $tvars);
-			$ll .= $tpl->show('ventry');
-		}
-		$tvars['vars'] = array(
-			'entries'  => $ll,
-			'name'     => secure_html($vrow['name']),
-			'allcnt'   => $allcnt,
-			'descr'    => secure_html($vrow['descr']),
-			'voteid'   => $vrow['id'],
-			'vactive'  => $vrow['active'] ? 'checked' : '',
-			'vclosed'  => $vrow['closed'] ? 'checked' : '',
-			'vregonly' => $vrow['regonly'] ? 'checked' : '',
-			'fregonly' => $vrow['regonly'] ? '[<b>' . $lang['voting:hdr.regflag'] . '</b>]' : '',
-			'php_self' => $PHP_SELF
-		);
-		$tpl->vars('vote', $tvars);
-		array_push($cfgX, array('type' => 'flat', 'input' => $tpl->show('vote')));
-		array_push($cfg, array('mode' => 'group', 'title' => '[ ' . $lang['voting:hdr.voting'] . ': <b><font color=blue>' . $vrow['name'] . '</font></b> ]', 'entries' => $cfgX));
-	}
-	generate_config_page($plugin, $cfg);
+    array_push($cfg, ['type' => 'flat', 'input' => '<tr><td colspan=2 style="background-color: #FFFF00;font : normal 14px verdana, sans-serif; padding: 4px;">'.$lang['voting:hdr.votelist'].'</td></tr>']);
+    array_push($cfg, ['type' => 'flat', 'input' => '<tr><td align=left style="padding-left: 14px;"><input type=button value="'.$lang['voting:button.create'].'" style="width:343px;" onclick="document.location='."'".$PHP_SELF."?mod=extra-config&plugin=voting&action=newvote'".';"/></td><td align=right style="padding-top: 8px; padding-bottom: 8px;"> <input type=button value="'.$lang['voting:button.show_all'].'" style="width:170px;" onclick="showHide(1);"/> <input type=button value="'.$lang['voting:button.hide_all'].'" style="width:170px;" onclick="showHide(0);"/>']);
+    $tpl->template('sheader', extras_dir.'/voting/tpl');
+    $tpl->vars('sheader', []);
+    array_push($cfg, ['type' => 'flat', 'input' => $tpl->show('sheader')]);
+    $tpl->template('vote', extras_dir.'/voting/tpl');
+    $tpl->template('ventry', extras_dir.'/voting/tpl');
+    $flag_nonactive = 0;
+    $flag_active = 0;
+    $flag_closed = 0;
+    foreach ($mysql->select('select * from '.prefix.'_vote order by active,closed') as $vrow) {
+        $cfgX = [];
+        if (!$vrow['active'] && !$vrow['closed'] && !$flag_nonactive) {
+            $flag_nonactive = 1;
+            array_push($cfg, ['type' => 'flat', 'input' => '<tr><td colspan=2 style="background-color: #AAAAAA;font : normal 10px verdana, sans-serif; padding: 4px;"><b>'.$lang['voting:hdr.inactive'].'</b></td></tr>']);
+        }
+        if ($vrow['active'] && !$vrow['closed'] && !$flag_active) {
+            $flag_active = 1;
+            array_push($cfg, ['type' => 'flat', 'input' => '<tr><td colspan=2 style="background-color: #99BB88;font : normal 10px verdana, sans-serif; padding: 4px;"><b>'.$lang['voting:hdr.active'].'</b></td></tr>']);
+        }
+        if ($vrow['active'] && $vrow['closed'] && !$flag_closed) {
+            $flag_closed = 1;
+            array_push($cfg, ['type' => 'flat', 'input' => '<tr><td colspan=2 style="background-color: #77BB44;font : normal 10px verdana, sans-serif; padding: 4px;"><b>'.$lang['voting:hdr.closed'].'</b></td></tr>']);
+        }
+        $ll = '';
+        $allcnt = 0;
+        foreach ($mysql->select('select * from '.prefix.'_voteline where voteid='.$vrow['id'].' order by id') as $row) {
+            $tvars['vars'] = [
+                'name'     => secure_html($row['name']),
+                'count'    => $row['cnt'],
+                'id'       => $row['id'],
+                'veactive' => $row['active'] ? 'checked' : '',
+            ];
+            $allcnt += $row['cnt'];
+            $tpl->vars('ventry', $tvars);
+            $ll .= $tpl->show('ventry');
+        }
+        $tvars['vars'] = [
+            'entries'  => $ll,
+            'name'     => secure_html($vrow['name']),
+            'allcnt'   => $allcnt,
+            'descr'    => secure_html($vrow['descr']),
+            'voteid'   => $vrow['id'],
+            'vactive'  => $vrow['active'] ? 'checked' : '',
+            'vclosed'  => $vrow['closed'] ? 'checked' : '',
+            'vregonly' => $vrow['regonly'] ? 'checked' : '',
+            'fregonly' => $vrow['regonly'] ? '[<b>'.$lang['voting:hdr.regflag'].'</b>]' : '',
+            'php_self' => $PHP_SELF,
+        ];
+        $tpl->vars('vote', $tvars);
+        array_push($cfgX, ['type' => 'flat', 'input' => $tpl->show('vote')]);
+        array_push($cfg, ['mode' => 'group', 'title' => '[ '.$lang['voting:hdr.voting'].': <b><font color=blue>'.$vrow['name'].'</font></b> ]', 'entries' => $cfgX]);
+    }
+    generate_config_page($plugin, $cfg);
 }

--- a/voting/install.php
+++ b/voting/install.php
@@ -1,84 +1,87 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Voting plugin installer
 //
 plugins_load_config();
-function plugin_voting_install($action) {
+function plugin_voting_install($action)
+{
+    global $lang;
+    if ($action != 'autoapply') {
+        loadPluginLang('voting', 'config', '', '', ':');
+    }
+    $db_update = [
+        [
+            'table'  => 'vote',
+            'action' => 'cmodify',
+            'key'    => 'primary key(id)',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'],
+                ['action' => 'cmodify', 'name' => 'newsid', 'type' => 'int', 'params' => 'default 0'],
+                ['action' => 'cmodify', 'name' => 'name', 'type' => 'char(50)'],
+                ['action' => 'cmodify', 'name' => 'descr', 'type' => 'text'],
+                ['action' => 'cmodify', 'name' => 'active', 'type' => 'int', 'params' => 'default 0'],
+                ['action' => 'cmodify', 'name' => 'closed', 'type' => 'int', 'params' => 'default 0'],
+                ['action' => 'cmodify', 'name' => 'regonly', 'type' => 'int', 'params' => 'default 0'],
+            ],
+        ],
+        [
+            'table'  => 'voteline',
+            'action' => 'cmodify',
+            'key'    => 'primary key(id)',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'],
+                ['action' => 'cmodify', 'name' => 'voteid', 'type' => 'int', 'params' => 'default 0'],
+                ['action' => 'cmodify', 'name' => 'position', 'type' => 'int', 'params' => 'default 0'],
+                ['action' => 'cmodify', 'name' => 'name', 'type' => 'char(50)'],
+                ['action' => 'cmodify', 'name' => 'cnt', 'type' => 'int', 'params' => 'default 0'],
+                ['action' => 'cmodify', 'name' => 'active', 'type' => 'int', 'params' => 'default 1'],
+            ],
+        ],
+        [
+            'table'  => 'votestat',
+            'action' => 'cmodify',
+            'key'    => 'primary key(id)',
+            'fields' => [
+                ['action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'],
+                ['action' => 'cmodify', 'name' => 'userid', 'type' => 'int', 'params' => 'default 0'],
+                ['action' => 'cmodify', 'name' => 'voteid', 'type' => 'int', 'params' => 'default 0'],
+                ['action' => 'cmodify', 'name' => 'voteline', 'type' => 'int', 'params' => 'default 0'],
+                ['action' => 'cmodify', 'name' => 'ip', 'type' => 'char(15)'],
+                ['action' => 'cmodify', 'name' => 'dt', 'type' => 'datetime'],
+            ],
+        ],
+    ];
+    // Apply requested action
+    switch ($action) {
+        case 'confirm':
+            generate_install_page('voting', $lang['voting:install#desc']);
+            break;
+        case 'autoapply':
+        case 'apply':
+            if (fixdb_plugin_install('voting', $db_update, 'install', ($action == 'autoapply') ? true : false)) {
+                plugin_mark_installed('voting');
+            }
+            // Now we need to set some default params
+            $params = [
+                'access'     => 1,
+                'refresh'    => 30,
+                'history'    => 30,
+                'rate_limit' => 0,
+                'maxidle'    => 0,
+                'maxwlen'    => 40,
+                'maxlen'     => 500,
+            ];
+            foreach ($params as $k => $v) {
+                extra_set_param('voting', $k, $v);
+            }
+            extra_commit_changes();
+            break;
+    }
 
-	global $lang;
-	if ($action != 'autoapply')
-		loadPluginLang('voting', 'config', '', '', ':');
-	$db_update = array(
-		array(
-			'table'  => 'vote',
-			'action' => 'cmodify',
-			'key'    => 'primary key(id)',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'),
-				array('action' => 'cmodify', 'name' => 'newsid', 'type' => 'int', 'params' => 'default 0'),
-				array('action' => 'cmodify', 'name' => 'name', 'type' => 'char(50)'),
-				array('action' => 'cmodify', 'name' => 'descr', 'type' => 'text'),
-				array('action' => 'cmodify', 'name' => 'active', 'type' => 'int', 'params' => 'default 0'),
-				array('action' => 'cmodify', 'name' => 'closed', 'type' => 'int', 'params' => 'default 0'),
-				array('action' => 'cmodify', 'name' => 'regonly', 'type' => 'int', 'params' => 'default 0'),
-			)
-		),
-		array(
-			'table'  => 'voteline',
-			'action' => 'cmodify',
-			'key'    => 'primary key(id)',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'),
-				array('action' => 'cmodify', 'name' => 'voteid', 'type' => 'int', 'params' => 'default 0'),
-				array('action' => 'cmodify', 'name' => 'position', 'type' => 'int', 'params' => 'default 0'),
-				array('action' => 'cmodify', 'name' => 'name', 'type' => 'char(50)'),
-				array('action' => 'cmodify', 'name' => 'cnt', 'type' => 'int', 'params' => 'default 0'),
-				array('action' => 'cmodify', 'name' => 'active', 'type' => 'int', 'params' => 'default 1'),
-			)
-		),
-		array(
-			'table'  => 'votestat',
-			'action' => 'cmodify',
-			'key'    => 'primary key(id)',
-			'fields' => array(
-				array('action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'),
-				array('action' => 'cmodify', 'name' => 'userid', 'type' => 'int', 'params' => 'default 0'),
-				array('action' => 'cmodify', 'name' => 'voteid', 'type' => 'int', 'params' => 'default 0'),
-				array('action' => 'cmodify', 'name' => 'voteline', 'type' => 'int', 'params' => 'default 0'),
-				array('action' => 'cmodify', 'name' => 'ip', 'type' => 'char(15)'),
-				array('action' => 'cmodify', 'name' => 'dt', 'type' => 'datetime'),
-			),
-		),
-	);
-	// Apply requested action
-	switch ($action) {
-		case 'confirm':
-			generate_install_page('voting', $lang['voting:install#desc']);
-			break;
-		case 'autoapply':
-		case 'apply':
-			if (fixdb_plugin_install('voting', $db_update, 'install', ($action == 'autoapply') ? true : false)) {
-				plugin_mark_installed('voting');
-			}
-			// Now we need to set some default params
-			$params = array(
-				'access'     => 1,
-				'refresh'    => 30,
-				'history'    => 30,
-				'rate_limit' => 0,
-				'maxidle'    => 0,
-				'maxwlen'    => 40,
-				'maxlen'     => 500,
-			);
-			foreach ($params as $k => $v) {
-				extra_set_param('voting', $k, $v);
-			}
-			extra_commit_changes();
-			break;
-	}
-
-	return true;
+    return true;
 }
-

--- a/voting/uninstall.php
+++ b/voting/uninstall.php
@@ -1,28 +1,30 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Voting plugin deinstaller
 //
 plugins_load_config();
 LoadPluginLang('voting', 'install');
-$db_update = array(
-	// array(
-	//  'table'  => 'vote',
-	//  'action' => 'drop',
-	// ),
-	// array(
-	//  'table'  => 'voteline',
-	//  'action' => 'drop',
-	// ),
-);
+$db_update = [
+    // array(
+    //  'table'  => 'vote',
+    //  'action' => 'drop',
+    // ),
+    // array(
+    //  'table'  => 'voteline',
+    //  'action' => 'drop',
+    // ),
+];
 if ($_REQUEST['action'] == 'commit') {
-	// If submit requested, do config save
-	if (fixdb_plugin_install('voting', $db_update, 'deinstall')) {
-		plugin_mark_deinstalled('voting');
-	}
+    // If submit requested, do config save
+    if (fixdb_plugin_install('voting', $db_update, 'deinstall')) {
+        plugin_mark_deinstalled('voting');
+    }
 } else {
-	$text = 'Внимание! Удаление плагина приведёт к удалению всех созданных на сайте опросов!<br><br>';
-	generate_install_page('voting', $text, 'deinstall');
+    $text = 'Внимание! Удаление плагина приведёт к удалению всех созданных на сайте опросов!<br><br>';
+    generate_install_page('voting', $text, 'deinstall');
 }
-?>

--- a/voting/voting.php
+++ b/voting/voting.php
@@ -1,31 +1,34 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 add_act('index', 'plugin_voting');
 register_plugin_page('voting', 'panel', 'plugin_voting_panel', 0);
 register_plugin_page('voting', '', 'plugin_voting_page', 0);
 loadPluginLang('voting', 'main', '', '', ':');
-function plugin_voting_panel() {
-
-	plugin_voting_screen(true);
+function plugin_voting_panel()
+{
+    plugin_voting_screen(true);
 }
 
-function plugin_voting_page() {
-
-	plugin_voting_screen(false);
+function plugin_voting_page()
+{
+    plugin_voting_screen(false);
 }
 
-function plugin_voting() {
-
-	global $mysql, $tpl, $template, $REQUEST_URI;
-	$voteid = intval(pluginGetVariable('voting', 'active'));
-	$rand = pluginGetVariable('voting', 'rotate');
-	$voted = isset($_COOKIE['ngcms_voting']) ? explode(",", $_COOKIE['ngcms_voting'] . '') : array();
-	$skin = pluginGetVariable('voting', 'skin');
-	if ((!is_dir(extras_dir . '/voting/tpl/skins/' . $skin)) || (!$skin)) {
-		$skin = 'basic';
-	}
-	$template['vars']['voting'] = plugin_showvote($skin, 4, $voteid, $rand, $voted);
+function plugin_voting()
+{
+    global $mysql, $tpl, $template, $REQUEST_URI;
+    $voteid = intval(pluginGetVariable('voting', 'active'));
+    $rand = pluginGetVariable('voting', 'rotate');
+    $voted = isset($_COOKIE['ngcms_voting']) ? explode(',', $_COOKIE['ngcms_voting'].'') : [];
+    $skin = pluginGetVariable('voting', 'skin');
+    if ((!is_dir(extras_dir.'/voting/tpl/skins/'.$skin)) || (!$skin)) {
+        $skin = 'basic';
+    }
+    $template['vars']['voting'] = plugin_showvote($skin, 4, $voteid, $rand, $voted);
 }
 
 //
@@ -43,228 +46,228 @@ function plugin_voting() {
 //	3. voteid - vote id (in show one mode)
 //  4. rand - rand flag (in show one mode)
 //	5. votedList - list of voted (in show list mode)
-function plugin_showvote($tpl_skin, $mode, $voteid = 0, $rand = 0, $votedList = array()) {
+function plugin_showvote($tpl_skin, $mode, $voteid = 0, $rand = 0, $votedList = [])
+{
+    global $tpl, $mysql, $username, $userROW, $ip, $REQUEST_URI, $TemplateCache, $SYSTEM_FLAGS, $lang;
+    $result = '';
+    $tpath = locatePluginTemplates(['shls_vote', 'edls_vote', 'shls_vline', 'edls_vline', 'lshdr', 'sh_vote', 'ed_vote', 'sh_vline', 'ed_vline'], 'voting', pluginGetVariable('voting', 'localsource'), $tpl_skin);
+    // Preload templates
+    if ($mode < 4) {
+        $post_url = generateLink('core', 'plugin', ['plugin' => 'voting'], []);
+        $tpl->template('shls_vote', $tpath['shls_vote']);
+        $tpl->template('edls_vote', $tpath['edls_vote']);
+        $tpl->template('shls_vline', $tpath['shls_vline']);
+        $tpl->template('edls_vline', $tpath['edls_vline']);
+        $tpl->template('lshdr', $tpath['lshdr']);
+        $tpl->vars('lshdr', ['vars' => ['home' => home, 'post_url' => $post_url]]);
+        $result = $tpl->show('lshdr');
+    } else {
+        $post_url = generateLink('core', 'plugin', ['plugin' => 'voting', 'handler' => 'panel'], []);
+        $tpl->template('sh_vote', $tpath['sh_vote']);
+        $tpl->template('ed_vote', $tpath['ed_vote']);
+        $tpl->template('sh_vline', $tpath['sh_vline']);
+        $tpl->template('ed_vline', $tpath['ed_vline']);
+    }
+    // Page number
+    $page = isset($_GET['page']) ? intval($_GET['page']) : 1;
+    if ($page < 1) {
+        $page = 1;
+    }
+    $vpp = intval(pluginGetVariable('voting', 'vpp'));
+    $pageCount = 0;
+    if ($vpp > 0 && !$mode) {
+        // Calculate real number of pages
+        $pc = $mysql->record('select count(*) as cnt from '.prefix.'_vote where active = 1');
+        $pageCount = ceil($pc['cnt'] / $vpp);
+    }
+    if ($page > $pageCount) {
+        $page = $pageCount;
+    }
+    if (!$mode) {
+        $where = 'where active = 1 order by id desc'.(($vpp > 0) ? (' limit '.(($page - 1) * $vpp).', '.$vpp) : '');
+    } else {
+        if ($rand) {
+            $where = 'where active = 1 order by rand() limit 1';
+        } elseif ($voteid) {
+            $where = 'where id = '.db_squote($voteid);
+        } else {
+            $where = 'where active = 1 limit 1';
+        }
+    }
+    // If we have voteid - show only this vote, else - show all active
+    //print "QUERY: 'select * from ".prefix."_vote $where'<br>\n";
+    $vCount = 0;
+    foreach ($mysql->select('select * from '.prefix."_vote $where") as $row) {
+        $vCount++;
+        $votelines = '';
+        $dup = 0;
+        if ($secure = pluginGetVariable('voting', 'secure')) {
+            $condition = (is_array($userROW)) ? 'userid = '.$userROW['id'] : "ip='$ip'";
+            if ($mysql->record('select * from '.prefix.'_votestat where voteid = '.$row['id']." and $condition limit 1")) {
+                $dup = 1;
+            }
+        } else {
+            $dup = array_key_exists($row['id'], $votedList);
+        }
+        $cnt = 0;
+        //print ">Query: 'select * from ".prefix."_voteline where voteid = ".$row['id']." and active=1'<br>\n";
+        $lrows = $mysql->select('select * from '.prefix.'_voteline where voteid = '.$row['id'].' and active=1 order by id');
+        foreach ($lrows as $lrow) {
+            $cnt += $lrow['cnt'];
+        }
+        if (!$cnt) {
+            $cnt = 1;
+        }
+        // Choose template name for this operation
+        switch ($mode) {
+            case '0':
+            case '1':
+                $tpl_prefix = ($dup || $row['closed'] || ($row['regonly'] && !$username)) ? 'shls' : 'edls';
+                break;
+            case '2':
+                $tpl_prefix = 'edls';
+                break;
+            case '3':
+                $tpl_prefix = 'shls';
+                break;
+            case '4':
+                $tpl_prefix = ($dup || $row['closed'] || ($row['regonly'] && !$username)) ? 'sh' : 'ed';
+                break;
+            case '5':
+                $tpl_prefix = 'ed';
+                break;
+            case '6':
+                $tpl_prefix = 'sh';
+                break;
+        }
+        $num = 1;
+        $tcount = 0;
+        foreach ($lrows as $lrow) {
+            $tvars['vars'] = [
+                'id'       => $lrow['id'],
+                'name'     => $lrow['name'],
+                'num'      => $num,
+                'count'    => $lrow['cnt'],
+                'perc'     => intval($lrow['cnt'] * 100 / $cnt),
+                'post_url' => $post_url,
+                'tpl_dir'  => admin_url.'/plugins/voting/tpl/skins/'.$tpl_skin,
+            ];
+            $tpl->vars($tpl_prefix.'_vline', $tvars);
+            $votelines .= $tpl->show($tpl_prefix.'_vline');
+            $num++;
+            $tcount += $lrow['cnt'];
+        }
+        $tvars['vars'] = [
+            'votename'  => $row['name'],
+            'voteid'    => $row['id'],
+            'votelines' => $votelines,
+            'votedescr' => $row['descr'],
+            'REFERER'   => isset($REQUEST_URI) ? $REQUEST_URI : '',
+            'home'      => home,
+            'vcount'    => $tcount,
+            'post_url'  => $post_url,
+            'tpl_dir'   => admin_url.'/plugins/voting/tpl/skins/'.$tpl_skin,
+        ];
+        $tvars['regx']['#\[votedescr](.*?)\[/votedescr]#is'] = (strlen($row['descr']) > 0) ? '$1' : '';
+        $tpl->vars($tpl_prefix.'_vote', $tvars);
+        $result .= $tpl->show($tpl_prefix.'_vote');
+    }
+    // Add page navigation
+    if ($pageCount > 0) {
+        $paginationParams = [
+            'pluginName'    => 'core',
+            'pluginHandler' => 'plugin',
+            'params'        => ['plugin' => 'voting'],
+            'xparams'       => [],
+            'paginator'     => ['page', 1, false],
+        ];
+        templateLoadVariables(true);
+        $navigations = $TemplateCache['site']['#variables']['navigation'];
+        $result .= '<br/>'.generatePagination($page, 1, $pageCount, 10, $paginationParams, $navigations);
+    }
+    if (!$vCount) {
+        $result = $lang['voting:msg.nofound'];
+    }
 
-	global $tpl, $mysql, $username, $userROW, $ip, $REQUEST_URI, $TemplateCache, $SYSTEM_FLAGS, $lang;
-	$result = '';
-	$tpath = locatePluginTemplates(array('shls_vote', 'edls_vote', 'shls_vline', 'edls_vline', 'lshdr', 'sh_vote', 'ed_vote', 'sh_vline', 'ed_vline'), 'voting', pluginGetVariable('voting', 'localsource'), $tpl_skin);
-	// Preload templates
-	if ($mode < 4) {
-		$post_url = generateLink('core', 'plugin', array('plugin' => 'voting'), array());
-		$tpl->template('shls_vote', $tpath['shls_vote']);
-		$tpl->template('edls_vote', $tpath['edls_vote']);
-		$tpl->template('shls_vline', $tpath['shls_vline']);
-		$tpl->template('edls_vline', $tpath['edls_vline']);
-		$tpl->template('lshdr', $tpath['lshdr']);
-		$tpl->vars('lshdr', array('vars' => array('home' => home, 'post_url' => $post_url)));
-		$result = $tpl->show('lshdr');
-	} else {
-		$post_url = generateLink('core', 'plugin', array('plugin' => 'voting', 'handler' => 'panel'), array());
-		$tpl->template('sh_vote', $tpath['sh_vote']);
-		$tpl->template('ed_vote', $tpath['ed_vote']);
-		$tpl->template('sh_vline', $tpath['sh_vline']);
-		$tpl->template('ed_vline', $tpath['ed_vline']);
-	}
-	// Page number
-	$page = isset($_GET['page']) ? intval($_GET['page']) : 1;
-	if ($page < 1) {
-		$page = 1;
-	}
-	$vpp = intval(pluginGetVariable('voting', 'vpp'));
-	$pageCount = 0;
-	if ($vpp > 0 && !$mode) {
-		// Calculate real number of pages
-		$pc = $mysql->record("select count(*) as cnt from " . prefix . "_vote where active = 1");
-		$pageCount = ceil($pc['cnt'] / $vpp);
-	}
-	if ($page > $pageCount) {
-		$page = $pageCount;
-	}
-	if (!$mode) {
-		$where = 'where active = 1 order by id desc' . (($vpp > 0) ? (' limit ' . (($page - 1) * $vpp) . ', ' . $vpp) : '');
-	} else {
-		if ($rand) {
-			$where = 'where active = 1 order by rand() limit 1';
-		} else if ($voteid) {
-			$where = 'where id = ' . db_squote($voteid);
-		} else {
-			$where = 'where active = 1 limit 1';
-		}
-	}
-	// If we have voteid - show only this vote, else - show all active
-	//print "QUERY: 'select * from ".prefix."_vote $where'<br>\n";
-	$vCount = 0;
-	foreach ($mysql->select("select * from " . prefix . "_vote $where") as $row) {
-		$vCount++;
-		$votelines = '';
-		$dup = 0;
-		if ($secure = pluginGetVariable('voting', 'secure')) {
-			$condition = (is_array($userROW)) ? "userid = " . $userROW['id'] : "ip='$ip'";
-			if ($mysql->record("select * from " . prefix . "_votestat where voteid = " . $row['id'] . " and $condition limit 1")) {
-				$dup = 1;
-			}
-		} else {
-			$dup = array_key_exists($row['id'], $votedList);
-		}
-		$cnt = 0;
-		//print ">Query: 'select * from ".prefix."_voteline where voteid = ".$row['id']." and active=1'<br>\n";
-		$lrows = $mysql->select("select * from " . prefix . "_voteline where voteid = " . $row['id'] . " and active=1 order by id");
-		foreach ($lrows as $lrow) {
-			$cnt += $lrow['cnt'];
-		}
-		if (!$cnt) {
-			$cnt = 1;
-		}
-		// Choose template name for this operation
-		switch ($mode) {
-			case '0':
-			case '1':
-				$tpl_prefix = ($dup || $row['closed'] || ($row['regonly'] && !$username)) ? 'shls' : 'edls';
-				break;
-			case '2':
-				$tpl_prefix = 'edls';
-				break;
-			case '3':
-				$tpl_prefix = 'shls';
-				break;
-			case '4':
-				$tpl_prefix = ($dup || $row['closed'] || ($row['regonly'] && !$username)) ? 'sh' : 'ed';
-				break;
-			case '5':
-				$tpl_prefix = 'ed';
-				break;
-			case '6':
-				$tpl_prefix = 'sh';
-				break;
-		}
-		$num = 1;
-		$tcount = 0;
-		foreach ($lrows as $lrow) {
-			$tvars['vars'] = array(
-				'id'       => $lrow['id'],
-				'name'     => $lrow['name'],
-				'num'      => $num,
-				'count'    => $lrow['cnt'],
-				'perc'     => intval($lrow['cnt'] * 100 / $cnt),
-				'post_url' => $post_url,
-				'tpl_dir'  => admin_url . '/plugins/voting/tpl/skins/' . $tpl_skin
-			);
-			$tpl->vars($tpl_prefix . '_vline', $tvars);
-			$votelines .= $tpl->show($tpl_prefix . '_vline');
-			$num++;
-			$tcount += $lrow['cnt'];
-		}
-		$tvars['vars'] = array(
-			'votename'  => $row['name'],
-			'voteid'    => $row['id'],
-			'votelines' => $votelines,
-			'votedescr' => $row['descr'],
-			'REFERER'   => isset($REQUEST_URI) ? $REQUEST_URI : '',
-			'home'      => home,
-			'vcount'    => $tcount,
-			'post_url'  => $post_url,
-			'tpl_dir'   => admin_url . '/plugins/voting/tpl/skins/' . $tpl_skin
-		);
-		$tvars['regx']['#\[votedescr](.*?)\[/votedescr]#is'] = (strlen($row['descr']) > 0) ? '$1' : '';
-		$tpl->vars($tpl_prefix . '_vote', $tvars);
-		$result .= $tpl->show($tpl_prefix . '_vote');
-	}
-	// Add page navigation
-	if ($pageCount > 0) {
-		$paginationParams = array(
-			'pluginName'    => 'core',
-			'pluginHandler' => 'plugin',
-			'params'        => array('plugin' => 'voting'),
-			'xparams'       => array(),
-			'paginator'     => array('page', 1, false)
-		);
-		templateLoadVariables(true);
-		$navigations = $TemplateCache['site']['#variables']['navigation'];
-		$result .= '<br/>' . generatePagination($page, 1, $pageCount, 10, $paginationParams, $navigations);
-	}
-	if (!$vCount) {
-		$result = $lang['voting:msg.nofound'];
-	}
-
-	return $result;
+    return $result;
 }
 
 //
 //
-function plugin_voting_screen($flagPanel = false) {
-
-	global $mysql, $tpl, $template, $SUPRESS_TEMPLATE_SHOW, $lang, $userROW, $ip;
-	// Determine calling mode
-	$is_ajax = (($_GET['style'] == 'ajax') || ($_POST['style'] == 'ajax')) ? 1 : 0;
-	// Add own header for AJAX calls
-	if ($is_ajax) {
-		@header('Content-type: text/html; charset="windows-1251"');
-	}
-	$votedList = explode(",", $_COOKIE['ngcms_voting']);
-	// Get current skin
-	$skin = pluginGetVariable('voting', 'skin');
-	if ((!is_dir(extras_dir . '/voting/tpl/skins/' . $skin)) || (!$skin)) {
-		$skin = 'basic';
-	}
-	// ========================================
-	// MODE: Vote request
-	if (($_REQUEST['mode'] == 'vote') && ($choice = intval($_REQUEST['choice']))) {
-		// Search for poll and poll line
-		if (($row = $mysql->record("select * from " . prefix . "_voteline where id = $choice")) && ($vrow = $mysql->record("select * from " . prefix . "_vote where id = " . $row['voteid']))) {
-			// Line was found
-			// Check is user already took part in this poll (according to security model)
-			$dup = 0;
-			if ($secure = pluginGetVariable('voting', 'secure')) {
-				$condition = (is_array($userROW)) ? "userid = " . $userROW['id'] : "ip=" . db_squote($ip);
-				if ($mysql->record("select * from " . prefix . "_votestat where voteid = " . $vrow['id'] . " and $condition limit 1")) {
-					$dup = 1;
-				}
-			} else {
-				$dup = array_key_exists($row['id'], $votedList);
-			}
-			// Report an error if user tries to take part twice
-			if ($dup) {
-				// Inform that vote is already accepted
-				$template['vars']['mainblock'] = $lang['voting:msg.already'];
-				if ($is_ajax) {
-					$SUPRESS_TEMPLATE_SHOW = 1;
-				}
-			} else {
-				$mysql->query("update " . prefix . "_voteline set cnt=cnt+1 where id = " . $row['id']);
-				// DONE. Vote accepted
-				if ($secure) {
-					$query = "insert into " . prefix . "_votestat (userid, voteid, voteline, ip, dt) values (" . (is_array($userROW) ? $userROW['id'] : '0') . "," . $vrow['id'] . "," . $row['id'] . ", '$ip', now() )";
-					$mysql->query($query);
-				} else {
-					if (!array_key_exists($vrow['id'], $votedList)) {
-						array_push($votedList, $vrow['id']);
-						@setcookie('ngcms_voting', implode(",", $votedList), time() + 3600 * 24 * 365, '/');
-					}
-				}
-				// Check returning mode for template
-				$retMode = 3;
-				if ($is_ajax && $flagPanel) {
-					$retMode = 6;
-				}
-				$template['vars']['mainblock'] = plugin_showvote($skin, $retMode, $vrow['id']);
-				if ($is_ajax) {
-					$SUPRESS_TEMPLATE_SHOW = 1;
-				}
-			}
-		} else {
-			// No such vote line
-			$template['vars']['mainblock'] = $lang['voting:msg.norec'];
-			if ($is_ajax) {
-				$SUPRESS_TEMPLATE_SHOW = 1;
-			}
-		}
-	} else if (($_REQUEST['mode'] == 'show') && ($voteid = intval($_REQUEST['voteid']))) {
-		$template['vars']['mainblock'] = plugin_showvote($skin, $flagPanel ? 6 : 3, $voteid);
-		if ($is_ajax) {
-			$SUPRESS_TEMPLATE_SHOW = 1;
-		}
-	} else {
-		// SHOW REQUEST
-		$template['vars']['mainblock'] = plugin_showvote($skin, 0, 0, 0, $votedList);
-	}
+function plugin_voting_screen($flagPanel = false)
+{
+    global $mysql, $tpl, $template, $SUPRESS_TEMPLATE_SHOW, $lang, $userROW, $ip;
+    // Determine calling mode
+    $is_ajax = (($_GET['style'] == 'ajax') || ($_POST['style'] == 'ajax')) ? 1 : 0;
+    // Add own header for AJAX calls
+    if ($is_ajax) {
+        @header('Content-type: text/html; charset="windows-1251"');
+    }
+    $votedList = explode(',', $_COOKIE['ngcms_voting']);
+    // Get current skin
+    $skin = pluginGetVariable('voting', 'skin');
+    if ((!is_dir(extras_dir.'/voting/tpl/skins/'.$skin)) || (!$skin)) {
+        $skin = 'basic';
+    }
+    // ========================================
+    // MODE: Vote request
+    if (($_REQUEST['mode'] == 'vote') && ($choice = intval($_REQUEST['choice']))) {
+        // Search for poll and poll line
+        if (($row = $mysql->record('select * from '.prefix."_voteline where id = $choice")) && ($vrow = $mysql->record('select * from '.prefix.'_vote where id = '.$row['voteid']))) {
+            // Line was found
+            // Check is user already took part in this poll (according to security model)
+            $dup = 0;
+            if ($secure = pluginGetVariable('voting', 'secure')) {
+                $condition = (is_array($userROW)) ? 'userid = '.$userROW['id'] : 'ip='.db_squote($ip);
+                if ($mysql->record('select * from '.prefix.'_votestat where voteid = '.$vrow['id']." and $condition limit 1")) {
+                    $dup = 1;
+                }
+            } else {
+                $dup = array_key_exists($row['id'], $votedList);
+            }
+            // Report an error if user tries to take part twice
+            if ($dup) {
+                // Inform that vote is already accepted
+                $template['vars']['mainblock'] = $lang['voting:msg.already'];
+                if ($is_ajax) {
+                    $SUPRESS_TEMPLATE_SHOW = 1;
+                }
+            } else {
+                $mysql->query('update '.prefix.'_voteline set cnt=cnt+1 where id = '.$row['id']);
+                // DONE. Vote accepted
+                if ($secure) {
+                    $query = 'insert into '.prefix.'_votestat (userid, voteid, voteline, ip, dt) values ('.(is_array($userROW) ? $userROW['id'] : '0').','.$vrow['id'].','.$row['id'].", '$ip', now() )";
+                    $mysql->query($query);
+                } else {
+                    if (!array_key_exists($vrow['id'], $votedList)) {
+                        array_push($votedList, $vrow['id']);
+                        @setcookie('ngcms_voting', implode(',', $votedList), time() + 3600 * 24 * 365, '/');
+                    }
+                }
+                // Check returning mode for template
+                $retMode = 3;
+                if ($is_ajax && $flagPanel) {
+                    $retMode = 6;
+                }
+                $template['vars']['mainblock'] = plugin_showvote($skin, $retMode, $vrow['id']);
+                if ($is_ajax) {
+                    $SUPRESS_TEMPLATE_SHOW = 1;
+                }
+            }
+        } else {
+            // No such vote line
+            $template['vars']['mainblock'] = $lang['voting:msg.norec'];
+            if ($is_ajax) {
+                $SUPRESS_TEMPLATE_SHOW = 1;
+            }
+        }
+    } elseif (($_REQUEST['mode'] == 'show') && ($voteid = intval($_REQUEST['voteid']))) {
+        $template['vars']['mainblock'] = plugin_showvote($skin, $flagPanel ? 6 : 3, $voteid);
+        if ($is_ajax) {
+            $SUPRESS_TEMPLATE_SHOW = 1;
+        }
+    } else {
+        // SHOW REQUEST
+        $template['vars']['mainblock'] = plugin_showvote($skin, 0, 0, 0, $votedList);
+    }
 }

--- a/xfields/config.php
+++ b/xfields/config.php
@@ -1,588 +1,618 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 // Load lang files
 LoadPluginLang('xfields', 'config');
 LoadPluginLang('xfields', 'config', '', 'xfconfig', '#');
-include_once root . 'plugins/xfields/xfields.php';
-if (!is_array($xf = xf_configLoad()))
-	$xf = array();
+include_once root.'plugins/xfields/xfields.php';
+if (!is_array($xf = xf_configLoad())) {
+    $xf = [];
+}
 //
 // Управление необходимыми действиями
 $sectionID = $_REQUEST['section'];
-if (!in_array($sectionID, array('news', 'grp.news', 'users', 'grp.users', 'tdata'))) {
-	$sectionID = 'news';
+if (!in_array($sectionID, ['news', 'grp.news', 'users', 'grp.users', 'tdata'])) {
+    $sectionID = 'news';
 }
 switch ($_REQUEST['action']) {
-	case 'add'        :
-		showAddEditForm();
-		break;
-	case 'doadd'    :
-		doAddEdit();
-		break;
-	case 'edit'        :
-		showAddEditForm();
-		break;
-	case 'doedit'    :
-		doAddEdit();
-		break;
-	case 'update'    :
-		doUpdate();
-		showList();
-		break;
-	default            :
-		showList();
+    case 'add':
+        showAddEditForm();
+        break;
+    case 'doadd':
+        doAddEdit();
+        break;
+    case 'edit':
+        showAddEditForm();
+        break;
+    case 'doedit':
+        doAddEdit();
+        break;
+    case 'update':
+        doUpdate();
+        showList();
+        break;
+    default:
+        showList();
 }
 //
 // Показать список полей
-function showList() {
-
-	global $sectionID;
-	if (in_array($sectionID, array('grp.news', 'grp.users'))) {
-		showSectionList();
-	} else {
-		showFieldList();
-	}
+function showList()
+{
+    global $sectionID;
+    if (in_array($sectionID, ['grp.news', 'grp.users'])) {
+        showSectionList();
+    } else {
+        showFieldList();
+    }
 }
 
 //
 //
-function showSectionList() {
-
-	global $xf, $lang, $tpl, $twig, $sectionID;
-	$output = '';
-	//$output .= "<pre>".var_export($xf[$sectionID], true)."</pre>";
-	$tVars = array(
-		'section_name' => $lang['xfconfig']['section.' . $sectionID],
-	);
-	// Prepare data
-	$grpNews = array();
-	foreach ($xf['grp.news'] as $k => $v) {
-		$grpNews[$k] = array(
-			'title'   => $v['title'],
-			'entries' => $v['entries'],
-		);
-	}
-	foreach (array('news', 'grp.news', 'users', 'grp.users', 'tdata') as $cID)
-		$tVars['bclass'][$cID] = ($cID == $sectionID) ? 'btnActive' : 'btnInactive';
-	$tVars['json']['groups.config'] = json_encode($grpNews);
-	$tVars['json']['fields.config'] = json_encode(arrayCharsetConvert(0, $xf['news']));
-	$xt = $twig->loadTemplate('plugins/xfields/tpl/groups.tpl');
-	echo $xt->render($tVars);
+function showSectionList()
+{
+    global $xf, $lang, $tpl, $twig, $sectionID;
+    $output = '';
+    //$output .= "<pre>".var_export($xf[$sectionID], true)."</pre>";
+    $tVars = [
+        'section_name' => $lang['xfconfig']['section.'.$sectionID],
+    ];
+    // Prepare data
+    $grpNews = [];
+    foreach ($xf['grp.news'] as $k => $v) {
+        $grpNews[$k] = [
+            'title'   => $v['title'],
+            'entries' => $v['entries'],
+        ];
+    }
+    foreach (['news', 'grp.news', 'users', 'grp.users', 'tdata'] as $cID) {
+        $tVars['bclass'][$cID] = ($cID == $sectionID) ? 'btnActive' : 'btnInactive';
+    }
+    $tVars['json']['groups.config'] = json_encode($grpNews);
+    $tVars['json']['fields.config'] = json_encode(arrayCharsetConvert(0, $xf['news']));
+    $xt = $twig->loadTemplate('plugins/xfields/tpl/groups.tpl');
+    echo $xt->render($tVars);
 }
 
 //
 // Показать список доп. полей
-function showFieldList() {
-
-	global $xf, $lang, $twig, $sectionID;
-	$xEntries = array();
-	$output = '';
-	foreach ($xf[$sectionID] as $id => $data) {
-		$storage = '';
-		if ($data['storage']) {
-			$storage = '<br/><font color="red"><b>' . $data['db.type'] . ($data['db.len'] ? (' (' . $data['db.len'] . ')') : '') . '</b> </font>';
-		}
-		$xEntry = array(
-			'name'     => $id,
-			'title'    => $data['title'],
-			'type'     => $lang['xfconfig']['type_' . $data['type']] . $storage,
-			'default'  => (($data['type'] == "checkbox") ? ($data['default'] ? $lang['yesa'] : $lang['noa']) : ($data['default'])),
-			'link'     => '?mod=extra-config&plugin=xfields&action=edit&section=' . $sectionID . '&field=' . $id,
-			'linkup'   => '?mod=extra-config&plugin=xfields&action=update&subaction=up&section=' . $sectionID . '&field=' . $id,
-			'linkdown' => '?mod=extra-config&plugin=xfields&action=update&subaction=down&section=' . $sectionID . '&field=' . $id,
-			'linkdel'  => '?mod=extra-config&plugin=xfields&action=update&subaction=del&section=' . $sectionID . '&field=' . $id,
-			'area'     => (intval($data['area']) > 0) ? intval($data['area']) : '',
-			'flags'    => array(
-				'required' => $data['required'] ? true : false,
-				'default'  => (($data['default'] != '') || ($data['type'] == "checkbox")) ? true : false,
-				'disabled' => $data['disabled'] ? true : false,
-				'regpage'  => $data['regpage'] ? true : false,
-			),
-		);
-		$options = '';
-		if (is_array($data['options']) && count($data['options'])) {
-			foreach ($data['options'] as $k => $v)
-				$options .= (($data['storekeys']) ? ('<b>' . $k . '</b>: ' . $v) : ('<b>' . $v . '</b>')) . "<br>\n";
-		}
-		$xEntry['options'] = $options;
-		$xEntries [] = $xEntry;
-	}
-	if (!count($xf[$sectionID]))
-		$output = $lang['xfconfig']['nof'];
-	$tVars = array(
-		'entries'      => $xEntries,
-		'section_name' => $lang['xfconfig']['section.' . $sectionID],
-		'sectionID'    => $sectionID,
-	);
-	foreach (array('news', 'grp.news', 'users', 'grp.users', 'tdata') as $cID)
-		$tVars['bclass'][$cID] = ($cID == $sectionID) ? 'btnActive' : 'btnInactive';
-	$xt = $twig->loadTemplate('plugins/xfields/tpl/config.tpl');
-	echo $xt->render($tVars);
+function showFieldList()
+{
+    global $xf, $lang, $twig, $sectionID;
+    $xEntries = [];
+    $output = '';
+    foreach ($xf[$sectionID] as $id => $data) {
+        $storage = '';
+        if ($data['storage']) {
+            $storage = '<br/><font color="red"><b>'.$data['db.type'].($data['db.len'] ? (' ('.$data['db.len'].')') : '').'</b> </font>';
+        }
+        $xEntry = [
+            'name'     => $id,
+            'title'    => $data['title'],
+            'type'     => $lang['xfconfig']['type_'.$data['type']].$storage,
+            'default'  => (($data['type'] == 'checkbox') ? ($data['default'] ? $lang['yesa'] : $lang['noa']) : ($data['default'])),
+            'link'     => '?mod=extra-config&plugin=xfields&action=edit&section='.$sectionID.'&field='.$id,
+            'linkup'   => '?mod=extra-config&plugin=xfields&action=update&subaction=up&section='.$sectionID.'&field='.$id,
+            'linkdown' => '?mod=extra-config&plugin=xfields&action=update&subaction=down&section='.$sectionID.'&field='.$id,
+            'linkdel'  => '?mod=extra-config&plugin=xfields&action=update&subaction=del&section='.$sectionID.'&field='.$id,
+            'area'     => (intval($data['area']) > 0) ? intval($data['area']) : '',
+            'flags'    => [
+                'required' => $data['required'] ? true : false,
+                'default'  => (($data['default'] != '') || ($data['type'] == 'checkbox')) ? true : false,
+                'disabled' => $data['disabled'] ? true : false,
+                'regpage'  => $data['regpage'] ? true : false,
+            ],
+        ];
+        $options = '';
+        if (is_array($data['options']) && count($data['options'])) {
+            foreach ($data['options'] as $k => $v) {
+                $options .= (($data['storekeys']) ? ('<b>'.$k.'</b>: '.$v) : ('<b>'.$v.'</b>'))."<br>\n";
+            }
+        }
+        $xEntry['options'] = $options;
+        $xEntries[] = $xEntry;
+    }
+    if (!count($xf[$sectionID])) {
+        $output = $lang['xfconfig']['nof'];
+    }
+    $tVars = [
+        'entries'      => $xEntries,
+        'section_name' => $lang['xfconfig']['section.'.$sectionID],
+        'sectionID'    => $sectionID,
+    ];
+    foreach (['news', 'grp.news', 'users', 'grp.users', 'tdata'] as $cID) {
+        $tVars['bclass'][$cID] = ($cID == $sectionID) ? 'btnActive' : 'btnInactive';
+    }
+    $xt = $twig->loadTemplate('plugins/xfields/tpl/config.tpl');
+    echo $xt->render($tVars);
 }
 
 //
 //
-function showAddEditForm($xdata = '', $eMode = null, $efield = null) {
-
-	global $xf, $lang, $sectionID, $twig;
-	$field = ($efield == null) ? $_REQUEST['field'] : $efield;
-	if ($eMode == null) {
-		$editMode = (is_array($xf[$sectionID][$field])) ? 1 : 0;
-	} else {
-		$editMode = $eMode;
-	}
-	$tVars = array();
-	if ($editMode) {
-		$data = is_array($xdata) ? $xdata : $xf[$sectionID][$field];
-		$tVars['flags']['editMode'] = 1;
-		$tVars['flags']['disabled'] = $data['disabled'] ? true : false;
-		$tVars['flags']['regpage'] = $data['regpage'] ? true : false;
-		$tVars = $tVars + array(
-				'id'           => $field,
-				'title'        => $data['title'],
-				'type'         => $data['type'],
-				'storage'      => intval($data['storage']),
-				'db_type'      => $data['db.type'],
-				'db_len'       => (intval($data['db.len']) > 0) ? intval($data['db.len']) : '',
-				'area'         => (intval($data['area']) > 0) ? intval($data['area']) : '',
-				'bb_support'   => $data['bb_support'] ? 'checked="checked"' : '',
-				'html_support' => $data['html_support'] ? 'checked="checked"' : '',
-				'noformat'     => $data['noformat'] ? 'checked="checked"' : '',
-			);
-		$xsel = '';
-		foreach (array('text', 'textarea', 'select', 'multiselect', 'checkbox', 'images') as $ts) {
-			$tVars['defaults'][$ts] = ($data['type'] == $ts) ? (($ts == "checkbox") ? ($data['default'] ? ' checked="checked"' : '') : $data['default']) : '';
-			$xsel .= '<option value="' . $ts . '"' . (($data['type'] == $ts) ? ' selected' : '') . '>' . $lang['xfields_type_' . $ts];
-		}
-		$sOpts = array();
-		$fNum = 1;
-		if ($data['type'] == 'select') {
-			if (is_array($data['options']))
-				foreach ($data['options'] as $k => $v) {
-					array_push($sOpts, '<tr><td><input size="12" name="so_data[' . ($fNum) . '][0]" type="text" value="' . ($data['storekeys'] ? htmlspecialchars($k, ENT_COMPAT | ENT_HTML401, 'cp1251') : '') . '"/></td><td><input type="text" size="55" name="so_data[' . ($fNum) . '][1]" value="' . htmlspecialchars($v, ENT_COMPAT | ENT_HTML401, 'cp1251') . '"/></td><td><a href="#" onclick="return false;"><img src="' . skins_url . '/images/delete.gif" alt="DEL" width="12" height="12" /></a></td></tr>');
-					$fNum++;
-				}
-		}
-		if (!count($sOpts)) {
-			array_push($sOpts, '<tr><td><input size="12" name="so_data[1][0]" type="text" value=""/></td><td><input type="text" size="55" name="so_data[1][1]" value=""/></td><td><a href="#" onclick="return false;"><img src="' . skins_url . '/images/delete.gif" alt="DEL" width="12" height="12" /></a></td></tr>');
-		}
-		$m_sOpts = array();
-		$fNum = 1;
-		if ($data['type'] == 'multiselect') {
-			if (is_array($data['options']))
-				foreach ($data['options'] as $k => $v) {
-					array_push($m_sOpts, '<tr><td><input size="12" name="mso_data[' . ($fNum) . '][0]" type="text" value="' . ($data['storekeys'] ? htmlspecialchars($k, ENT_COMPAT | ENT_HTML401, 'cp1251') : '') . '"/></td><td><input type="text" size="55" name="mso_data[' . ($fNum) . '][1]" value="' . htmlspecialchars($v, ENT_COMPAT | ENT_HTML401, 'cp1251') . '"/></td><td><a href="#" onclick="return false;"><img src="' . skins_url . '/images/delete.gif" alt="DEL" width="12" height="12" /></a></td></tr>');
-					$fNum++;
-				}
-		}
-		if (!count($m_sOpts)) {
-			array_push($m_sOpts, '<tr><td><input size="12" name="mso_data[1][0]" type="text" value=""/></td><td><input type="text" size="55" name="mso_data[1][1]" value=""/></td><td><a href="#" onclick="return false;"><img src="' . skins_url . '/images/delete.gif" alt="DEL" width="12" height="12" /></a></td></tr>');
-		}
-		$tVars = $tVars + array(
-				'sOpts'          => implode("\n", $sOpts),
-				'm_sOpts'        => implode("\n", $m_sOpts),
-				'type_opts'      => $xsel,
-				'storekeys_opts' => '<option value="0">Сохранять значение</option><option value="1"' . (($data['storekeys']) ? ' selected' : '') . '>Сохранять код</option>',
-				'required_opts'  => '<option value="0">Нет</option><option value="1"' . (($data['required']) ? ' selected' : '') . '>Да</option>',
-				'images'         => array(
-					'maxCount'    => intval($data['maxCount']),
-					'thumbWidth'  => intval($data['thumbWidth']),
-					'thumbHeight' => intval($data['thumbHeight']),
-				),
-			);
-		foreach (array('imgStamp', 'imgShadow', 'imgThumb', 'thumbStamp', 'thumbShadow') as $k) {
-			$tVars['images'][$k] = intval($data[$k]) ? 'checked="checked"' : '';
-		}
-		//print "<pre>".var_export($tVars, true)."</pre>";
-	} else {
-		$sOpts = array();
-		array_push($sOpts, '<tr><td><input size="12" name="so_data[1][0]" type="text" value=""/></td><td><input type="text" size="55" name="so_data[1][1]" value=""/></td><td><a href="#" onclick="return false;"><img src="' . skins_url . '/images/delete.gif" alt="DEL" width="12" height="12" /></a></td></tr>');
-		$m_sOpts = array();
-		array_push($m_sOpts, '<tr><td><input size="12" name="mso_data[1][0]" type="text" value=""/></td><td><input type="text" size="55" name="mso_data[1][1]" value=""/></td><td><a href="#" onclick="return false;"><img src="' . skins_url . '/images/delete.gif" alt="DEL" width="12" height="12" /></a></td></tr>');
-		$tVars['flags']['editmode'] = 0;
-		$tVars['flags']['disabled'] = false;
-		$tVars = $tVars + array(
-				'sOpts'   => implode("\n", $sOpts),
-				'm_sOpts' => implode("\n", $m_sOpts),
-				'id'      => '',
-				'title'   => '',
-				'type'    => 'text',
-				'storage' => '0',
-				'db_type' => '',
-				'db_len'  => '',
-			);
-		$xsel = '';
-		foreach (array('text', 'textarea', 'select', 'multiselect', 'checkbox', 'images') as $ts) {
-			$tVars['defaults'][$ts] = '';
-			$xsel .= '<option value="' . $ts . '"' . (($data['type'] == 'text') ? ' selected' : '') . '>' . $lang['xfields_type_' . $ts];
-		}
-		$tVars = $tVars + array(
-				'type_opts'      => $xsel,
-				'storekeys_opts' => '<option value="0">Сохранять значение</option><option value="1">Сохранять код</option>',
-				'required_opts'  => '<option value="0">Нет</option><option value="1">Да</option>',
-				'select_options' => '',
-				'images' => array(
-					'maxCount'    => '1',
-					'thumbWidth'  => '150',
-					'thumbHeight' => '150',
-				),
-			);
-		foreach (array('imgStamp', 'imgShadow', 'imgThumb', 'thumbStamp', 'thumbShadow') as $k) {
-			$tVars['images'][$k] = '';
-		}
-	}
-	$tVars['sectionID'] = $sectionID;
-	$xt = $twig->loadTemplate('plugins/xfields/tpl/config_edit.tpl');
-	echo $xt->render($tVars);
+function showAddEditForm($xdata = '', $eMode = null, $efield = null)
+{
+    global $xf, $lang, $sectionID, $twig;
+    $field = ($efield == null) ? $_REQUEST['field'] : $efield;
+    if ($eMode == null) {
+        $editMode = (is_array($xf[$sectionID][$field])) ? 1 : 0;
+    } else {
+        $editMode = $eMode;
+    }
+    $tVars = [];
+    if ($editMode) {
+        $data = is_array($xdata) ? $xdata : $xf[$sectionID][$field];
+        $tVars['flags']['editMode'] = 1;
+        $tVars['flags']['disabled'] = $data['disabled'] ? true : false;
+        $tVars['flags']['regpage'] = $data['regpage'] ? true : false;
+        $tVars = $tVars + [
+            'id'           => $field,
+            'title'        => $data['title'],
+            'type'         => $data['type'],
+            'storage'      => intval($data['storage']),
+            'db_type'      => $data['db.type'],
+            'db_len'       => (intval($data['db.len']) > 0) ? intval($data['db.len']) : '',
+            'area'         => (intval($data['area']) > 0) ? intval($data['area']) : '',
+            'bb_support'   => $data['bb_support'] ? 'checked="checked"' : '',
+            'html_support' => $data['html_support'] ? 'checked="checked"' : '',
+            'noformat'     => $data['noformat'] ? 'checked="checked"' : '',
+        ];
+        $xsel = '';
+        foreach (['text', 'textarea', 'select', 'multiselect', 'checkbox', 'images'] as $ts) {
+            $tVars['defaults'][$ts] = ($data['type'] == $ts) ? (($ts == 'checkbox') ? ($data['default'] ? ' checked="checked"' : '') : $data['default']) : '';
+            $xsel .= '<option value="'.$ts.'"'.(($data['type'] == $ts) ? ' selected' : '').'>'.$lang['xfields_type_'.$ts];
+        }
+        $sOpts = [];
+        $fNum = 1;
+        if ($data['type'] == 'select') {
+            if (is_array($data['options'])) {
+                foreach ($data['options'] as $k => $v) {
+                    array_push($sOpts, '<tr><td><input size="12" name="so_data['.($fNum).'][0]" type="text" value="'.($data['storekeys'] ? htmlspecialchars($k, ENT_COMPAT | ENT_HTML401, 'cp1251') : '').'"/></td><td><input type="text" size="55" name="so_data['.($fNum).'][1]" value="'.htmlspecialchars($v, ENT_COMPAT | ENT_HTML401, 'cp1251').'"/></td><td><a href="#" onclick="return false;"><img src="'.skins_url.'/images/delete.gif" alt="DEL" width="12" height="12" /></a></td></tr>');
+                    $fNum++;
+                }
+            }
+        }
+        if (!count($sOpts)) {
+            array_push($sOpts, '<tr><td><input size="12" name="so_data[1][0]" type="text" value=""/></td><td><input type="text" size="55" name="so_data[1][1]" value=""/></td><td><a href="#" onclick="return false;"><img src="'.skins_url.'/images/delete.gif" alt="DEL" width="12" height="12" /></a></td></tr>');
+        }
+        $m_sOpts = [];
+        $fNum = 1;
+        if ($data['type'] == 'multiselect') {
+            if (is_array($data['options'])) {
+                foreach ($data['options'] as $k => $v) {
+                    array_push($m_sOpts, '<tr><td><input size="12" name="mso_data['.($fNum).'][0]" type="text" value="'.($data['storekeys'] ? htmlspecialchars($k, ENT_COMPAT | ENT_HTML401, 'cp1251') : '').'"/></td><td><input type="text" size="55" name="mso_data['.($fNum).'][1]" value="'.htmlspecialchars($v, ENT_COMPAT | ENT_HTML401, 'cp1251').'"/></td><td><a href="#" onclick="return false;"><img src="'.skins_url.'/images/delete.gif" alt="DEL" width="12" height="12" /></a></td></tr>');
+                    $fNum++;
+                }
+            }
+        }
+        if (!count($m_sOpts)) {
+            array_push($m_sOpts, '<tr><td><input size="12" name="mso_data[1][0]" type="text" value=""/></td><td><input type="text" size="55" name="mso_data[1][1]" value=""/></td><td><a href="#" onclick="return false;"><img src="'.skins_url.'/images/delete.gif" alt="DEL" width="12" height="12" /></a></td></tr>');
+        }
+        $tVars = $tVars + [
+            'sOpts'          => implode("\n", $sOpts),
+            'm_sOpts'        => implode("\n", $m_sOpts),
+            'type_opts'      => $xsel,
+            'storekeys_opts' => '<option value="0">Сохранять значение</option><option value="1"'.(($data['storekeys']) ? ' selected' : '').'>Сохранять код</option>',
+            'required_opts'  => '<option value="0">Нет</option><option value="1"'.(($data['required']) ? ' selected' : '').'>Да</option>',
+            'images'         => [
+                'maxCount'    => intval($data['maxCount']),
+                'thumbWidth'  => intval($data['thumbWidth']),
+                'thumbHeight' => intval($data['thumbHeight']),
+            ],
+        ];
+        foreach (['imgStamp', 'imgShadow', 'imgThumb', 'thumbStamp', 'thumbShadow'] as $k) {
+            $tVars['images'][$k] = intval($data[$k]) ? 'checked="checked"' : '';
+        }
+        //print "<pre>".var_export($tVars, true)."</pre>";
+    } else {
+        $sOpts = [];
+        array_push($sOpts, '<tr><td><input size="12" name="so_data[1][0]" type="text" value=""/></td><td><input type="text" size="55" name="so_data[1][1]" value=""/></td><td><a href="#" onclick="return false;"><img src="'.skins_url.'/images/delete.gif" alt="DEL" width="12" height="12" /></a></td></tr>');
+        $m_sOpts = [];
+        array_push($m_sOpts, '<tr><td><input size="12" name="mso_data[1][0]" type="text" value=""/></td><td><input type="text" size="55" name="mso_data[1][1]" value=""/></td><td><a href="#" onclick="return false;"><img src="'.skins_url.'/images/delete.gif" alt="DEL" width="12" height="12" /></a></td></tr>');
+        $tVars['flags']['editmode'] = 0;
+        $tVars['flags']['disabled'] = false;
+        $tVars = $tVars + [
+            'sOpts'   => implode("\n", $sOpts),
+            'm_sOpts' => implode("\n", $m_sOpts),
+            'id'      => '',
+            'title'   => '',
+            'type'    => 'text',
+            'storage' => '0',
+            'db_type' => '',
+            'db_len'  => '',
+        ];
+        $xsel = '';
+        foreach (['text', 'textarea', 'select', 'multiselect', 'checkbox', 'images'] as $ts) {
+            $tVars['defaults'][$ts] = '';
+            $xsel .= '<option value="'.$ts.'"'.(($data['type'] == 'text') ? ' selected' : '').'>'.$lang['xfields_type_'.$ts];
+        }
+        $tVars = $tVars + [
+            'type_opts'      => $xsel,
+            'storekeys_opts' => '<option value="0">Сохранять значение</option><option value="1">Сохранять код</option>',
+            'required_opts'  => '<option value="0">Нет</option><option value="1">Да</option>',
+            'select_options' => '',
+            'images'         => [
+                'maxCount'    => '1',
+                'thumbWidth'  => '150',
+                'thumbHeight' => '150',
+            ],
+        ];
+        foreach (['imgStamp', 'imgShadow', 'imgThumb', 'thumbStamp', 'thumbShadow'] as $k) {
+            $tVars['images'][$k] = '';
+        }
+    }
+    $tVars['sectionID'] = $sectionID;
+    $xt = $twig->loadTemplate('plugins/xfields/tpl/config_edit.tpl');
+    echo $xt->render($tVars);
 }
 
 //
 //
-function doAddEdit() {
+function doAddEdit()
+{
+    global $xf, $XF, $lang, $tpl, $twig, $mysql, $sectionID;
+    //print "<pre>".var_export($_POST, true)."</pre>";
+    $error = 0;
+    $field = $_REQUEST['id'];
+    $editMode = $_REQUEST['edit'] ? 1 : 0;
+    // Check if field exists or not [depends on mode]
+    if ($editMode && (!is_array($xf[$sectionID][$field]))) {
+        msg(['type' => 'error', 'text' => $lang['xfields_msge_noexists']]);
+        $error = 1;
+    } elseif (!$editMode && (is_array($xf[$sectionID][$field]))) {
+        msg(['type' => 'error', 'text' => $lang['xfields_msge_exists']]);
+        $error = 1;
+    }
+    // Check if Field name fits our requirements
+    if (!$editMode) {
+        if (!preg_match('/^[a-z]{1}[a-z0-9]{2}[a-z0-9]*$/', $field)) {
+            msg(['type' => 'error', 'text' => $lang['xfields_msge_format']]);
+            $error = 1;
+        }
+    }
+    // Let's fill parameters
+    $data['title'] = $_REQUEST['title'];
+    $data['required'] = intval($_REQUEST['required']);
+    $data['disabled'] = intval($_REQUEST['disabled']);
+    $data['area'] = intval($_REQUEST['area']);
+    $data['type'] = $_REQUEST['type'];
+    $data['bb_support'] = $_REQUEST['bb_support'] ? 1 : 0;
+    $data['default'] = '';
+    if (($sectionID == 'users') && ($data['type'] != 'images')) {
+        $data['regpage'] = intval($_REQUEST['regpage']);
+    }
+    switch ($data['type']) {
+        case 'checkbox':
+            $data['default'] = $_REQUEST['checkbox_default'] ? 1 : 0;
+            break;
+        case 'text':
+            if ($_REQUEST['text_default'] != '') {
+                $data['default'] = $_REQUEST['text_default'];
+            }
+            $data['bb_support'] = $_REQUEST['text_bb_support'] ? 1 : 0;
+            $data['html_support'] = $_REQUEST['text_html_support'] ? 1 : 0;
+            break;
+        case 'textarea':
+            if ($_REQUEST['textarea_default'] != '') {
+                $data['default'] = $_REQUEST['textarea_default'];
+            }
+            $data['bb_support'] = $_REQUEST['textarea_bb_support'] ? 1 : 0;
+            $data['html_support'] = $_REQUEST['textarea_html_support'] ? 1 : 0;
+            $data['noformat'] = $_REQUEST['textarea_noformat'] ? 1 : 0;
+            break;
+        case 'select':
+            // Check options
+            $optlist = [];
+            $optvals = [];
+            if (isset($_REQUEST['so_data']) && is_array($_REQUEST['so_data'])) {
+                foreach ($_REQUEST['so_data'] as $k => $v) {
+                    if (is_array($v) && isset($v[0]) && isset($v[1]) && (($v[0] != '') || ($v[1] != ''))) {
+                        if ($v[0] != '') {
+                            $optlist[$v[0]] = $v[1];
+                        } else {
+                            $optlist[] = $v[1];
+                        }
+                        //print "<pre>SO_LINE: ".$v[0].", ".$v[1]."</pre>";
+                    }
+                }
+            }
+            $opt_vals = array_values($optlist);
+            /*
+            $opts = $_REQUEST['select_options'];
+            $optlist = array();
+            $optvals = array();
+            foreach (explode("\n", $opts) as $line) {
+                $line = trim($line);
+                if (preg_match('/^(.+?) *\=\> *(.+?)$/', $line, $match)) {
+                    $optlist[$match[1]] = $match[2];
+                    $optvals[$match[2]] = 1;
+                } elseif ($line != '') {
+                    $optlist[] = $line;
+                    $optvals[$line] = 1;
+                }
+            }
+            */
+            $data['storekeys'] = intval($_REQUEST['select_storekeys']) ? 1 : 0;
+            $data['options'] = $optlist;
+            if (trim($_REQUEST['select_default'])) {
+                $data['default'] = trim($_REQUEST['select_default']);
+                if (
+                    (($data['storekeys']) && (!array_key_exists($data['default'], $optlist))) ||
+                    ((!$data['storekeys']) && (!in_array($data['default'], $optlist)))
+                ) {
+                    msg(['type' => 'error', 'text' => $lang['xfields_msge_errdefault']]);
+                    $error = 1;
+                }
+            }
+            break;
+        case 'multiselect':
+            // Check options
+            $optlist = [];
+            $optvals = [];
+            if (isset($_REQUEST['mso_data']) && is_array($_REQUEST['mso_data'])) {
+                foreach ($_REQUEST['mso_data'] as $k => $v) {
+                    if (is_array($v) && isset($v[0]) && isset($v[1]) && (($v[0] != '') || ($v[1] != ''))) {
+                        if ($v[0] != '') {
+                            $optlist[$v[0]] = $v[1];
+                        } else {
+                            $optlist[] = $v[1];
+                        }
+                        //print "<pre>SO_LINE: ".$v[0].", ".$v[1]."</pre>";
+                    }
+                }
+            }
+            $opt_vals = array_values($optlist);
+            /*
+            $opts = $_REQUEST['select_options'];
+            $optlist = array();
+            $optvals = array();
+            foreach (explode("\n", $opts) as $line) {
+                $line = trim($line);
+                if (preg_match('/^(.+?) *\=\> *(.+?)$/', $line, $match)) {
+                    $optlist[$match[1]] = $match[2];
+                    $optvals[$match[2]] = 1;
+                } elseif ($line != '') {
+                    $optlist[] = $line;
+                    $optvals[$line] = 1;
+                }
+            }
+            */
+            $data['storekeys'] = intval($_REQUEST['select_storekeys_multi']) ? 1 : 0;
+            $data['options'] = $optlist;
+            if (trim($_REQUEST['select_default_multi'])) {
+                $data['default'] = trim($_REQUEST['select_default_multi']);
+                if (
+                    (($data['storekeys']) && (!array_key_exists($data['default'], $optlist))) ||
+                    ((!$data['storekeys']) && (!in_array($data['default'], $optlist)))
+                ) {
+                    msg(['type' => 'error', 'text' => $lang['xfields_msge_errdefault']]);
+                    $error = 1;
+                }
+            }
+            break;
+        case 'images':
+            $data['maxCount'] = intval($_REQUEST['images_maxCount']);
+            $data['imgShadow'] = intval($_REQUEST['images_imgShadow']) ? 1 : 0;
+            $data['imgStamp'] = intval($_REQUEST['images_imgStamp']) ? 1 : 0;
+            $data['imgThumb'] = intval($_REQUEST['images_imgThumb']) ? 1 : 0;
+            $data['thumbWidth'] = intval($_REQUEST['images_thumbWidth']);
+            $data['thumbHeight'] = intval($_REQUEST['images_thumbHeight']);
+            $data['thumbStamp'] = intval($_REQUEST['images_thumbStamp']) ? 1 : 0;
+            $data['thumbShadow'] = intval($_REQUEST['images_thumbShadow']) ? 1 : 0;
+            break;
+        default:
+            $data['type'] = '';
+            break;
+    }
+    if (!$data['type']) {
+        msg(['type' => 'error', 'text' => $lang['xfields_msge_errtype']]);
+        $error = 1;
+    }
+    if (!$data['title']) {
+        msg(['type' => 'error', 'text' => $lang['xfields_msge_errtitle']]);
+        $error = 1;
+    }
+    // Check for storage params
+    $data['storage'] = $_REQUEST['storage'];
+    $data['db.type'] = $_REQUEST['db_type'];
+    $data['db.len'] = intval($_REQUEST['db_len']);
+    if ($data['storage']) {
+        // Check for correct DB type
+        if (!in_array($data['db.type'], ['int', 'decimal', 'char', 'datetime', 'text'])) {
+            msg(['type' => 'error', 'text' => $lang['xfields_error.db.type']]);
+            $error = 1;
+        }
+        // Check for correct DB len (if applicable)
+        if (($data['db.type'] == 'char') && ((intval($data['db.len']) < 1) || (intval($data['db.len']) > 255))) {
+            msg(['type' => 'error', 'text' => $lang['xfields_error.db.len']]);
+            $error = 1;
+        }
+    }
+    if ($error) {
+        showAddEditForm($data, $editMode, $field, $sectionID);
 
-	global $xf, $XF, $lang, $tpl, $twig, $mysql, $sectionID;
-	//print "<pre>".var_export($_POST, true)."</pre>";
-	$error = 0;
-	$field = $_REQUEST['id'];
-	$editMode = $_REQUEST['edit'] ? 1 : 0;
-	// Check if field exists or not [depends on mode]
-	if ($editMode && (!is_array($xf[$sectionID][$field]))) {
-		msg(array("type" => "error", "text" => $lang['xfields_msge_noexists']));
-		$error = 1;
-	} elseif (!$editMode && (is_array($xf[$sectionID][$field]))) {
-		msg(array("type" => "error", "text" => $lang['xfields_msge_exists']));
-		$error = 1;
-	}
-	// Check if Field name fits our requirements
-	if (!$editMode) {
-		if (!preg_match('/^[a-z]{1}[a-z0-9]{2}[a-z0-9]*$/', $field)) {
-			msg(array("type" => "error", "text" => $lang['xfields_msge_format']));
-			$error = 1;
-		}
-	}
-	// Let's fill parameters
-	$data['title'] = $_REQUEST['title'];
-	$data['required'] = intval($_REQUEST['required']);
-	$data['disabled'] = intval($_REQUEST['disabled']);
-	$data['area'] = intval($_REQUEST['area']);
-	$data['type'] = $_REQUEST['type'];
-	$data['bb_support'] = $_REQUEST['bb_support'] ? 1 : 0;
-	$data['default'] = '';
-	if (($sectionID == 'users') && ($data['type'] != 'images'))
-		$data['regpage'] = intval($_REQUEST['regpage']);
-	switch ($data['type']) {
-		case 'checkbox':
-			$data['default'] = $_REQUEST['checkbox_default'] ? 1 : 0;
-			break;
-		case 'text':
-			if ($_REQUEST['text_default'] != '')
-				$data['default'] = $_REQUEST['text_default'];
-			$data['bb_support'] = $_REQUEST['text_bb_support'] ? 1 : 0;
-			$data['html_support'] = $_REQUEST['text_html_support'] ? 1 : 0;
-			break;
-		case 'textarea':
-			if ($_REQUEST['textarea_default'] != '')
-				$data['default'] = $_REQUEST['textarea_default'];
-			$data['bb_support'] = $_REQUEST['textarea_bb_support'] ? 1 : 0;
-			$data['html_support'] = $_REQUEST['textarea_html_support'] ? 1 : 0;
-			$data['noformat'] = $_REQUEST['textarea_noformat'] ? 1 : 0;
-			break;
-		case 'select':
-			// Check options
-			$optlist = array();
-			$optvals = array();
-			if (isset($_REQUEST['so_data']) && is_array($_REQUEST['so_data'])) {
-				foreach ($_REQUEST['so_data'] as $k => $v) {
-					if (is_array($v) && isset($v[0]) && isset($v[1]) && (($v[0] != '') || ($v[1] != ''))) {
-						if ($v[0] != '') {
-							$optlist[$v[0]] = $v[1];
-						} else {
-							$optlist[] = $v[1];
-						}
-						//print "<pre>SO_LINE: ".$v[0].", ".$v[1]."</pre>";
-					}
-				}
-			}
-			$opt_vals = array_values($optlist);
-			/*
-			$opts = $_REQUEST['select_options'];
-			$optlist = array();
-			$optvals = array();
-			foreach (explode("\n", $opts) as $line) {
-				$line = trim($line);
-				if (preg_match('/^(.+?) *\=\> *(.+?)$/', $line, $match)) {
-					$optlist[$match[1]] = $match[2];
-					$optvals[$match[2]] = 1;
-				} elseif ($line != '') {
-					$optlist[] = $line;
-					$optvals[$line] = 1;
-				}
-			}
-			*/
-			$data['storekeys'] = intval($_REQUEST['select_storekeys']) ? 1 : 0;
-			$data['options'] = $optlist;
-			if (trim($_REQUEST['select_default'])) {
-				$data['default'] = trim($_REQUEST['select_default']);
-				if (
-					(($data['storekeys']) && (!array_key_exists($data['default'], $optlist))) ||
-					((!$data['storekeys']) && (!in_array($data['default'], $optlist)))
-				) {
-					msg(array("type" => "error", "text" => $lang['xfields_msge_errdefault']));
-					$error = 1;
-				}
-			}
-			break;
-		case 'multiselect':
-			// Check options
-			$optlist = array();
-			$optvals = array();
-			if (isset($_REQUEST['mso_data']) && is_array($_REQUEST['mso_data'])) {
-				foreach ($_REQUEST['mso_data'] as $k => $v) {
-					if (is_array($v) && isset($v[0]) && isset($v[1]) && (($v[0] != '') || ($v[1] != ''))) {
-						if ($v[0] != '') {
-							$optlist[$v[0]] = $v[1];
-						} else {
-							$optlist[] = $v[1];
-						}
-						//print "<pre>SO_LINE: ".$v[0].", ".$v[1]."</pre>";
-					}
-				}
-			}
-			$opt_vals = array_values($optlist);
-			/*
-			$opts = $_REQUEST['select_options'];
-			$optlist = array();
-			$optvals = array();
-			foreach (explode("\n", $opts) as $line) {
-				$line = trim($line);
-				if (preg_match('/^(.+?) *\=\> *(.+?)$/', $line, $match)) {
-					$optlist[$match[1]] = $match[2];
-					$optvals[$match[2]] = 1;
-				} elseif ($line != '') {
-					$optlist[] = $line;
-					$optvals[$line] = 1;
-				}
-			}
-			*/
-			$data['storekeys'] = intval($_REQUEST['select_storekeys_multi']) ? 1 : 0;
-			$data['options'] = $optlist;
-			if (trim($_REQUEST['select_default_multi'])) {
-				$data['default'] = trim($_REQUEST['select_default_multi']);
-				if (
-					(($data['storekeys']) && (!array_key_exists($data['default'], $optlist))) ||
-					((!$data['storekeys']) && (!in_array($data['default'], $optlist)))
-				) {
-					msg(array("type" => "error", "text" => $lang['xfields_msge_errdefault']));
-					$error = 1;
-				}
-			}
-			break;
-		case 'images':
-			$data['maxCount'] = intval($_REQUEST['images_maxCount']);
-			$data['imgShadow'] = intval($_REQUEST['images_imgShadow']) ? 1 : 0;
-			$data['imgStamp'] = intval($_REQUEST['images_imgStamp']) ? 1 : 0;
-			$data['imgThumb'] = intval($_REQUEST['images_imgThumb']) ? 1 : 0;
-			$data['thumbWidth'] = intval($_REQUEST['images_thumbWidth']);
-			$data['thumbHeight'] = intval($_REQUEST['images_thumbHeight']);
-			$data['thumbStamp'] = intval($_REQUEST['images_thumbStamp']) ? 1 : 0;
-			$data['thumbShadow'] = intval($_REQUEST['images_thumbShadow']) ? 1 : 0;
-			break;
-		default:
-			$data['type'] = '';
-			break;
-	}
-	if (!$data['type']) {
-		msg(array("type" => "error", "text" => $lang['xfields_msge_errtype']));
-		$error = 1;
-	}
-	if (!$data['title']) {
-		msg(array("type" => "error", "text" => $lang['xfields_msge_errtitle']));
-		$error = 1;
-	}
-	// Check for storage params
-	$data['storage'] = $_REQUEST['storage'];
-	$data['db.type'] = $_REQUEST['db_type'];
-	$data['db.len'] = intval($_REQUEST['db_len']);
-	if ($data['storage']) {
-		// Check for correct DB type
-		if (!in_array($data['db.type'], array('int', 'decimal', 'char', 'datetime', 'text'))) {
-			msg(array("type" => "error", "text" => $lang['xfields_error.db.type']));
-			$error = 1;
-		}
-		// Check for correct DB len (if applicable)
-		if (($data['db.type'] == 'char') && ((intval($data['db.len']) < 1) || (intval($data['db.len']) > 255))) {
-			msg(array("type" => "error", "text" => $lang['xfields_error.db.len']));
-			$error = 1;
-		}
-	}
-	if ($error) {
-		showAddEditForm($data, $editMode, $field, $sectionID);
+        return;
+    }
+    $DB = [];
+    $DB['new'] = ['storage' => $data['storage'], 'db.type' => $data['db.type'], 'db.len' => $data['db.len']];
+    if ($editMode) {
+        $DB['old'] = ['storage' => $XF[$sectionID][$field]['storage'], 'db.type' => $XF[$sectionID][$field]['db.type'], 'db.len' => $XF[$sectionID][$field]['db.len']];
+    }
+    $XF[$sectionID][$field] = $data;
+    if (!xf_configSave()) {
+        msg(['type' => 'error', 'text' => $lang['xfields_msge_errcsave']]);
+        showAddEditForm($data, $editMode, $field);
 
-		return;
-	}
-	$DB = array();
-	$DB['new'] = array('storage' => $data['storage'], 'db.type' => $data['db.type'], 'db.len' => $data['db.len']);
-	if ($editMode) {
-		$DB['old'] = array('storage' => $XF[$sectionID][$field]['storage'], 'db.type' => $XF[$sectionID][$field]['db.type'], 'db.len' => $XF[$sectionID][$field]['db.len']);
-	}
-	$XF[$sectionID][$field] = $data;
-	if (!xf_configSave()) {
-		msg(array("type" => "error", "text" => $lang['xfields_msge_errcsave']));
-		showAddEditForm($data, $editMode, $field);
+        return;
+    }
+    // Now we should update table `_news` structure and content
+    if (!($tableName = xf_getTableBySectionID($sectionID))) {
+        echo 'Ошибка: неизвестная секция/блок ('.$sectionID.')';
 
-		return;
-	}
-	// Now we should update table `_news` structure and content
-	if (!($tableName = xf_getTableBySectionID($sectionID))) {
-		print 'Ошибка: неизвестная секция/блок (' . $sectionID . ')';
-
-		return;
-	}
-	$found = 0;
-	foreach ($mysql->select("describe " . $tableName, 1) as $row) {
-		if ($row['Field'] == 'xfields_' . $field) {
-			$found = 1;
-			break;
-		}
-	}
-	$dbFlagChanged = 0;
-	// 1. If we add XFIELD and field already exists in DB - drop it!
-	// 2. If we don't want to store data in separate field - drop it!
-	if ($found && (!$editMode || !$DB['new']['storage'])) {
-		$mysql->query("alter table " . $tableName . " drop column `xfields_" . $field . "`");
-	}
-	// If we need to have this field - let's make it. But only if smth was changed
-	do {
-		if (!$data['storage']) break;
-		// Anything should be done only if field is changed
-		if (($DB['old']['db.type'] == $DB['new']['db.type']) && ($DB['old']['db.len'] == $DB['new']['db.len'])) break;
-		$ftype = '';
-		switch ($DB['new']['db.type']) {
-			case 'int':
-				$ftype = 'int';
-				break;
-			case 'decimal':
-				$ftype = 'decimal (12,2)';
-				break;
-			case 'datetime':
-				$ftype = 'datetime';
-				break;
-			case 'char':
-				if (($DB['new']['db.len'] > 0) && ($DB['new']['db.len'] <= 255)) {
-					$ftype = 'char(' . intval($DB['new']['db.len']) . ')';
-					break;
-				}
-			case 'text':
-				$ftype = 'text';
-				break;
-		}
-		if ($ftype) {
-			$dbFlagChanged = 1;
-			if ($found) {
-				$mysql->query("alter table " . $tableName . " change column `xfields_" . $field . '` `xfields_' . $field . '` ' . $ftype);
-				$mysql->query("update " . $tableName . " set `xfields_" . $field . "` = NULL");
-			} else {
-				$mysql->query("alter table " . $tableName . " add column `xfields_" . $field . '` ' . $ftype);
-			}
-		}
-	} while (0);
-	// Second - fill field's content if required
-	if ($DB['new']['storage'] && $dbFlagChanged) {
-		// Make updates with chunks for 500 RECS
-		$recCount = 0;
-		$maxID = 0;
-		do {
-			$recCount = 0;
-			foreach ($mysql->select("select id, xfields from " . $tableName . " where (id > " . $maxID . ") and (xfields is not NULL) and (xfields <> '') order by id limit 500") as $rec) {
-				$recCount++;
-				if ($rec['id'] > $maxID) $maxID = $rec['id'];
-				$xlist = xf_decode($rec['xfields']);
-				if (isset($xlist[$field]) && ($xlist[$field] != '')) {
-					$mysql->query("update " . $tableName . " set `xfields_" . $field . "` = " . db_squote($xlist[$field]) . " where id = " . db_squote($rec['id']));
-				}
-			}
-		} while ($recCount);
-	}
-	$tVars = array(
-		'id'        => $field,
-		'sectionID' => $sectionID,
-		'flags'     => array(
-			'editMode' => $editMode ? true : false,
-		),
-	);
-	$tVars['sectionID'] = $sectionID;
-	$xt = $twig->loadTemplate('plugins/xfields/tpl/config_done.tpl');
-	echo $xt->render($tVars);
+        return;
+    }
+    $found = 0;
+    foreach ($mysql->select('describe '.$tableName, 1) as $row) {
+        if ($row['Field'] == 'xfields_'.$field) {
+            $found = 1;
+            break;
+        }
+    }
+    $dbFlagChanged = 0;
+    // 1. If we add XFIELD and field already exists in DB - drop it!
+    // 2. If we don't want to store data in separate field - drop it!
+    if ($found && (!$editMode || !$DB['new']['storage'])) {
+        $mysql->query('alter table '.$tableName.' drop column `xfields_'.$field.'`');
+    }
+    // If we need to have this field - let's make it. But only if smth was changed
+    do {
+        if (!$data['storage']) {
+            break;
+        }
+        // Anything should be done only if field is changed
+        if (($DB['old']['db.type'] == $DB['new']['db.type']) && ($DB['old']['db.len'] == $DB['new']['db.len'])) {
+            break;
+        }
+        $ftype = '';
+        switch ($DB['new']['db.type']) {
+            case 'int':
+                $ftype = 'int';
+                break;
+            case 'decimal':
+                $ftype = 'decimal (12,2)';
+                break;
+            case 'datetime':
+                $ftype = 'datetime';
+                break;
+            case 'char':
+                if (($DB['new']['db.len'] > 0) && ($DB['new']['db.len'] <= 255)) {
+                    $ftype = 'char('.intval($DB['new']['db.len']).')';
+                    break;
+                }
+            case 'text':
+                $ftype = 'text';
+                break;
+        }
+        if ($ftype) {
+            $dbFlagChanged = 1;
+            if ($found) {
+                $mysql->query('alter table '.$tableName.' change column `xfields_'.$field.'` `xfields_'.$field.'` '.$ftype);
+                $mysql->query('update '.$tableName.' set `xfields_'.$field.'` = NULL');
+            } else {
+                $mysql->query('alter table '.$tableName.' add column `xfields_'.$field.'` '.$ftype);
+            }
+        }
+    } while (0);
+    // Second - fill field's content if required
+    if ($DB['new']['storage'] && $dbFlagChanged) {
+        // Make updates with chunks for 500 RECS
+        $recCount = 0;
+        $maxID = 0;
+        do {
+            $recCount = 0;
+            foreach ($mysql->select('select id, xfields from '.$tableName.' where (id > '.$maxID.") and (xfields is not NULL) and (xfields <> '') order by id limit 500") as $rec) {
+                $recCount++;
+                if ($rec['id'] > $maxID) {
+                    $maxID = $rec['id'];
+                }
+                $xlist = xf_decode($rec['xfields']);
+                if (isset($xlist[$field]) && ($xlist[$field] != '')) {
+                    $mysql->query('update '.$tableName.' set `xfields_'.$field.'` = '.db_squote($xlist[$field]).' where id = '.db_squote($rec['id']));
+                }
+            }
+        } while ($recCount);
+    }
+    $tVars = [
+        'id'        => $field,
+        'sectionID' => $sectionID,
+        'flags'     => [
+            'editMode' => $editMode ? true : false,
+        ],
+    ];
+    $tVars['sectionID'] = $sectionID;
+    $xt = $twig->loadTemplate('plugins/xfields/tpl/config_done.tpl');
+    echo $xt->render($tVars);
 }
 
 //
 //
-function doUpdate() {
+function doUpdate()
+{
+    global $xf, $XF, $lang, $tpl, $mysql, $sectionID;
+    $error = 0;
+    $field = $_REQUEST['field'];
+    // Check if field exists or not [depends on mode]
+    if (!is_array($xf[$sectionID][$field])) {
+        msg(['type' => 'error', 'text' => $lang['xfields_msge_noexists'].'('.$sectionID.': '.$field.')']);
+        $error = 1;
+    }
+    $notif = '';
+    switch ($_REQUEST['subaction']) {
+        case 'del':        // Delete field from SQL table if required
+            if (($XF[$sectionID][$field]['storage']) && ($tableName = xf_getTableBySectionID($sectionID))) {
+                // Check if field really exist
+                $found = 0;
+                foreach ($mysql->select('describe '.$tableName, 1) as $row) {
+                    if ($row['Field'] == 'xfields_'.$field) {
+                        $found = 1;
+                        break;
+                    }
+                }
+                if ($found) {
+                    $mysql->query('alter table '.$tableName.' drop column `xfields_'.$field.'`');
+                }
+            }
+            unset($XF[$sectionID][$field]);
+            $notif = $lang['xfields_done_del'];
+            break;
+        case 'up':
+            array_key_move($XF[$sectionID], $field, -1);
+            $notif = $lang['xfields_done_up'];
+            break;
+        case 'down':
+            array_key_move($XF[$sectionID], $field, 1);
+            $notif = $lang['xfields_done_down'];
+            break;
+        default:
+            $notif = $lang['xfields_updateunk'];
+    }
+    if (!xf_configSave()) {
+        msg(['type' => 'error', 'text' => $lang['xfields_msge_errcsave']]);
 
-	global $xf, $XF, $lang, $tpl, $mysql, $sectionID;
-	$error = 0;
-	$field = $_REQUEST['field'];
-	// Check if field exists or not [depends on mode]
-	if (!is_array($xf[$sectionID][$field])) {
-		msg(array("type" => "error", "text" => $lang['xfields_msge_noexists'] . '(' . $sectionID . ': ' . $field . ')'));
-		$error = 1;
-	};
-	$notif = '';
-	switch ($_REQUEST['subaction']) {
-		case 'del':        // Delete field from SQL table if required
-			if (($XF[$sectionID][$field]['storage']) && ($tableName = xf_getTableBySectionID($sectionID))) {
-				// Check if field really exist
-				$found = 0;
-				foreach ($mysql->select("describe " . $tableName, 1) as $row) {
-					if ($row['Field'] == 'xfields_' . $field) {
-						$found = 1;
-						break;
-					}
-				}
-				if ($found)
-					$mysql->query("alter table " . $tableName . " drop column `xfields_" . $field . "`");
-			}
-			unset($XF[$sectionID][$field]);
-			$notif = $lang['xfields_done_del'];
-			break;
-		case 'up':
-			array_key_move($XF[$sectionID], $field, -1);
-			$notif = $lang['xfields_done_up'];
-			break;
-		case 'down':
-			array_key_move($XF[$sectionID], $field, 1);
-			$notif = $lang['xfields_done_down'];
-			break;
-		default:
-			$notif = $lang['xfields_updateunk'];
-	}
-	if (!xf_configSave()) {
-		msg(array("type" => "error", "text" => $lang['xfields_msge_errcsave']));
-
-		return;
-	}
-	$xf = $XF;
+        return;
+    }
+    $xf = $XF;
 }
 
-function array_key_move(&$arr, $key, $offset) {
-
-	$keys = array_keys($arr);
-	$index = -1;
-	foreach ($keys as $k => $v) if ($v == $key) {
-		$index = $k;
-		break;
-	}
-	if ($index == -1) return 0;
-	$index2 = $index + $offset;
-	if ($index2 < 0) $index2 = 0;
-	if ($index2 > (count($arr) - 1)) $index2 = count($arr) - 1;
-	if ($index == $index2) return 1;
-	$a = min($index, $index2);
-	$b = max($index, $index2);
-	$arr = array_slice($arr, 0, $a) +
-		array_slice($arr, $b, 1) +
-		array_slice($arr, $a + 1, $b - $a) +
-		array_slice($arr, $a, 1) +
-		array_slice($arr, $b, count($arr) - $b);
+function array_key_move(&$arr, $key, $offset)
+{
+    $keys = array_keys($arr);
+    $index = -1;
+    foreach ($keys as $k => $v) {
+        if ($v == $key) {
+            $index = $k;
+            break;
+        }
+    }
+    if ($index == -1) {
+        return 0;
+    }
+    $index2 = $index + $offset;
+    if ($index2 < 0) {
+        $index2 = 0;
+    }
+    if ($index2 > (count($arr) - 1)) {
+        $index2 = count($arr) - 1;
+    }
+    if ($index == $index2) {
+        return 1;
+    }
+    $a = min($index, $index2);
+    $b = max($index, $index2);
+    $arr = array_slice($arr, 0, $a) +
+        array_slice($arr, $b, 1) +
+        array_slice($arr, $a + 1, $b - $a) +
+        array_slice($arr, $a, 1) +
+        array_slice($arr, $b, count($arr) - $b);
 }

--- a/xfields/install.php
+++ b/xfields/install.php
@@ -1,52 +1,54 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
 plugins_load_config();
 LoadPluginLang('xfields', 'config');
-$db_update = array(
-	array(
-		'table'  => 'news',
-		'action' => 'modify',
-		'fields' => array(
-			array('action' => 'cmodify', 'name' => 'xfields', 'type' => 'text', 'params' => 'default null'),
-		)
-	),
-	array(
-		'table'  => 'category',
-		'action' => 'modify',
-		'fields' => array(
-			array('action' => 'cmodify', 'name' => 'xf_group', 'type' => 'char(40)', 'params' => 'default 0'),
-		)
-	),
-	array(
-		'table'  => 'users',
-		'action' => 'modify',
-		'fields' => array(
-			array('action' => 'cmodify', 'name' => 'xfields', 'type' => 'text', 'params' => 'default null'),
-		)
-	),
-	array(
-		'table'  => 'xfields',
-		'action' => 'cmodify',
-		'key'    => 'primary key(id)',
-		'fields' => array(
-			array('action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'),
-			array('action' => 'cmodify', 'name' => 'linked_ds', 'type' => 'int', 'params' => 'default 0'),
-			array('action' => 'cmodify', 'name' => 'linked_id', 'type' => 'int', 'params' => 'default 0'),
-			array('action' => 'cmodify', 'name' => 'xfields', 'type' => 'text', 'params' => 'default null'),
-		)
-	),
-);
+$db_update = [
+    [
+        'table'  => 'news',
+        'action' => 'modify',
+        'fields' => [
+            ['action' => 'cmodify', 'name' => 'xfields', 'type' => 'text', 'params' => 'default null'],
+        ],
+    ],
+    [
+        'table'  => 'category',
+        'action' => 'modify',
+        'fields' => [
+            ['action' => 'cmodify', 'name' => 'xf_group', 'type' => 'char(40)', 'params' => 'default 0'],
+        ],
+    ],
+    [
+        'table'  => 'users',
+        'action' => 'modify',
+        'fields' => [
+            ['action' => 'cmodify', 'name' => 'xfields', 'type' => 'text', 'params' => 'default null'],
+        ],
+    ],
+    [
+        'table'  => 'xfields',
+        'action' => 'cmodify',
+        'key'    => 'primary key(id)',
+        'fields' => [
+            ['action' => 'cmodify', 'name' => 'id', 'type' => 'int', 'params' => 'not null auto_increment'],
+            ['action' => 'cmodify', 'name' => 'linked_ds', 'type' => 'int', 'params' => 'default 0'],
+            ['action' => 'cmodify', 'name' => 'linked_id', 'type' => 'int', 'params' => 'default 0'],
+            ['action' => 'cmodify', 'name' => 'xfields', 'type' => 'text', 'params' => 'default null'],
+        ],
+    ],
+];
 if ($_REQUEST['action'] == 'commit') {
-	// If submit requested, do config save
-	if (fixdb_plugin_install('xfields', $db_update)) {
-		plugin_mark_installed('xfields');
-	}
+    // If submit requested, do config save
+    if (fixdb_plugin_install('xfields', $db_update)) {
+        plugin_mark_installed('xfields');
+    }
 } else {
-	$text = $lang['xfields_desc_install'];
-	generate_install_page('xfields', $text);
+    $text = $lang['xfields_desc_install'];
+    generate_install_page('xfields', $text);
 }
-?>

--- a/xfields/lib/common.php
+++ b/xfields/lib/common.php
@@ -1,89 +1,107 @@
 <?php
+
 // Global XF variables
 global $XF;
 global $XF_loaded;
-$XF = array();        // $XF - array with configuration
+$XF = [];        // $XF - array with configuration
 $XF_loaded = 0;        // $XF_loaded - flag if config is loaded
 // Load fields definition
-function xf_configLoad() {
+function xf_configLoad()
+{
+    global $lang, $XF, $XF_loaded;
+    if ($XF_loaded) {
+        return $XF;
+    }
+    if (!($confdir = get_plugcfg_dir('xfields'))) {
+        return false;
+    }
+    if (!file_exists($confdir.'/config.php')) {
+        $XF_loaded = 1;
 
-	global $lang, $XF, $XF_loaded;
-	if ($XF_loaded) return $XF;
-	if (!($confdir = get_plugcfg_dir('xfields'))) return false;
-	if (!file_exists($confdir . '/config.php')) {
-		$XF_loaded = 1;
+        return ['news' => []];
+    }
+    include $confdir.'/config.php';
+    $XF_loaded = 1;
+    $XF = is_array($xarray) ? $xarray : ['news' => []];
 
-		return array('news' => array());
-	}
-	include $confdir . '/config.php';
-	$XF_loaded = 1;
-	$XF = is_array($xarray) ? $xarray : array('news' => array());
-
-	return $XF;
+    return $XF;
 }
 
 // Save fields definition
-function xf_configSave($xf = null) {
+function xf_configSave($xf = null)
+{
+    global $lang, $XF, $XF_loaded;
+    if (!$XF_loaded) {
+        return false;
+    }
+    if (!($confdir = get_plugcfg_dir('xfields'))) {
+        return false;
+    }
+    // Open config
+    if (!($fn = fopen($confdir.'/config.php', 'w'))) {
+        return false;
+    }
+    // Write config
+    fwrite($fn, "<?php\n\$xarray = ".var_export(is_array($xf) ? $xf : $XF, true).";\n");
+    fclose($fn);
 
-	global $lang, $XF, $XF_loaded;
-	if (!$XF_loaded) return false;
-	if (!($confdir = get_plugcfg_dir('xfields'))) return false;
-	// Open config
-	if (!($fn = fopen($confdir . '/config.php', 'w'))) return false;
-	// Write config
-	fwrite($fn, "<?php\n\$xarray = " . var_export(is_array($xf) ? $xf : $XF, true) . ";\n");
-	fclose($fn);
-
-	return true;
+    return true;
 }
 
 // Decode fields from text
-function xf_decode($text) {
+function xf_decode($text)
+{
+    if ($text == '') {
+        return [];
+    }
+    // MODERN METHOD
+    if (substr($text, 0, 4) == 'SER|') {
+        return unserialize(substr($text, 4));
+    }
+    // OLD METHOD. OBSOLETE but supported for reading
+    $xfieldsdata = explode('||', $text);
+    foreach ($xfieldsdata as $xfielddata) {
+        list($xfielddataname, $xfielddatavalue) = explode('|', $xfielddata);
+        $xfielddataname = str_replace('&#124;', '|', $xfielddataname);
+        $xfielddataname = str_replace('__NEWL__', "\r\n", $xfielddataname);
+        $xfielddatavalue = str_replace('&#124;', '|', $xfielddatavalue);
+        $xfielddatavalue = str_replace('__NEWL__', "\r\n", $xfielddatavalue);
+        $data[$xfielddataname] = $xfielddatavalue;
+    }
 
-	if ($text == '') return array();
-	// MODERN METHOD
-	if (substr($text, 0, 4) == "SER|") return unserialize(substr($text, 4));
-	// OLD METHOD. OBSOLETE but supported for reading
-	$xfieldsdata = explode("||", $text);
-	foreach ($xfieldsdata as $xfielddata) {
-		list($xfielddataname, $xfielddatavalue) = explode("|", $xfielddata);
-		$xfielddataname = str_replace("&#124;", "|", $xfielddataname);
-		$xfielddataname = str_replace("__NEWL__", "\r\n", $xfielddataname);
-		$xfielddatavalue = str_replace("&#124;", "|", $xfielddatavalue);
-		$xfielddatavalue = str_replace("__NEWL__", "\r\n", $xfielddatavalue);
-		$data[$xfielddataname] = $xfielddatavalue;
-	}
-
-	return $data;
+    return $data;
 }
 
 // Encode fields into text
-function xf_encode($fields) {
+function xf_encode($fields)
+{
+    if (!is_array($fields)) {
+        return '';
+    }
 
-	if (!is_array($fields)) return '';
-
-	return 'SER|' . serialize($fields);
+    return 'SER|'.serialize($fields);
 }
 
-function xf_getTableBySectionID($sectionID) {
+function xf_getTableBySectionID($sectionID)
+{
+    switch ($sectionID) {
+        case 'news':
+            return prefix.'_news';
+        case 'users':
+            return prefix.'_users';
+        case 'tdata':
+            return prefix.'_xfields';
+    }
 
-	switch ($sectionID) {
-		case 'news':
-			return prefix . '_news';
-		case 'users':
-			return prefix . '_users';
-		case 'tdata':
-			return prefix . '_xfields';
-	}
-
-	return false;
+    return false;
 }
 
 //
 // Class for managing xfields data processing
-class XFieldsFilter {
-
-	//
-	function showTableEntry($newsID, $SQLnews, $rowData, &$rowVars) {
-	}
+class XFieldsFilter
+{
+    //
+    public function showTableEntry($newsID, $SQLnews, $rowData, &$rowVars)
+    {
+    }
 }

--- a/xfields/lib/libadmin.php
+++ b/xfields/lib/libadmin.php
@@ -1,50 +1,50 @@
 <?php
 
-class XFieldsFilterAdminCategories extends FilterAdminCategories {
+class XFieldsFilterAdminCategories extends FilterAdminCategories
+{
+    public function addCategory(&$tvars, &$SQL)
+    {
+        $SQL['allow_com'] = intval($_REQUEST['allow_com']);
 
-	function addCategory(&$tvars, &$SQL) {
+        return 1;
+    }
 
-		$SQL['allow_com'] = intval($_REQUEST['allow_com']);
+    public function addCategoryForm(&$tvars)
+    {
+        global $lang;
+        loadPluginLang('comments', 'config', '', '', ':');
+        $allowCom = pluginGetVariable('comments', 'default_categories');
+        $ms = '<select name="allow_com">';
+        $cv = ['0' => 'запретить', '1' => 'разрешить', '2' => 'по умолчанию'];
+        for ($i = 0; $i < 3; $i++) {
+            $ms .= '<option value="'.$i.'"'.(($allowCom == $i) ? ' selected="selected"' : '').'>'.$cv[$i].'</option>';
+        }
+        $tvars['vars']['extend'] .= '<tr><td width="70%" class="contentEntry1">'.$lang['comments:categories.comments'].'<br/><small>'.$lang['comments:categories.comments#desc'].'</small></td><td width="30%" class="contentEntry2">'.$ms.'</td></tr>';
 
-		return 1;
-	}
+        return 1;
+    }
 
-	function addCategoryForm(&$tvars) {
+    public function editCategoryForm($categoryID, $SQL, &$tvars)
+    {
+        global $lang;
+        loadPluginLang('comments', 'config', '', '', ':');
+        if (!isset($SQL['allow_com'])) {
+            $SQL['allow_com'] = pluginGetVariable('comments', 'default_categories');
+        }
+        $ms = '<select name="allow_com">';
+        $cv = ['0' => 'запретить', '1' => 'разрешить', '2' => 'по умолчанию'];
+        for ($i = 0; $i < 3; $i++) {
+            $ms .= '<option value="'.$i.'"'.(($SQL['allow_com'] == $i) ? ' selected="selected"' : '').'>'.$cv[$i].'</option>';
+        }
+        $tvars['vars']['extend'] .= '<tr><td width="70%" class="contentEntry1">'.$lang['comments:categories.comments'].'<br/><small>'.$lang['comments:categories.comments#desc'].'</small></td><td width="30%" class="contentEntry2">'.$ms.'</td></tr>';
 
-		global $lang;
-		loadPluginLang('comments', 'config', '', '', ':');
-		$allowCom = pluginGetVariable('comments', 'default_categories');
-		$ms = '<select name="allow_com">';
-		$cv = array('0' => 'запретить', '1' => 'разрешить', '2' => 'по умолчанию');
-		for ($i = 0; $i < 3; $i++) {
-			$ms .= '<option value="' . $i . '"' . (($allowCom == $i) ? ' selected="selected"' : '') . '>' . $cv[$i] . '</option>';
-		}
-		$tvars['vars']['extend'] .= '<tr><td width="70%" class="contentEntry1">' . $lang['comments:categories.comments'] . '<br/><small>' . $lang['comments:categories.comments#desc'] . '</small></td><td width="30%" class="contentEntry2">' . $ms . '</td></tr>';
+        return 1;
+    }
 
-		return 1;
-	}
+    public function editCategory($categoryID, $SQL, &$SQLnew, &$tvars)
+    {
+        $SQLnew['allow_com'] = intval($_REQUEST['allow_com']);
 
-	function editCategoryForm($categoryID, $SQL, &$tvars) {
-
-		global $lang;
-		loadPluginLang('comments', 'config', '', '', ':');
-		if (!isset($SQL['allow_com'])) {
-			$SQL['allow_com'] = pluginGetVariable('comments', 'default_categories');
-		}
-		$ms = '<select name="allow_com">';
-		$cv = array('0' => 'запретить', '1' => 'разрешить', '2' => 'по умолчанию');
-		for ($i = 0; $i < 3; $i++) {
-			$ms .= '<option value="' . $i . '"' . (($SQL['allow_com'] == $i) ? ' selected="selected"' : '') . '>' . $cv[$i] . '</option>';
-		}
-		$tvars['vars']['extend'] .= '<tr><td width="70%" class="contentEntry1">' . $lang['comments:categories.comments'] . '<br/><small>' . $lang['comments:categories.comments#desc'] . '</small></td><td width="30%" class="contentEntry2">' . $ms . '</td></tr>';
-
-		return 1;
-	}
-
-	function editCategory($categoryID, $SQL, &$SQLnew, &$tvars) {
-
-		$SQLnew['allow_com'] = intval($_REQUEST['allow_com']);
-
-		return 1;
-	}
+        return 1;
+    }
 }

--- a/xfields/lib/librpc.php
+++ b/xfields/lib/librpc.php
@@ -1,125 +1,125 @@
 <?php
+
 //
 // XFields configuration manipulations
 //
-function xfields_rpc_group_modify($params) {
+function xfields_rpc_group_modify($params)
+{
+    global $userROW;
+    include_once root.'plugins/xfields/xfields.php';
+    if (!is_array($xf = xf_configLoad())) {
+        $xf = [];
+    }
+    if (!is_array($userROW) || ($userROW['status'] != 1)) {
+        return ['status' => 0, 'errorCode' => 1, 'errorText' => 'Security error'];
+    }
+    if (!is_array($params) || !isset($params['action'])) {
+        return ['status' => 0, 'errorCode' => 2, 'errorText' => 'Activity mode is not set'];
+    }
+    $params = arrayCharsetConvert(1, $params);
+    switch ($params['action']) {
+        case 'grpAdd':
+            $grpId = $params['id'];
+            $grpName = $params['name'];
+            // Check for correct name
+            if (!preg_match('#^[a-zA-Z0-9]{2,10}$#', $grpId, $null)) {
+                return ['status' => 0, 'errorCode' => 3, 'errorText' => 'Wrong GroupID, id should contain only from [a-z, 0-9] and length between 2-10 chars'];
+            }
+            // Check for duplicates
+            if (isset($xf['grp.news'][$grpId])) {
+                return ['status' => 0, 'errorCode' => 4, 'errorText' => 'Duplicated group ID'];
+            }
+            // Create group
+            $xf['grp.news'][$grpId] = ['title' => $grpName, 'entries' => []];
+            xf_configSave($xf);
 
-	global $userROW;
-	include_once root . 'plugins/xfields/xfields.php';
-	if (!is_array($xf = xf_configLoad()))
-		$xf = array();
-	if (!is_array($userROW) || ($userROW['status'] != 1)) {
-		return array('status' => 0, 'errorCode' => 1, 'errorText' => 'Security error');
-	}
-	if (!is_array($params) || !isset($params['action']))
-		return array('status' => 0, 'errorCode' => 2, 'errorText' => 'Activity mode is not set');
-	$params = arrayCharsetConvert(1, $params);
-	switch ($params['action']) {
-		case 'grpAdd':
-			$grpId = $params['id'];
-			$grpName = $params['name'];
-			// Check for correct name
-			if (!preg_match('#^[a-zA-Z0-9]{2,10}$#', $grpId, $null)) {
-				return array('status' => 0, 'errorCode' => 3, 'errorText' => 'Wrong GroupID, id should contain only from [a-z, 0-9] and length between 2-10 chars');
-			}
-			// Check for duplicates
-			if (isset($xf['grp.news'][$grpId])) {
-				return array('status' => 0, 'errorCode' => 4, 'errorText' => 'Duplicated group ID');
-			}
-			// Create group
-			$xf['grp.news'][$grpId] = array('title' => $grpName, 'entries' => array());
-			xf_configSave($xf);
+            // Notify about changes
+            return ['status' => 1, 'errorCode' => 0, 'data' => 'New group was created', 'config' => arrayCharsetConvert(0, $xf['grp.news'])];
+        case 'grpEdit':
+            $grpId = $params['id'];
+            $grpName = $params['name'];
+            // Check if group exists
+            if (!isset($xf['grp.news'][$grpId])) {
+                return ['status' => 0, 'errorCode' => 5, 'errorText' => 'Requested group does not exist'];
+            }
+            // Modify group
+            $xf['grp.news'][$grpId]['title'] = $grpName;
+            xf_configSave($xf);
 
-			// Notify about changes
-			return array('status' => 1, 'errorCode' => 0, 'data' => 'New group was created', 'config' => arrayCharsetConvert(0, $xf['grp.news']));
-		case 'grpEdit':
-			$grpId = $params['id'];
-			$grpName = $params['name'];
-			// Check if group exists
-			if (!isset($xf['grp.news'][$grpId])) {
-				return array('status' => 0, 'errorCode' => 5, 'errorText' => 'Requested group does not exist');
-			}
-			// Modify group
-			$xf['grp.news'][$grpId]['title'] = $grpName;
-			xf_configSave($xf);
+            // Notify about changes
+            return ['status' => 1, 'errorCode' => 0, 'data' => 'Group was changed', 'config' => arrayCharsetConvert(0, $xf['grp.news'])];
+        case 'grpDel':
+            $grpId = $params['id'];
+            // Check if group exists
+            if (!isset($xf['grp.news'][$grpId])) {
+                return ['status' => 0, 'errorCode' => 5, 'errorText' => 'Requested group does not exist'];
+            }
+            unset($xf['grp.news'][$grpId]);
+            xf_configSave($xf);
 
-			// Notify about changes
-			return array('status' => 1, 'errorCode' => 0, 'data' => 'Group was changed', 'config' => arrayCharsetConvert(0, $xf['grp.news']));
-		case 'grpDel':
-			$grpId = $params['id'];
-			// Check if group exists
-			if (!isset($xf['grp.news'][$grpId])) {
-				return array('status' => 0, 'errorCode' => 5, 'errorText' => 'Requested group does not exist');
-			}
-			unset($xf['grp.news'][$grpId]);
-			xf_configSave($xf);
+            // Notify about changes
+            return ['status' => 1, 'errorCode' => 0, 'data' => 'Group was deleted', 'config' => arrayCharsetConvert(0, $xf['grp.news'])];
+        case 'fldAdd':
+            $grpId = $params['id'];
+            $fldId = $params['field'];
+            // Check if group exists
+            if (!isset($xf['grp.news'][$grpId])) {
+                return ['status' => 0, 'errorCode' => 5, 'errorText' => 'Requested group does not exist'];
+            }
+            // Check if field already exists
+            if (array_search($fldId, $xf['grp.news'][$grpId]['entries']) !== false) {
+                return ['status' => 0, 'errorCode' => 6, 'errorText' => 'Field already is a member of the group'];
+            }
+            // Check if field exists
+            if (!isset($xf['news'][$fldId])) {
+                return ['status' => 0, 'errorCode' => 7, 'errorText' => 'Field does not exists'];
+            }
+            array_push($xf['grp.news'][$grpId]['entries'], $fldId);
+            xf_configSave($xf);
 
-			// Notify about changes
-			return array('status' => 1, 'errorCode' => 0, 'data' => 'Group was deleted', 'config' => arrayCharsetConvert(0, $xf['grp.news']));
-		case 'fldAdd':
-			$grpId = $params['id'];
-			$fldId = $params['field'];
-			// Check if group exists
-			if (!isset($xf['grp.news'][$grpId])) {
-				return array('status' => 0, 'errorCode' => 5, 'errorText' => 'Requested group does not exist');
-			}
-			// Check if field already exists
-			if (array_search($fldId, $xf['grp.news'][$grpId]['entries']) !== false) {
-				return array('status' => 0, 'errorCode' => 6, 'errorText' => 'Field already is a member of the group');
-			}
-			// Check if field exists
-			if (!isset($xf['news'][$fldId])) {
-				return array('status' => 0, 'errorCode' => 7, 'errorText' => 'Field does not exists');
-			}
-			array_push($xf['grp.news'][$grpId]['entries'], $fldId);
-			xf_configSave($xf);
+            // Notify about changes
+            return ['status' => 1, 'errorCode' => 0, 'data' => 'Field was added into group', 'config' => arrayCharsetConvert(0, $xf['grp.news'])];
+        case 'fldDel':
+        case 'fldUp':
+        case 'fldDown':
+            $grpId = $params['id'];
+            $fldId = $params['field'];
+            if (!isset($xf['grp.news'][$grpId])) {
+                return ['status' => 0, 'errorCode' => 5, 'errorText' => 'Requested group does not exist'];
+            }
+            // Check if field already exists
+            if (array_search($fldId, $xf['grp.news'][$grpId]['entries']) === false) {
+                return ['status' => 0, 'errorCode' => 8, 'errorText' => 'Field is not a member of the group'];
+            }
+            $position = array_search($fldId, $xf['grp.news'][$grpId]['entries']);
+            // Decide an action
+            if ($params['action'] == 'fldDel') {
+                unset($xf['grp.news'][$grpId]['entries'][$position]);
+            }
+            if (($params['action'] == 'fldUp') && ($position > 0)) {
+                $tmp = $xf['grp.news'][$grpId]['entries'][$position - 1];
+                $xf['grp.news'][$grpId]['entries'][$position - 1] = $xf['grp.news'][$grpId]['entries'][$position];
+                $xf['grp.news'][$grpId]['entries'][$position] = $tmp;
+            }
+            if (($params['action'] == 'fldDown') && (($position + 1) < count($xf['grp.news'][$grpId]['entries']))) {
+                $tmp = $xf['grp.news'][$grpId]['entries'][$position + 1];
+                $xf['grp.news'][$grpId]['entries'][$position + 1] = $xf['grp.news'][$grpId]['entries'][$position];
+                $xf['grp.news'][$grpId]['entries'][$position] = $tmp;
+            }
+            $xf['grp.news'][$grpId]['entries'] = array_values($xf['grp.news'][$grpId]['entries']);
+            xf_configSave($xf);
 
-			// Notify about changes
-			return array('status' => 1, 'errorCode' => 0, 'data' => 'Field was added into group', 'config' => arrayCharsetConvert(0, $xf['grp.news']));
-		case 'fldDel':
-		case 'fldUp':
-		case 'fldDown':
-			$grpId = $params['id'];
-			$fldId = $params['field'];
-			if (!isset($xf['grp.news'][$grpId])) {
-				return array('status' => 0, 'errorCode' => 5, 'errorText' => 'Requested group does not exist');
-			}
-			// Check if field already exists
-			if (array_search($fldId, $xf['grp.news'][$grpId]['entries']) === false) {
-				return array('status' => 0, 'errorCode' => 8, 'errorText' => 'Field is not a member of the group');
-			}
-			$position = array_search($fldId, $xf['grp.news'][$grpId]['entries']);
-			// Decide an action
-			if ($params['action'] == 'fldDel') {
-				unset($xf['grp.news'][$grpId]['entries'][$position]);
-			}
-			if (($params['action'] == 'fldUp') && ($position > 0)) {
-				$tmp = $xf['grp.news'][$grpId]['entries'][$position - 1];
-				$xf['grp.news'][$grpId]['entries'][$position - 1] = $xf['grp.news'][$grpId]['entries'][$position];
-				$xf['grp.news'][$grpId]['entries'][$position] = $tmp;
-			}
-			if (($params['action'] == 'fldDown') && (($position + 1) < count($xf['grp.news'][$grpId]['entries']))) {
-				$tmp = $xf['grp.news'][$grpId]['entries'][$position + 1];
-				$xf['grp.news'][$grpId]['entries'][$position + 1] = $xf['grp.news'][$grpId]['entries'][$position];
-				$xf['grp.news'][$grpId]['entries'][$position] = $tmp;
-			}
-			$xf['grp.news'][$grpId]['entries'] = array_values($xf['grp.news'][$grpId]['entries']);
-			xf_configSave($xf);
+            // Notify about changes
+            return ['status' => 1, 'errorCode' => 0, 'data' => 'Field was deleted/moved up/moved down', 'config' => arrayCharsetConvert(0, $xf['grp.news'])];
+    }
 
-			// Notify about changes
-			return array('status' => 1, 'errorCode' => 0, 'data' => 'Field was deleted/moved up/moved down', 'config' => arrayCharsetConvert(0, $xf['grp.news']));
-	}
-
-	return array('status' => 1, 'errorCode' => 0, 'data' => 'OK, ' . var_export($params, true));
+    return ['status' => 1, 'errorCode' => 0, 'data' => 'OK, '.var_export($params, true)];
 }
 
-function xfields_rpc_demo($params) {
-
-	return array('status' => 1, 'errorCode' => 0, 'data' => var_export($params, true));
+function xfields_rpc_demo($params)
+{
+    return ['status' => 1, 'errorCode' => 0, 'data' => var_export($params, true)];
 }
 
 rpcRegisterFunction('plugin.xfields.demo', 'xfields_rpc_demo');
 rpcRegisterFunction('plugin.xfields.group.modify', 'xfields_rpc_group_modify');
-
-
-

--- a/xfields/uninstall.php
+++ b/xfields/uninstall.php
@@ -1,41 +1,43 @@
 <?php
+
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 //
 // Configuration file for plugin
 //
 plugins_load_config();
 LoadPluginLang('xfields', 'config');
-$db_update = array(
-	array(
-		'table'  => 'news',
-		'action' => 'modify',
-		'fields' => array(
-			array('action' => 'drop', 'name' => 'xfields', 'type' => 'text'),
-		)
-	),
-	array(
-		'table'  => 'category',
-		'action' => 'modify',
-		'fields' => array(
-			array('action' => 'drop', 'name' => 'xf_group', 'type' => 'text'),
-		)
-	),
-	array(
-		'table'  => 'users',
-		'action' => 'modify',
-		'fields' => array(
-			array('action' => 'drop', 'name' => 'xfields', 'type' => 'text'),
-		)
-	)
-);
+$db_update = [
+    [
+        'table'  => 'news',
+        'action' => 'modify',
+        'fields' => [
+            ['action' => 'drop', 'name' => 'xfields', 'type' => 'text'],
+        ],
+    ],
+    [
+        'table'  => 'category',
+        'action' => 'modify',
+        'fields' => [
+            ['action' => 'drop', 'name' => 'xf_group', 'type' => 'text'],
+        ],
+    ],
+    [
+        'table'  => 'users',
+        'action' => 'modify',
+        'fields' => [
+            ['action' => 'drop', 'name' => 'xfields', 'type' => 'text'],
+        ],
+    ],
+];
 if ($_REQUEST['action'] == 'commit') {
-	// If submit requested, do config save
-	if (fixdb_plugin_install('xfields', $db_update, 'deinstall')) {
-		plugin_mark_deinstalled('xfields');
-	}
+    // If submit requested, do config save
+    if (fixdb_plugin_install('xfields', $db_update, 'deinstall')) {
+        plugin_mark_deinstalled('xfields');
+    }
 } else {
-	$text = $lang['xfields_desc_uninstall'];
-	generate_install_page('xfields', $text, 'deinstall');
+    $text = $lang['xfields_desc_uninstall'];
+    generate_install_page('xfields', $text, 'deinstall');
 }
-?>

--- a/xfields/xfields.php
+++ b/xfields/xfields.php
@@ -1,1398 +1,1464 @@
 <?php
+
 // #==========================================================#
 // # Plugin name: xfields [ Additional fields managment ]     #
 // # Author: Vitaly A Ponomarev, vp7@mail.ru                  #
 // # Allowed to use only with: Next Generation CMS            #
 // #==========================================================#
 // Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 // Load lang files
 LoadPluginLang('xfields', 'config');
 LoadPluginLibrary('xfields', 'common');
 //
 // XFields: Add/Modify attached files
-function xf_modifyAttachedImages($dsID, $newsID, $xf, $attachList) {
-
-	global $mysql, $config, $DSlist;
-	//print "<pre>".var_export($_REQUEST, true)."</pre>";
-	// Init file/image processing libraries
-	$fmanager = new file_managment();
-	$imanager = new image_managment();
-	// Select xf group name
-	$xfGroupName = '';
-	foreach (array('news', 'users') as $k) {
-		if ($DSlist[$k] == $dsID) {
-			$xfGroupName = $k;
-			break;
-		}
-	}
-	if (!$xfGroupName) {
-		return false;
-	}
-	// Scan if user want to change description
-	foreach ($attachList as $iRec) {
-		//print "[A:".$iRec['id']."]";
-		if (isset($_REQUEST['xfields_' . $iRec['pidentity'] . '_dscr']) && is_array($_REQUEST['xfields_' . $iRec['pidentity'] . '_dscr']) && isset($_REQUEST['xfields_' . $iRec['pidentity'] . '_dscr'][$iRec['id']])) {
-			// We have this field in EDIT mode
-			if ($_REQUEST['xfields_' . $iRec['pidentity'] . '_dscr'][$iRec['id']] != $iRec['decsription']) {
-				$mysql->query("update " . prefix . "_images set description = " . db_squote($_REQUEST['xfields_' . $iRec['pidentity'] . '_dscr'][$iRec['id']]) . " where id = " . intval($iRec['id']));
-			}
-		}
-	}
-	$xdata = array();
-	foreach ($xf[$xfGroupName] as $id => $data) {
-		// Attached images are processed in special way
-		if ($data['type'] == 'images') {
-			// Check if we should delete some images
-			if (isset($_POST['xfields_' . $id . '_del']) && is_array($_POST['xfields_' . $id . '_del'])) {
-				foreach ($_POST['xfields_' . $id . '_del'] as $key => $value) {
-					// Allow to delete only images, that are attached to current news
-					if ($value) {
-						$xf = false;
-						foreach ($attachList as $irow) {
-							if ($irow['id'] == $key) {
-								$xf = true;
-								break;
-							}
-						}
-						if (!$xf)
-							continue;
-						//print "NEED TO DEL [$key]<br/>\n";
-						$fmanager->file_delete(array('type' => 'image', 'id' => $key));
-					}
-				}
-			}
-			// Check for new attached files
-			if (isset($_FILES['xfields_' . $id]) && isset($_FILES['xfields_' . $id]['name']) && is_array($_FILES['xfields_' . $id]['name'])) {
-				foreach ($_FILES['xfields_' . $id]['name'] as $iId => $iName) {
-					if ($_FILES['xfields_' . $id]['error'][$iId] > 0) {
-						//print $iId." >>ERROR: ".$_FILES['xfields_'.$id]['error'][$iId]."<br/>\n";
-						continue;
-					}
-					if ($_FILES['xfields_' . $id]['size'][$iId] == 0) {
-						//print $iId." >>EMPTY IMAGE<br/>\n";
-						continue;
-					}
-					// Check if we try to overcome limits
-					$currCount = $mysql->record("select count(*) as cnt from " . prefix . "_images where (linked_ds = " . intval($dsID) . ") and (linked_id = " . intval($newsID) . ") and (plugin = 'xfields') and (pidentity=" . db_squote($id) . ")");
-					if ($currCount['cnt'] >= $data['maxCount'])
-						continue;
-					// Upload file
-					$up = $fmanager->file_upload(
-						array(
-							'dsn'         => true,
-							'linked_ds'   => $dsID,
-							'linked_id'   => $newsID,
-							'type'        => 'image',
-							'http_var'    => 'xfields_' . $id,
-							'http_varnum' => $iId,
-							'plugin'      => 'xfields',
-							'pidentity'   => $id,
-							'description' => (isset($_REQUEST['xfields_' . $id . '_adscr']) && is_array($_REQUEST['xfields_' . $id . '_adscr']) && isset($_REQUEST['xfields_' . $id . '_adscr'][$iId])) ? ($_REQUEST['xfields_' . $id . '_adscr'][$iId]) : '',
-						)
-					);
-					// Process upload error
-					if (!is_array($up)) {
-						continue;
-					}
-					//print "<pre>CREATED: ".var_export($up, true)."</pre>";
-					// Check if we need to create preview
-					$mkThumb = $data['imgThumb'];
-					$mkStamp = $data['imgStamp'];
-					$mkShadow = $data['imgShadow'];
-					$stampFileName = '';
-					if (file_exists(root . 'trash/' . $config['wm_image'] . '.gif')) {
-						$stampFileName = root . 'trash/' . $config['wm_image'] . '.gif';
-					} else if (file_exists(root . 'trash/' . $config['wm_image'])) {
-						$stampFileName = root . 'trash/' . $config['wm_image'];
-					}
-					if ($mkThumb) {
-						// Calculate sizes
-						$tsx = $data['thumbWidth'];
-						$tsy = $data['thumbHeight'];
-						if ($tsx < 10) {
-							$tsx = 150;
-						}
-						if ($tsy < 10) {
-							$tsy = 150;
-						}
-						$thumb = $imanager->create_thumb($config['attach_dir'] . $up[2], $up[1], $tsx, $tsy, $config['thumb_quality']);
-						//print "<pre>THUMB: ".var_export($thumb, true)."</pre>";
-						if ($thumb) {
-							//print "THUMB_OK<br/>";
-							// If we created thumb - check if we need to transform it
-							$stampThumb = ($data['thumbStamp'] && ($stampFileName != '')) ? 1 : 0;
-							$shadowThumb = $data['thumbShadow'];
-							if ($shadowThumb || $stampThumb) {
-								$stamp = $imanager->image_transform(
-									array(
-										'image'              => $config['attach_dir'] . $up[2] . '/thumb/' . $up[1],
-										'stamp'              => $stampThumb,
-										'stamp_transparency' => $config['wm_image_transition'],
-										'stamp_noerror'      => true,
-										'shadow'             => $shadowThumb,
-										'stampfile'          => $stampFileName
-									)
-								);
-								//print "THUMB [STAMP/SHADOW = (".$stamp.")]<br/>";
-							}
-						}
-					}
-					if ($mkStamp || $mkShadow) {
-						$stamp = $imanager->image_transform(
-							array(
-								'image'              => $config['attach_dir'] . $up[2] . '/' . $up[1],
-								'stamp'              => $mkStamp,
-								'stamp_transparency' => $config['wm_image_transition'],
-								'stamp_noerror'      => true,
-								'shadow'             => $mkShadow,
-								'stampfile'          => $stampFileName
-							)
-						);
-						//print "IMG [STAMP/SHADOW = (".var_export($stamp, true).")]<br/>";
-					}
-					// Now write info about image into DB
-					if (is_array($sz = $imanager->get_size($config['attach_dir'] . $up[2] . '/' . $up[1]))) {
-						$fmanager->get_limits($type);
-						// Gather filesize for thumbinals
-						$thumb_size_x = 0;
-						$thumb_size_y = 0;
-						if (is_array($thumb) && is_readable($config['attach_dir'] . $up[2] . '/thumb/' . $up[1]) && is_array($szt = $imanager->get_size($config['attach_dir'] . $up[2] . '/thumb/' . $up[1]))) {
-							$thumb_size_x = $szt[1];
-							$thumb_size_y = $szt[2];
-						}
-						$mysql->query("update " . prefix . "_" . $fmanager->tname . " set width=" . db_squote($sz[1]) . ", height=" . db_squote($sz[2]) . ", preview=" . db_squote(is_array($thumb) ? 1 : 0) . ", p_width=" . db_squote($thumb_size_x) . ", p_height=" . db_squote($thumb_size_y) . ", stamp=" . db_squote(is_array($stamp) ? 1 : 0) . " where id = " . db_squote($up[0]));
-					}
-				}
-			}
-		}
-	}
+function xf_modifyAttachedImages($dsID, $newsID, $xf, $attachList)
+{
+    global $mysql, $config, $DSlist;
+    //print "<pre>".var_export($_REQUEST, true)."</pre>";
+    // Init file/image processing libraries
+    $fmanager = new file_managment();
+    $imanager = new image_managment();
+    // Select xf group name
+    $xfGroupName = '';
+    foreach (['news', 'users'] as $k) {
+        if ($DSlist[$k] == $dsID) {
+            $xfGroupName = $k;
+            break;
+        }
+    }
+    if (!$xfGroupName) {
+        return false;
+    }
+    // Scan if user want to change description
+    foreach ($attachList as $iRec) {
+        //print "[A:".$iRec['id']."]";
+        if (isset($_REQUEST['xfields_'.$iRec['pidentity'].'_dscr']) && is_array($_REQUEST['xfields_'.$iRec['pidentity'].'_dscr']) && isset($_REQUEST['xfields_'.$iRec['pidentity'].'_dscr'][$iRec['id']])) {
+            // We have this field in EDIT mode
+            if ($_REQUEST['xfields_'.$iRec['pidentity'].'_dscr'][$iRec['id']] != $iRec['decsription']) {
+                $mysql->query('update '.prefix.'_images set description = '.db_squote($_REQUEST['xfields_'.$iRec['pidentity'].'_dscr'][$iRec['id']]).' where id = '.intval($iRec['id']));
+            }
+        }
+    }
+    $xdata = [];
+    foreach ($xf[$xfGroupName] as $id => $data) {
+        // Attached images are processed in special way
+        if ($data['type'] == 'images') {
+            // Check if we should delete some images
+            if (isset($_POST['xfields_'.$id.'_del']) && is_array($_POST['xfields_'.$id.'_del'])) {
+                foreach ($_POST['xfields_'.$id.'_del'] as $key => $value) {
+                    // Allow to delete only images, that are attached to current news
+                    if ($value) {
+                        $xf = false;
+                        foreach ($attachList as $irow) {
+                            if ($irow['id'] == $key) {
+                                $xf = true;
+                                break;
+                            }
+                        }
+                        if (!$xf) {
+                            continue;
+                        }
+                        //print "NEED TO DEL [$key]<br/>\n";
+                        $fmanager->file_delete(['type' => 'image', 'id' => $key]);
+                    }
+                }
+            }
+            // Check for new attached files
+            if (isset($_FILES['xfields_'.$id]) && isset($_FILES['xfields_'.$id]['name']) && is_array($_FILES['xfields_'.$id]['name'])) {
+                foreach ($_FILES['xfields_'.$id]['name'] as $iId => $iName) {
+                    if ($_FILES['xfields_'.$id]['error'][$iId] > 0) {
+                        //print $iId." >>ERROR: ".$_FILES['xfields_'.$id]['error'][$iId]."<br/>\n";
+                        continue;
+                    }
+                    if ($_FILES['xfields_'.$id]['size'][$iId] == 0) {
+                        //print $iId." >>EMPTY IMAGE<br/>\n";
+                        continue;
+                    }
+                    // Check if we try to overcome limits
+                    $currCount = $mysql->record('select count(*) as cnt from '.prefix.'_images where (linked_ds = '.intval($dsID).') and (linked_id = '.intval($newsID).") and (plugin = 'xfields') and (pidentity=".db_squote($id).')');
+                    if ($currCount['cnt'] >= $data['maxCount']) {
+                        continue;
+                    }
+                    // Upload file
+                    $up = $fmanager->file_upload(
+                        [
+                            'dsn'         => true,
+                            'linked_ds'   => $dsID,
+                            'linked_id'   => $newsID,
+                            'type'        => 'image',
+                            'http_var'    => 'xfields_'.$id,
+                            'http_varnum' => $iId,
+                            'plugin'      => 'xfields',
+                            'pidentity'   => $id,
+                            'description' => (isset($_REQUEST['xfields_'.$id.'_adscr']) && is_array($_REQUEST['xfields_'.$id.'_adscr']) && isset($_REQUEST['xfields_'.$id.'_adscr'][$iId])) ? ($_REQUEST['xfields_'.$id.'_adscr'][$iId]) : '',
+                        ]
+                    );
+                    // Process upload error
+                    if (!is_array($up)) {
+                        continue;
+                    }
+                    //print "<pre>CREATED: ".var_export($up, true)."</pre>";
+                    // Check if we need to create preview
+                    $mkThumb = $data['imgThumb'];
+                    $mkStamp = $data['imgStamp'];
+                    $mkShadow = $data['imgShadow'];
+                    $stampFileName = '';
+                    if (file_exists(root.'trash/'.$config['wm_image'].'.gif')) {
+                        $stampFileName = root.'trash/'.$config['wm_image'].'.gif';
+                    } elseif (file_exists(root.'trash/'.$config['wm_image'])) {
+                        $stampFileName = root.'trash/'.$config['wm_image'];
+                    }
+                    if ($mkThumb) {
+                        // Calculate sizes
+                        $tsx = $data['thumbWidth'];
+                        $tsy = $data['thumbHeight'];
+                        if ($tsx < 10) {
+                            $tsx = 150;
+                        }
+                        if ($tsy < 10) {
+                            $tsy = 150;
+                        }
+                        $thumb = $imanager->create_thumb($config['attach_dir'].$up[2], $up[1], $tsx, $tsy, $config['thumb_quality']);
+                        //print "<pre>THUMB: ".var_export($thumb, true)."</pre>";
+                        if ($thumb) {
+                            //print "THUMB_OK<br/>";
+                            // If we created thumb - check if we need to transform it
+                            $stampThumb = ($data['thumbStamp'] && ($stampFileName != '')) ? 1 : 0;
+                            $shadowThumb = $data['thumbShadow'];
+                            if ($shadowThumb || $stampThumb) {
+                                $stamp = $imanager->image_transform(
+                                    [
+                                        'image'              => $config['attach_dir'].$up[2].'/thumb/'.$up[1],
+                                        'stamp'              => $stampThumb,
+                                        'stamp_transparency' => $config['wm_image_transition'],
+                                        'stamp_noerror'      => true,
+                                        'shadow'             => $shadowThumb,
+                                        'stampfile'          => $stampFileName,
+                                    ]
+                                );
+                                //print "THUMB [STAMP/SHADOW = (".$stamp.")]<br/>";
+                            }
+                        }
+                    }
+                    if ($mkStamp || $mkShadow) {
+                        $stamp = $imanager->image_transform(
+                            [
+                                'image'              => $config['attach_dir'].$up[2].'/'.$up[1],
+                                'stamp'              => $mkStamp,
+                                'stamp_transparency' => $config['wm_image_transition'],
+                                'stamp_noerror'      => true,
+                                'shadow'             => $mkShadow,
+                                'stampfile'          => $stampFileName,
+                            ]
+                        );
+                        //print "IMG [STAMP/SHADOW = (".var_export($stamp, true).")]<br/>";
+                    }
+                    // Now write info about image into DB
+                    if (is_array($sz = $imanager->get_size($config['attach_dir'].$up[2].'/'.$up[1]))) {
+                        $fmanager->get_limits($type);
+                        // Gather filesize for thumbinals
+                        $thumb_size_x = 0;
+                        $thumb_size_y = 0;
+                        if (is_array($thumb) && is_readable($config['attach_dir'].$up[2].'/thumb/'.$up[1]) && is_array($szt = $imanager->get_size($config['attach_dir'].$up[2].'/thumb/'.$up[1]))) {
+                            $thumb_size_x = $szt[1];
+                            $thumb_size_y = $szt[2];
+                        }
+                        $mysql->query('update '.prefix.'_'.$fmanager->tname.' set width='.db_squote($sz[1]).', height='.db_squote($sz[2]).', preview='.db_squote(is_array($thumb) ? 1 : 0).', p_width='.db_squote($thumb_size_x).', p_height='.db_squote($thumb_size_y).', stamp='.db_squote(is_array($stamp) ? 1 : 0).' where id = '.db_squote($up[0]));
+                    }
+                }
+            }
+        }
+    }
 }
 
 // Perform replacements while showing news
-class XFieldsNewsFilter extends NewsFilter {
+class XFieldsNewsFilter extends NewsFilter
+{
+    public function addNewsForm(&$tvars)
+    {
+        global $lang, $twig, $catz;
+        // Load config
+        $xf = xf_configLoad();
+        if (!is_array($xf)) {
+            return false;
+        }
+        $output = '';
+        $xfEntries = [];
+        $xfList = [];
+        if (is_array($xf['news'])) {
+            foreach ($xf['news'] as $id => $data) {
+                if ($data['disabled']) {
+                    continue;
+                }
+                $xfEntry = [
+                    'title'        => $data['title'],
+                    'id'           => $id,
+                    'value'        => $xdata[$id],
+                    'secure_value' => secure_html($xdata[$id]),
+                    'data'         => $data,
+                    'required'     => $lang['xfields_fld_'.($data['required'] ? 'required' : 'optional')],
+                    'flags'        => [
+                        'required' => $data['required'] ? true : false,
+                    ],
+                ];
+                switch ($data['type']) {
+                    case 'checkbox':
+                        $val = '<input type="checkbox" id="form_xfields_'.$id.'" name="xfields['.$id.']" title="'.$data['title'].'" value="1" '.($data['default'] ? 'checked="checked"' : '').'"/>';
+                        $xfEntry['input'] = $val;
+                        break;
+                    case 'text':
+                        $val = '<input type="text" id="form_xfields_'.$id.'" name="xfields['.$id.']" title="'.$data['title'].'" value="'.secure_html($data['default']).'"/>';
+                        $xfEntry['input'] = $val;
+                        break;
+                    case 'select':
+                        $val = '<select name="xfields['.$id.']" id="form_xfields_'.$id.'" >';
+                        if (!$data['required']) {
+                            $val .= '<option value=""></option>';
+                        }
+                        if (is_array($data['options'])) {
+                            foreach ($data['options'] as $k => $v) {
+                                $val .= '<option value="'.secure_html(($data['storekeys']) ? $k : $v).'"'.((($data['storekeys'] && $data['default'] == $k) || (!$data['storekeys'] && $data['default'] == $v)) ? ' selected' : '').'>'.$v.'</option>';
+                            }
+                        }
+                        $val .= '</select>';
+                        $xfEntry['input'] = $val;
+                        break;
+                    case 'multiselect':
+                        $val = '<select name="xfields['.$id.'][]" id="form_xfields_'.$id.'" multiple="multiple">';
+                        if (!$data['required']) {
+                            $val .= '<option value=""></option>';
+                        }
+                        if (is_array($data['options'])) {
+                            foreach ($data['options'] as $k => $v) {
+                                $val .= '<option value="'.secure_html(($data['storekeys']) ? $k : $v).'"'.((($data['storekeys'] && $data['default'] == $k) || (!$data['storekeys'] && $data['default'] == $v)) ? ' selected' : '').'>'.$v.'</option>';
+                            }
+                        }
+                        $val .= '</select>';
+                        $xfEntry['input'] = $val;
+                        break;
+                    case 'textarea':
+                        $val = '<textarea cols="30" rows="5" name="xfields['.$id.']" id="form_xfields_'.$id.'" >'.$data['default'].'</textarea>';
+                        $xfEntry['input'] = $val;
+                        break;
+                    case 'images':
+                        $iCount = 0;
+                        $input = '';
+                        $tVars = ['images' => []];
+                        // Show entries for allowed number of attaches
+                        for ($i = $iCount + 1; $i <= intval($data['maxCount']); $i++) {
+                            $tImage = [
+                                'number' => $i,
+                                'id'     => $id,
+                                'flags'  => [
+                                    'exist' => false,
+                                ],
+                            ];
+                            $tVars['images'][] = $tImage;
+                        }
+                        // Make template
+                        $xt = $twig->loadTemplate('plugins/xfields/tpl/ed_entry.image.tpl');
+                        $val = $xt->render($tVars);
+                        $xfEntry['input'] = $val;
+                        break;
+                    default:
+                        continue;
+                }
+                $xfEntries[intval($data['area'])][] = $xfEntry;
+                $xfList[$id] = $xfEntry;
+            }
+        }
+        $xfCategories = [];
+        foreach ($catz as $cId => $cData) {
+            $xfCategories[$cData['id']] = $cData['xf_group'];
+        }
+        // Prepare table data [if needed]
+        $flagTData = false;
+        if (isset($xf['tdata']) && is_array($xf['tdata'])) {
+            // Data are not provisioned
+            $tlist = [];
+            // Prepare config
+            $tclist = [];
+            $thlist = [];
+            foreach ($xf['tdata'] as $fId => $fData) {
+                if ($fData['disabled']) {
+                    continue;
+                }
+                $flagTData = true;
+                $tclist[$fId] = [
+                    'title'    => $fData['title'],
+                    'required' => $fData['required'],
+                    'type'     => $fData['type'],
+                    'default'  => $fData['default'],
+                ];
+                $thlist[] = [
+                    'id'    => $fId,
+                    'title' => $fData['title'],
+                ];
+                if ($fData['type'] == 'select') {
+                    $tclist[$fId]['storekeys'] = $fData['storekeys'];
+                    $tclist[$fId]['options'] = $fData['options'];
+                }
+            }
+        }
+        $tVars = [
+            //	'entries'	=>	$xfEntries,
+            'xfGC'       => json_encode(arrayCharsetConvert(0, $xf['grp.news'])),
+            'xfCat'      => json_encode(arrayCharsetConvert(0, $xfCategories)),
+            'xfList'     => json_encode(arrayCharsetConvert(0, array_keys($xf['news']))),
+            'xtableConf' => json_encode(arrayCharsetConvert(0, $tclist)),
+            'xtableVal'  => isset($_POST['xftable']) ? $_POST['xftable'] : json_encode(arrayCharsetConvert(0, $tlist)),
+            'xtableHdr'  => $thlist,
+            'xtablecnt'  => count($thlist),
+            'flags'      => [
+                'tdata' => $flagTData,
+            ],
+        ];
+        if (!isset($xfEntries[0])) {
+            $xfEntries[0] = [];
+        }
+        foreach ($xfEntries as $k => $v) {
+            // Check if we have template for specific area, elsewhere - use basic [0] template
+            $templateName = 'plugins/xfields/tpl/news.add.'.(file_exists(root.'plugins/xfields/tpl/news.add.'.$k.'.tpl') ? $k : '0').'.tpl';
+            $xt = $twig->loadTemplate($templateName);
+            $tVars['entries'] = $v;
+            $tVars['entryCount'] = count($v);
+            $tVars['area'] = $k;
+            // Table data is available only for area 0
+            $tVars['flags']['tdata'] = (!$k) ? $flagTData : 0;
+            // Render block
+            $tvars['plugin']['xfields'][$k] .= $xt->render($tVars);
+        }
+        unset($tVars['entries']);
+        unset($tVars['area']);
+        // Render general part [with JavaScript]
+        $xt = $twig->loadTemplate('plugins/xfields/tpl/news.general.tpl');
+        $tvars['plugin']['xfields']['general'] = $xt->render($tVars);
+        $tvars['plugin']['xfields']['fields'] = $xfList;
 
-	function addNewsForm(&$tvars) {
+        return 1;
+    }
 
-		global $lang, $twig, $catz;
-		// Load config
-		$xf = xf_configLoad();
-		if (!is_array($xf))
-			return false;
-		$output = '';
-		$xfEntries = array();
-		$xfList = array();
-		if (is_array($xf['news']))
-			foreach ($xf['news'] as $id => $data) {
-				if ($data['disabled'])
-					continue;
-				$xfEntry = array(
-					'title'        => $data['title'],
-					'id'           => $id,
-					'value'        => $xdata[$id],
-					'secure_value' => secure_html($xdata[$id]),
-					'data'         => $data,
-					'required'     => $lang['xfields_fld_' . ($data['required'] ? 'required' : 'optional')],
-					'flags'        => array(
-						'required' => $data['required'] ? true : false,
-					),
-				);
-				switch ($data['type']) {
-					case 'checkbox'  :
-						$val = '<input type="checkbox" id="form_xfields_' . $id . '" name="xfields[' . $id . ']" title="' . $data['title'] . '" value="1" ' . ($data['default'] ? 'checked="checked"' : '') . '"/>';
-						$xfEntry['input'] = $val;
-						break;
-					case 'text'  :
-						$val = '<input type="text" id="form_xfields_' . $id . '" name="xfields[' . $id . ']" title="' . $data['title'] . '" value="' . secure_html($data['default']) . '"/>';
-						$xfEntry['input'] = $val;
-						break;
-					case 'select':
-						$val = '<select name="xfields[' . $id . ']" id="form_xfields_' . $id . '" >';
-						if (!$data['required']) $val .= '<option value=""></option>';
-						if (is_array($data['options']))
-							foreach ($data['options'] as $k => $v)
-								$val .= '<option value="' . secure_html(($data['storekeys']) ? $k : $v) . '"' . ((($data['storekeys'] && $data['default'] == $k) || (!$data['storekeys'] && $data['default'] == $v)) ? ' selected' : '') . '>' . $v . '</option>';
-						$val .= '</select>';
-						$xfEntry['input'] = $val;
-						break;
-					case 'multiselect':
-						$val = '<select name="xfields[' . $id . '][]" id="form_xfields_' . $id . '" multiple="multiple">';
-						if (!$data['required']) $val .= '<option value=""></option>';
-						if (is_array($data['options']))
-							foreach ($data['options'] as $k => $v)
-								$val .= '<option value="' . secure_html(($data['storekeys']) ? $k : $v) . '"' . ((($data['storekeys'] && $data['default'] == $k) || (!$data['storekeys'] && $data['default'] == $v)) ? ' selected' : '') . '>' . $v . '</option>';
-						$val .= '</select>';
-						$xfEntry['input'] = $val;
-						break;
-					case 'textarea'  :
-						$val = '<textarea cols="30" rows="5" name="xfields[' . $id . ']" id="form_xfields_' . $id . '" >' . $data['default'] . '</textarea>';
-						$xfEntry['input'] = $val;
-						break;
-					case 'images'    :
-						$iCount = 0;
-						$input = '';
-						$tVars = array('images' => array());
-						// Show entries for allowed number of attaches
-						for ($i = $iCount + 1; $i <= intval($data['maxCount']); $i++) {
-							$tImage = array(
-								'number' => $i,
-								'id'     => $id,
-								'flags'  => array(
-									'exist' => false,
-								),
-							);
-							$tVars['images'][] = $tImage;
-						}
-						// Make template
-						$xt = $twig->loadTemplate('plugins/xfields/tpl/ed_entry.image.tpl');
-						$val = $xt->render($tVars);
-						$xfEntry['input'] = $val;
-						break;
-					default:
-						continue;
-				}
-				$xfEntries[intval($data['area'])][] = $xfEntry;
-				$xfList[$id] = $xfEntry;
-			}
-		$xfCategories = array();
-		foreach ($catz as $cId => $cData) {
-			$xfCategories[$cData['id']] = $cData['xf_group'];
-		}
-		// Prepare table data [if needed]
-		$flagTData = false;
-		if (isset($xf['tdata']) && is_array($xf['tdata'])) {
-			// Data are not provisioned
-			$tlist = array();
-			// Prepare config
-			$tclist = array();
-			$thlist = array();
-			foreach ($xf['tdata'] as $fId => $fData) {
-				if ($fData['disabled'])
-					continue;
-				$flagTData = true;
-				$tclist[$fId] = array(
-					'title'    => $fData['title'],
-					'required' => $fData['required'],
-					'type'     => $fData['type'],
-					'default'  => $fData['default'],
-				);
-				$thlist [] = array(
-					'id'    => $fId,
-					'title' => $fData['title'],
-				);
-				if ($fData['type'] == 'select') {
-					$tclist[$fId]['storekeys'] = $fData['storekeys'];
-					$tclist[$fId]['options'] = $fData['options'];
-				}
-			}
-		}
-		$tVars = array(
-			//	'entries'	=>	$xfEntries,
-			'xfGC'       => json_encode(arrayCharsetConvert(0, $xf['grp.news'])),
-			'xfCat'      => json_encode(arrayCharsetConvert(0, $xfCategories)),
-			'xfList'     => json_encode(arrayCharsetConvert(0, array_keys($xf['news']))),
-			'xtableConf' => json_encode(arrayCharsetConvert(0, $tclist)),
-			'xtableVal'  => isset($_POST['xftable']) ? $_POST['xftable'] : json_encode(arrayCharsetConvert(0, $tlist)),
-			'xtableHdr'  => $thlist,
-			'xtablecnt'  => count($thlist),
-			'flags'      => array(
-				'tdata' => $flagTData,
-			),
-		);
-		if (!isset($xfEntries[0])) {
-			$xfEntries[0] = array();
-		}
-		foreach ($xfEntries as $k => $v) {
-			// Check if we have template for specific area, elsewhere - use basic [0] template
-			$templateName = 'plugins/xfields/tpl/news.add.' . (file_exists(root . 'plugins/xfields/tpl/news.add.' . $k . '.tpl') ? $k : '0') . '.tpl';
-			$xt = $twig->loadTemplate($templateName);
-			$tVars['entries'] = $v;
-			$tVars['entryCount'] = count($v);
-			$tVars['area'] = $k;
-			// Table data is available only for area 0
-			$tVars['flags']['tdata'] = (!$k) ? $flagTData : 0;
-			// Render block
-			$tvars['plugin']['xfields'][$k] .= $xt->render($tVars);
-		}
-		unset($tVars['entries']);
-		unset($tVars['area']);
-		// Render general part [with JavaScript]
-		$xt = $twig->loadTemplate('plugins/xfields/tpl/news.general.tpl');
-		$tvars['plugin']['xfields']['general'] = $xt->render($tVars);
-		$tvars['plugin']['xfields']['fields'] = $xfList;
+    public function addNews(&$tvars, &$SQL)
+    {
+        global $lang, $twig, $twigLoader;
+        // Load config
+        $xf = xf_configLoad();
+        if (!is_array($xf)) {
+            return 1;
+        }
+        $rcall = $_REQUEST['xfields'];
+        if (!is_array($rcall)) {
+            $rcall = [];
+        }
+        $xdata = [];
+        foreach ($xf['news'] as $id => $data) {
+            if ($data['disabled']) {
+                continue;
+            }
+            if ($data['type'] == 'images') {
+                continue;
+            }
+            // Fill xfields. Check that all required fields are filled
+            if ($rcall[$id] != '') {
+                $xdata[$id] = $rcall[$id];
+            } elseif ($data['required']) {
+                msg(['type' => 'error', 'text' => str_replace('{field}', $id, $lang['xfields_msge_emptyrequired'])]);
 
-		return 1;
-	}
+                return 0;
+            }
+            // Check if we should save data into separate SQL field
+            if ($data['storage'] && ($rcall[$id] != '')) {
+                $SQL['xfields_'.$id] = $rcall[$id];
+            }
+        }
+        //var_dump($xdata);
+        $SQL['xfields'] = xf_encode($xdata);
 
-	function addNews(&$tvars, &$SQL) {
+        return 1;
+    }
 
-		global $lang, $twig, $twigLoader;
-		// Load config
-		$xf = xf_configLoad();
-		if (!is_array($xf))
-			return 1;
-		$rcall = $_REQUEST['xfields'];
-		if (!is_array($rcall)) $rcall = array();
-		$xdata = array();
-		foreach ($xf['news'] as $id => $data) {
-			if ($data['disabled'])
-				continue;
-			if ($data['type'] == 'images') {
-				continue;
-			}
-			// Fill xfields. Check that all required fields are filled
-			if ($rcall[$id] != '') {
-				$xdata[$id] = $rcall[$id];
-			} else if ($data['required']) {
-				msg(array("type" => "error", "text" => str_replace('{field}', $id, $lang['xfields_msge_emptyrequired'])));
+    public function addNewsNotify(&$tvars, $SQL, $newsID)
+    {
+        global $mysql;
+        // Load config
+        $xf = xf_configLoad();
+        if (!is_array($xf)) {
+            return 1;
+        }
+        xf_modifyAttachedImages(1, $newsID, $xf, []);
+        // Scan fields and check if we have attached images for fields with type 'images'
+        $haveImages = false;
+        foreach ($xf['news'] as $fid => $fval) {
+            if ($fval['type'] == 'images') {
+                $haveImages = true;
+                break;
+            }
+        }
+        if ($haveImages) {
+            // Get real ID's of attached images and print here
+            $idlist = [];
+            foreach ($mysql->select('select id, plugin, pidentity from '.prefix.'_images where (linked_ds = 1) and (linked_id = '.db_squote($newsID).')') as $irec) {
+                if ($irec['plugin'] == 'xfields') {
+                    $idlist[$irec['pidentity']][] = $irec['id'];
+                }
+            }
+            // Decode xfields
+            $xdata = xf_decode($SQL['xfields']);
+            //print "<pre>IDLIST: ".var_export($idlist, tru)."</pre>";
+            // Scan for fields that should be configured to have attached images
+            foreach ($xf['news'] as $fid => $fval) {
+                if (($fval['type'] == 'images') && (isset($idlist[$fid]))) {
+                    $xdata[$fid] = implode(',', $idlist[$fid]);
+                }
+            }
+            $mysql->query('update '.prefix.'_news set xfields = '.db_squote(xf_encode($xdata)).' where id = '.db_squote($newsID));
+        }
+        // Prepare table data [if needed]
+        if (isset($xf['tdata']) && is_array($xf['tdata']) && isset($_POST['xftable']) && is_array($xft = json_decode(iconv('Windows-1251', 'UTF-8', $_POST['xftable']), true))) {
+            $xft = arrayCharsetConvert(1, $xft);
+            //print "<pre>[".(is_array($xft)?'ARR':'NOARR')."]INCOMING ARRAY: ".var_export($xft, true)."</pre>";
+            $recList = [];
+            $queryList = [];
+            // SCAN records
+            foreach ($xft as $k => $v) {
+                if (is_array($v) && isset($v['#id'])) {
+                    $editMode = 0;
+                    $tRec = ['xfields' => []];
+                    foreach ($xf['tdata'] as $fId => $fData) {
+                        if ($fData['storage']) {
+                            $tRec['xfields_'.$fId] = db_squote($v[$fId]);
+                        }
+                        $tRec['xfields'][$fId] = $v[$fId];
+                    }
+                    $tRec['xfields'] = db_squote(serialize($tRec['xfields']));
+                    // Now update record info
+                    $query = 'insert into '.prefix.'_xfields ('.implode(', ', array_keys($tRec)).', linked_ds, linked_id) values ('.implode(', ', array_values($tRec)).', 1, '.(intval($newsID)).')';
+                    //print "SQL: $query <br/>\n";
+                    $queryList[] = $query;
+                    //$mysql->query($query);
+                    //print "GOT LINE:<pre>".var_export($tRec, true)."</pre>";
+                }
+            }
+            // Execute queries
+            foreach ($queryList as $query) {
+                $mysql->query($query);
+            }
+        }
 
-				return 0;
-			}
-			// Check if we should save data into separate SQL field
-			if ($data['storage'] && ($rcall[$id] != ''))
-				$SQL['xfields_' . $id] = $rcall[$id];
-		}
-		//var_dump($xdata);
-		$SQL['xfields'] = xf_encode($xdata);
+        return 1;
+    }
 
-		return 1;
-	}
+    public function editNewsForm($newsID, $SQLold, &$tvars)
+    {
+        global $lang, $catz, $mysql, $config, $twig, $twigLoader;
+        //print "<pre>".var_export($lang, true)."</pre>";
+        // Load config
+        $xf = xf_configLoad();
+        if (!is_array($xf)) {
+            return false;
+        }
+        // Fetch xfields data
+        $xdata = xf_decode($SQLold['xfields']);
+        if (!is_array($xdata)) {
+            return false;
+        }
+        $output = '';
+        $xfEntries = [];
+        foreach ($xf['news'] as $id => $data) {
+            if ($data['disabled']) {
+                continue;
+            }
+            $xfEntry = [
+                'title'    => $data['title'],
+                'id'       => $id,
+                'required' => $lang['xfields_fld_'.($data['required'] ? 'required' : 'optional')],
+                'flags'    => [
+                    'required' => $data['required'] ? true : false,
+                ],
+            ];
+            switch ($data['type']) {
+                case 'checkbox':
+                    $val = '<input type="checkbox" id="form_xfields_'.$id.'" name="xfields['.$id.']" title="'.$data['title'].'" value="1" '.($xdata[$id] ? 'checked="checked"' : '').'"/>';
+                    $xfEntry['input'] = $val;
+                    $xfEntries[intval($data['area'])][] = $xfEntry;
+                    break;
+                case 'text':
+                    $val = '<input type="text" name="xfields['.$id.']"  id="form_xfields_'.$id.'" title="'.$data['title'].'" value="'.secure_html($xdata[$id]).'" />';
+                    $xfEntry['input'] = $val;
+                    $xfEntries[intval($data['area'])][] = $xfEntry;
+                    break;
+                case 'select':
+                    $val = '<select name="xfields['.$id.']" id="form_xfields_'.$id.'" >';
+                    if (!$data['required']) {
+                        $val .= '<option value="">&nbsp;</option>';
+                    }
+                    if (is_array($data['options'])) {
+                        foreach ($data['options'] as $k => $v) {
+                            $val .= '<option value="'.secure_html(($data['storekeys']) ? $k : $v).'"'.((($data['storekeys'] && ($xdata[$id] == $k)) || (!$data['storekeys'] && ($xdata[$id] == $v))) ? ' selected' : '').'>'.$v.'</option>';
+                        }
+                    }
+                    $val .= '</select>';
+                    $xfEntry['input'] = $val;
+                    $xfEntries[intval($data['area'])][] = $xfEntry;
+                    break;
+                case 'multiselect':
+                    $val = '<select name="xfields['.$id.'][]" id="form_xfields_'.$id.'" multiple="multiple">';
+                    if (!$data['required']) {
+                        $val .= '<option value="">&nbsp;</option>';
+                    }
+                    if (is_array($data['options'])) {
+                        foreach ($data['options'] as $k => $v) {
+                            var_dump();
+                            $val .= '<option value="'.secure_html(($data['storekeys']) ? $k : $v).'"'.((($data['storekeys'] && (in_array($k, $xdata[$id]))) || (!$data['storekeys'] && (in_array($v, $xdata[$id])))) ? ' selected' : '').'>'.$v.'</option>';
+                        }
+                    }
+                    $val .= '</select>';
+                    $xfEntry['input'] = $val;
+                    $xfEntries[intval($data['area'])][] = $xfEntry;
+                    break;
+                case 'textarea':
+                    $val = '<textarea cols="30" rows="4" name="xfields['.$id.']" id="form_xfields_'.$id.'">'.$xdata[$id].'</textarea>';
+                    $xfEntry['input'] = $val;
+                    $xfEntries[intval($data['area'])][] = $xfEntry;
+                    break;
+                case 'images':
+                    // First - show already attached images
+                    $iCount = 0;
+                    $input = '';
+                    $tVars = ['images' => []];
+                    //$tpl -> template('ed_entry.image', extras_dir.'/xfields/tpl');
+                    if (is_array($SQLold['#images'])) {
+                        foreach ($SQLold['#images'] as $irow) {
+                            // Skip images, that are not related to current field
+                            if (($irow['plugin'] != 'xfields') || ($irow['pidentity'] != $id)) {
+                                continue;
+                            }
+                            // Show attached image
+                            $iCount++;
+                            $tImage = [
+                                'number'      => $iCount,
+                                'id'          => $id,
+                                'preview'     => [
+                                    'width'  => $irow['p_width'],
+                                    'height' => $irow['p_height'],
+                                    'url'    => $config['attach_url'].'/'.$irow['folder'].'/thumb/'.$irow['name'],
+                                ],
+                                'image'       => [
+                                    'id'     => $irow['id'],
+                                    'number' => $iCount,
+                                    'url'    => $config['attach_url'].'/'.$irow['folder'].'/'.$irow['name'],
+                                    'width'  => $irow['width'],
+                                    'height' => $irow['height'],
+                                ],
+                                'flags'       => [
+                                    'preview' => $irow['preview'] ? true : false,
+                                    'exist'   => true,
+                                ],
+                                'description' => secure_html($irow['description']),
+                            ];
+                            $tVars['images'][] = $tImage;
+                        }
+                    }
+                    // Second - show entries for allowed number of attaches
+                    for ($i = $iCount + 1; $i <= intval($data['maxCount']); $i++) {
+                        $tImage = [
+                            'number' => $i,
+                            'id'     => $id,
+                            'flags'  => [
+                                'exist' => false,
+                            ],
+                        ];
+                        $tVars['images'][] = $tImage;
+                    }
+                    // Make template
+                    $xt = $twig->loadTemplate('plugins/xfields/tpl/ed_entry.image.tpl');
+                    $val = $xt->render($tVars);
+                    $xfEntry['input'] = $val;
+                    $xfEntries[intval($data['area'])][] = $xfEntry;
+                    break;
+            }
+        }
+        $xfCategories = [];
+        foreach ($catz as $cId => $cData) {
+            $xfCategories[$cData['id']] = $cData['xf_group'];
+        }
+        // Prepare table data [if needed]
+        $flagTData = false;
+        if (isset($xf['tdata']) && is_array($xf['tdata'])) {
+            // Load table data for specific news
+            $tlist = [];
+            foreach ($mysql->select('select * from '.prefix.'_xfields where (linked_ds = 1) and (linked_id = '.db_squote($newsID).')') as $trow) {
+                $ts = unserialize($trow['xfields']);
+                $tEntry = ['#id' => $trow['id']];
+                // Scan every field for value
+                foreach ($xf['tdata'] as $fId => $fData) {
+                    $fValue = '';
+                    if (is_array($ts) && isset($ts[$fId])) {
+                        $fValue = $ts[$fId];
+                    } elseif (isset($trow['xfields_'.$fId])) {
+                        $fValue = $trow['xfields_'.$fId];
+                    }
+                    $tEntry[$fId] = $fValue;
+                }
+                $tlist[] = $tEntry;
+            }
+            // Prepare config
+            $tclist = [];
+            $thlist = [];
+            foreach ($xf['tdata'] as $fId => $fData) {
+                if ($fData['disabled']) {
+                    continue;
+                }
+                $flagTData = true;
+                $tclist[$fId] = [
+                    'title'    => $fData['title'],
+                    'required' => $fData['required'],
+                    'type'     => $fData['type'],
+                    'default'  => $fData['default'],
+                ];
+                $thlist[] = [
+                    'id'    => $fId,
+                    'title' => $fData['title'],
+                ];
+                if ($fData['type'] == 'select') {
+                    $tclist[$fId]['storekeys'] = $fData['storekeys'];
+                    $tclist[$fId]['options'] = $fData['options'];
+                }
+            }
+        }
+        // Prepare personal [group] variables
+        $tVars = [
+            //	'entries'		=>	$xfEntries[0],
+            'xfGC'       => json_encode(arrayCharsetConvert(0, $xf['grp.news'])),
+            'xfCat'      => json_encode(arrayCharsetConvert(0, $xfCategories)),
+            'xfList'     => json_encode(arrayCharsetConvert(0, array_keys($xf['news']))),
+            'xtableConf' => json_encode(arrayCharsetConvert(0, $tclist)),
+            'xtableVal'  => json_encode(arrayCharsetConvert(0, $tlist)),
+            'xtableHdr'  => $thlist,
+            'xtablecnt'  => count($thlist),
+            'flags'      => [
+                'tdata' => $flagTData,
+            ],
+        ];
+        if (!isset($xfEntries[0])) {
+            $xfEntries[0] = [];
+        }
+        foreach ($xfEntries as $k => $v) {
+            // Check if we have template for specific area, elsewhere - use basic [0] template
+            $templateName = 'plugins/xfields/tpl/news.edit.'.(file_exists(root.'plugins/xfields/tpl/news.edit.'.$k.'.tpl') ? $k : '0').'.tpl';
+            $xt = $twig->loadTemplate($templateName);
+            $tVars['entries'] = $v;
+            $tVars['entryCount'] = count($v);
+            $tVars['area'] = $k;
+            // Table data is available only for area 0
+            $tVars['flags']['tdata'] = (!$k) ? $flagTData : 0;
+            // Render block
+            $tvars['plugin']['xfields'][$k] .= $xt->render($tVars);
+        }
+        unset($tVars['entries']);
+        unset($tVars['area']);
+        // Render general part [with JavaScript]
+        $xt = $twig->loadTemplate('plugins/xfields/tpl/news.general.tpl');
+        $tvars['plugin']['xfields']['general'] = $xt->render($tVars);
 
-	function addNewsNotify(&$tvars, $SQL, $newsID) {
+        return 1;
+    }
 
-		global $mysql;
-		// Load config
-		$xf = xf_configLoad();
-		if (!is_array($xf))
-			return 1;
-		xf_modifyAttachedImages(1, $newsID, $xf, array());
-		// Scan fields and check if we have attached images for fields with type 'images'
-		$haveImages = false;
-		foreach ($xf['news'] as $fid => $fval) {
-			if ($fval['type'] == 'images') {
-				$haveImages = true;
-				break;
-			}
-		}
-		if ($haveImages) {
-			// Get real ID's of attached images and print here
-			$idlist = array();
-			foreach ($mysql->select("select id, plugin, pidentity from " . prefix . "_images where (linked_ds = 1) and (linked_id = " . db_squote($newsID) . ")") as $irec) {
-				if ($irec['plugin'] == 'xfields') {
-					$idlist[$irec['pidentity']] [] = $irec['id'];
-				}
-			}
-			// Decode xfields
-			$xdata = xf_decode($SQL['xfields']);
-			//print "<pre>IDLIST: ".var_export($idlist, tru)."</pre>";
-			// Scan for fields that should be configured to have attached images
-			foreach ($xf['news'] as $fid => $fval) {
-				if (($fval['type'] == 'images') && (isset($idlist[$fid]))) {
-					$xdata[$fid] = join(",", $idlist[$fid]);
-				}
-			}
-			$mysql->query("update " . prefix . "_news set xfields = " . db_squote(xf_encode($xdata)) . " where id = " . db_squote($newsID));
-		}
-		// Prepare table data [if needed]
-		if (isset($xf['tdata']) && is_array($xf['tdata']) && isset($_POST['xftable']) && is_array($xft = json_decode(iconv('Windows-1251', 'UTF-8', $_POST['xftable']), true))) {
-			$xft = arrayCharsetConvert(1, $xft);
-			//print "<pre>[".(is_array($xft)?'ARR':'NOARR')."]INCOMING ARRAY: ".var_export($xft, true)."</pre>";
-			$recList = array();
-			$queryList = array();
-			// SCAN records
-			foreach ($xft as $k => $v) {
-				if (is_array($v) && isset($v['#id'])) {
-					$editMode = 0;
-					$tRec = array('xfields' => array());
-					foreach ($xf['tdata'] as $fId => $fData) {
-						if ($fData['storage']) {
-							$tRec['xfields_' . $fId] = db_squote($v[$fId]);
-						}
-						$tRec['xfields'][$fId] = $v[$fId];
-					}
-					$tRec['xfields'] = db_squote(serialize($tRec['xfields']));
-					// Now update record info
-					$query = "insert into " . prefix . "_xfields (" . join(", ", array_keys($tRec)) . ", linked_ds, linked_id) values (" . join(", ", array_values($tRec)) . ", 1, " . (intval($newsID)) . ")";
-					//print "SQL: $query <br/>\n";
-					$queryList [] = $query;
-					//$mysql->query($query);
-					//print "GOT LINE:<pre>".var_export($tRec, true)."</pre>";
-				}
-			}
-			// Execute queries
-			foreach ($queryList as $query) {
-				$mysql->query($query);
-			}
-		}
+    public function editNews($newsID, $SQLold, &$SQLnew, &$tvars)
+    {
+        global $lang, $config, $mysql;
+        //	print "<pre>POST VARS: ".var_export($_POST, true)."</pre>";
+        // Load config
+        $xf = xf_configLoad();
+        if (!is_array($xf)) {
+            return 1;
+        }
+        $rcall = $_POST['xfields'];
+        if (!is_array($rcall)) {
+            $rcall = [];
+        }
+        // Decode previusly stored data
+        $oldFields = xf_decode($SQLold['xfields']);
+        // Manage attached images
+        xf_modifyAttachedImages(1, $newsID, $xf, $SQLold['#images']);
+        $xdata = [];
+        // Scan fields and check if we have attached images for fields with type 'images'
+        $haveImages = false;
+        foreach ($xf['news'] as $fid => $fval) {
+            if ($fval['type'] == 'images') {
+                $haveImages = true;
+                break;
+            }
+        }
+        if ($haveImages) {
+            // Get real ID's of attached images and print here
+            $idlist = [];
+            foreach ($mysql->select('select id, plugin, pidentity from '.prefix.'_images where (linked_ds = 1) and (linked_id = '.db_squote($newsID).')') as $irec) {
+                if ($irec['plugin'] == 'xfields') {
+                    $idlist[$irec['pidentity']][] = $irec['id'];
+                }
+            }
+            // Scan for fields that should be configured to have attached images
+            foreach ($xf['news'] as $fid => $fval) {
+                if (($fval['type'] == 'images') && (is_array($idlist[$fid]))) {
+                    $xdata[$fid] = implode(',', $idlist[$fid]);
+                }
+            }
+        }
+        foreach ($xf['news'] as $id => $data) {
+            // Attached images are processed in special way
+            if ($data['type'] == 'images') {
+                continue;
+            }
+            // Skip disabled fields
+            if ($data['disabled']) {
+                $xdata[$id] = $oldFields[$id];
+                continue;
+            }
+            if ($rcall[$id] != '') {
+                $xdata[$id] = $rcall[$id];
+            } elseif ($data['required']) {
+                msg(['type' => 'error', 'text' => str_replace('{field}', $id, $lang['xfields_msge_emptyrequired'])]);
 
-		return 1;
-	}
+                return 0;
+            }
+            // Check if we should save data into separate SQL field
+            if ($data['storage']) {
+                $SQLnew['xfields_'.$id] = $rcall[$id];
+            }
+        }
+        // Prepare table data [if needed]
+        $haveTable = false;
+        if (isset($xf['tdata']) && is_array($xf['tdata']) && isset($_POST['xftable']) && is_array($xft = json_decode(iconv('Windows-1251', 'UTF-8', $_POST['xftable']), true))) {
+            $xft = arrayCharsetConvert(1, $xft);
+            //print "<pre>[".(is_array($xft)?'ARR':'NOARR')."]INCOMING ARRAY: ".var_export($xft, true)."</pre>";
+            $recList = [];
+            $queryList = [];
+            // SCAN records
+            foreach ($xft as $k => $v) {
+                if (is_array($v) && isset($v['#id'])) {
+                    $editMode = 0;
+                    $tOldRec = [];
+                    $tOldRecX = [];
+                    if (intval($v['#id'])) {
+                        $recList[] = intval($v['#id']);
+                        $editMode = 1;
+                        $tOldRec = $mysql->record('select * from '.prefix.'_xfields where (id = '.intval($v['#id']).') and (linked_ds = 1) and (linked_id = '.intval($newsID).')');
+                        $tOldRecX = unserialize($tOldRec['xfields']);
+                    }
+                    $tRec = ['xfields' => []];
+                    foreach ($xf['tdata'] as $fId => $fData) {
+                        // Manage disabled fields
+                        if ($fData['disabled']) {
+                            $tRec['xfields'][$fId] = $tOldRecX[$fId];
+                            continue;
+                        }
+                        if ($fData['storage']) {
+                            $tRec['xfields_'.$fId] = db_squote($v[$fId]);
+                        }
+                        $tRec['xfields'][$fId] = $v[$fId];
+                    }
+                    $tRec['xfields'] = db_squote(serialize($tRec['xfields']));
+                    // Now update record info
+                    $haveTable = true;
+                    if ($editMode) {
+                        $vt = [];
+                        foreach ($tRec as $kx => $vx) {
+                            $vt[] = $kx.' = '.$vx;
+                        }
+                        $query = 'update '.prefix.'_xfields set '.implode(', ', $vt).' where (id = '.intval($v['#id']).') and (linked_ds = 1) and (linked_id = '.intval($newsID).')';
+                        //print "SQL: $query <br/>\n";
+                        $queryList[] = $query;
+                    //$mysql->query($query);
+                    } else {
+                        $query = 'insert into '.prefix.'_xfields ('.implode(', ', array_keys($tRec)).', linked_ds, linked_id) values ('.implode(', ', array_values($tRec)).', 1, '.(intval($newsID)).')';
+                        //print "SQL: $query <br/>\n";
+                        $queryList[] = $query;
+                        //$mysql->query($query);
+                    }
+                    //print "GOT LINE:<pre>".var_export($tRec, true)."</pre>";
+                }
+            }
+            // Now delete old lines
+            if (count($recList)) {
+                $query = 'delete from '.prefix.'_xfields where (linked_ds = 1) and (linked_id = '.intval($newsID).') and id not in ('.implode(', ', $recList).')';
+            } else {
+                $query = 'delete from '.prefix.'_xfields where (linked_ds = 1) and (linked_id = '.intval($newsID).')';
+            }
+            $mysql->query($query);
+            // Execute queries
+            foreach ($queryList as $query) {
+                $mysql->query($query);
+            }
+        }
+        // Save info about table data
+        if ($haveTable) {
+            $xdata['#table'] = 1;
+        }
+        $SQLnew['xfields'] = xf_encode($xdata);
 
-	function editNewsForm($newsID, $SQLold, &$tvars) {
+        return 1;
+    }
 
-		global $lang, $catz, $mysql, $config, $twig, $twigLoader;
-		//print "<pre>".var_export($lang, true)."</pre>";
-		// Load config
-		$xf = xf_configLoad();
-		if (!is_array($xf))
-			return false;
-		// Fetch xfields data
-		$xdata = xf_decode($SQLold['xfields']);
-		if (!is_array($xdata))
-			return false;
-		$output = '';
-		$xfEntries = array();
-		foreach ($xf['news'] as $id => $data) {
-			if ($data['disabled'])
-				continue;
-			$xfEntry = array(
-				'title'    => $data['title'],
-				'id'       => $id,
-				'required' => $lang['xfields_fld_' . ($data['required'] ? 'required' : 'optional')],
-				'flags'    => array(
-					'required' => $data['required'] ? true : false,
-				),
-			);
-			switch ($data['type']) {
-				case 'checkbox'  :
-					$val = '<input type="checkbox" id="form_xfields_' . $id . '" name="xfields[' . $id . ']" title="' . $data['title'] . '" value="1" ' . ($xdata[$id] ? 'checked="checked"' : '') . '"/>';
-					$xfEntry['input'] = $val;
-					$xfEntries[intval($data['area'])][] = $xfEntry;
-					break;
-				case 'text'  :
-					$val = '<input type="text" name="xfields[' . $id . ']"  id="form_xfields_' . $id . '" title="' . $data['title'] . '" value="' . secure_html($xdata[$id]) . '" />';
-					$xfEntry['input'] = $val;
-					$xfEntries[intval($data['area'])][] = $xfEntry;
-					break;
-				case 'select':
-					$val = '<select name="xfields[' . $id . ']" id="form_xfields_' . $id . '" >';
-					if (!$data['required']) $val .= '<option value="">&nbsp;</option>';
-					if (is_array($data['options']))
-						foreach ($data['options'] as $k => $v) {
-							$val .= '<option value="' . secure_html(($data['storekeys']) ? $k : $v) . '"' . ((($data['storekeys'] && ($xdata[$id] == $k)) || (!$data['storekeys'] && ($xdata[$id] == $v))) ? ' selected' : '') . '>' . $v . '</option>';
-						}
-					$val .= '</select>';
-					$xfEntry['input'] = $val;
-					$xfEntries[intval($data['area'])][] = $xfEntry;
-					break;
-				case 'multiselect':
-					$val = '<select name="xfields[' . $id . '][]" id="form_xfields_' . $id . '" multiple="multiple">';
-					if (!$data['required']) $val .= '<option value="">&nbsp;</option>';
-					if (is_array($data['options']))
-						foreach ($data['options'] as $k => $v) {
-							var_dump();
-							$val .= '<option value="' . secure_html(($data['storekeys']) ? $k : $v) . '"' . ((($data['storekeys'] && (in_array($k, $xdata[$id]))) || (!$data['storekeys'] && (in_array($v, $xdata[$id])))) ? ' selected' : '') . '>' . $v . '</option>';
-						}
-					$val .= '</select>';
-					$xfEntry['input'] = $val;
-					$xfEntries[intval($data['area'])][] = $xfEntry;
-					break;
-				case 'textarea'    :
-					$val = '<textarea cols="30" rows="4" name="xfields[' . $id . ']" id="form_xfields_' . $id . '">' . $xdata[$id] . '</textarea>';
-					$xfEntry['input'] = $val;
-					$xfEntries[intval($data['area'])][] = $xfEntry;
-					break;
-				case 'images'    :
-					// First - show already attached images
-					$iCount = 0;
-					$input = '';
-					$tVars = array('images' => array());
-					//$tpl -> template('ed_entry.image', extras_dir.'/xfields/tpl');
-					if (is_array($SQLold['#images'])) {
-						foreach ($SQLold['#images'] as $irow) {
-							// Skip images, that are not related to current field
-							if (($irow['plugin'] != 'xfields') || ($irow['pidentity'] != $id)) continue;
-							// Show attached image
-							$iCount++;
-							$tImage = array(
-								'number'      => $iCount,
-								'id'          => $id,
-								'preview'     => array(
-									'width'  => $irow['p_width'],
-									'height' => $irow['p_height'],
-									'url'    => $config['attach_url'] . '/' . $irow['folder'] . '/thumb/' . $irow['name'],
-								),
-								'image'       => array(
-									'id'     => $irow['id'],
-									'number' => $iCount,
-									'url'    => $config['attach_url'] . '/' . $irow['folder'] . '/' . $irow['name'],
-									'width'  => $irow['width'],
-									'height' => $irow['height'],
-								),
-								'flags'       => array(
-									'preview' => $irow['preview'] ? true : false,
-									'exist'   => true,
-								),
-								'description' => secure_html($irow['description']),
-							);
-							$tVars['images'][] = $tImage;
-						}
-					}
-					// Second - show entries for allowed number of attaches
-					for ($i = $iCount + 1; $i <= intval($data['maxCount']); $i++) {
-						$tImage = array(
-							'number' => $i,
-							'id'     => $id,
-							'flags'  => array(
-								'exist' => false,
-							),
-						);
-						$tVars['images'][] = $tImage;
-					}
-					// Make template
-					$xt = $twig->loadTemplate('plugins/xfields/tpl/ed_entry.image.tpl');
-					$val = $xt->render($tVars);
-					$xfEntry['input'] = $val;
-					$xfEntries[intval($data['area'])][] = $xfEntry;
-					break;
-			}
-		}
-		$xfCategories = array();
-		foreach ($catz as $cId => $cData) {
-			$xfCategories[$cData['id']] = $cData['xf_group'];
-		}
-		// Prepare table data [if needed]
-		$flagTData = false;
-		if (isset($xf['tdata']) && is_array($xf['tdata'])) {
-			// Load table data for specific news
-			$tlist = array();
-			foreach ($mysql->select("select * from " . prefix . "_xfields where (linked_ds = 1) and (linked_id = " . db_squote($newsID) . ")") as $trow) {
-				$ts = unserialize($trow['xfields']);
-				$tEntry = array('#id' => $trow['id']);
-				// Scan every field for value
-				foreach ($xf['tdata'] as $fId => $fData) {
-					$fValue = '';
-					if (is_array($ts) && isset($ts[$fId])) {
-						$fValue = $ts[$fId];
-					} elseif (isset($trow['xfields_' . $fId])) {
-						$fValue = $trow['xfields_' . $fId];
-					}
-					$tEntry[$fId] = $fValue;
-				}
-				$tlist [] = $tEntry;
-			}
-			// Prepare config
-			$tclist = array();
-			$thlist = array();
-			foreach ($xf['tdata'] as $fId => $fData) {
-				if ($fData['disabled'])
-					continue;
-				$flagTData = true;
-				$tclist[$fId] = array(
-					'title'    => $fData['title'],
-					'required' => $fData['required'],
-					'type'     => $fData['type'],
-					'default'  => $fData['default'],
-				);
-				$thlist [] = array(
-					'id'    => $fId,
-					'title' => $fData['title'],
-				);
-				if ($fData['type'] == 'select') {
-					$tclist[$fId]['storekeys'] = $fData['storekeys'];
-					$tclist[$fId]['options'] = $fData['options'];
-				}
-			}
-		}
-		// Prepare personal [group] variables
-		$tVars = array(
-			//	'entries'		=>	$xfEntries[0],
-			'xfGC'       => json_encode(arrayCharsetConvert(0, $xf['grp.news'])),
-			'xfCat'      => json_encode(arrayCharsetConvert(0, $xfCategories)),
-			'xfList'     => json_encode(arrayCharsetConvert(0, array_keys($xf['news']))),
-			'xtableConf' => json_encode(arrayCharsetConvert(0, $tclist)),
-			'xtableVal'  => json_encode(arrayCharsetConvert(0, $tlist)),
-			'xtableHdr'  => $thlist,
-			'xtablecnt'  => count($thlist),
-			'flags'      => array(
-				'tdata' => $flagTData,
-			),
-		);
-		if (!isset($xfEntries[0])) {
-			$xfEntries[0] = array();
-		}
-		foreach ($xfEntries as $k => $v) {
-			// Check if we have template for specific area, elsewhere - use basic [0] template
-			$templateName = 'plugins/xfields/tpl/news.edit.' . (file_exists(root . 'plugins/xfields/tpl/news.edit.' . $k . '.tpl') ? $k : '0') . '.tpl';
-			$xt = $twig->loadTemplate($templateName);
-			$tVars['entries'] = $v;
-			$tVars['entryCount'] = count($v);
-			$tVars['area'] = $k;
-			// Table data is available only for area 0
-			$tVars['flags']['tdata'] = (!$k) ? $flagTData : 0;
-			// Render block
-			$tvars['plugin']['xfields'][$k] .= $xt->render($tVars);
-		}
-		unset($tVars['entries']);
-		unset($tVars['area']);
-		// Render general part [with JavaScript]
-		$xt = $twig->loadTemplate('plugins/xfields/tpl/news.general.tpl');
-		$tvars['plugin']['xfields']['general'] = $xt->render($tVars);
+    // Delete news notifier [ after news is deleted ]
+    public function deleteNewsNotify($newsID, $SQLnews)
+    {
+        global $mysql;
+        $query = 'delete from '.prefix.'_xfields where (linked_ds = 1) and (linked_id = '.intval($newsID).')';
+        $mysql->query($query);
 
-		return 1;
-	}
+        return 1;
+    }
 
-	function editNews($newsID, $SQLold, &$SQLnew, &$tvars) {
+    // Called before showing list of news
+    public function onBeforeShowlist($callingParams)
+    {
+        if (isset($linkedFiles['data']) && is_array($linkedFiles['data'])) {
+            // Check for news that have attached TABLE data and load this table into memory
+            // ...
+        }
+    }
 
-		global $lang, $config, $mysql;
-		//	print "<pre>POST VARS: ".var_export($_POST, true)."</pre>";
-		// Load config
-		$xf = xf_configLoad();
-		if (!is_array($xf))
-			return 1;
-		$rcall = $_POST['xfields'];
-		if (!is_array($rcall)) $rcall = array();
-		// Decode previusly stored data
-		$oldFields = xf_decode($SQLold['xfields']);
-		// Manage attached images
-		xf_modifyAttachedImages(1, $newsID, $xf, $SQLold['#images']);
-		$xdata = array();
-		// Scan fields and check if we have attached images for fields with type 'images'
-		$haveImages = false;
-		foreach ($xf['news'] as $fid => $fval) {
-			if ($fval['type'] == 'images') {
-				$haveImages = true;
-				break;
-			}
-		}
-		if ($haveImages) {
-			// Get real ID's of attached images and print here
-			$idlist = array();
-			foreach ($mysql->select("select id, plugin, pidentity from " . prefix . "_images where (linked_ds = 1) and (linked_id = " . db_squote($newsID) . ")") as $irec) {
-				if ($irec['plugin'] == 'xfields') {
-					$idlist[$irec['pidentity']] [] = $irec['id'];
-				}
-			}
-			// Scan for fields that should be configured to have attached images
-			foreach ($xf['news'] as $fid => $fval) {
-				if (($fval['type'] == 'images') && (is_array($idlist[$fid]))) {
-					$xdata[$fid] = join(",", $idlist[$fid]);
-				}
-			}
-		}
-		foreach ($xf['news'] as $id => $data) {
-			// Attached images are processed in special way
-			if ($data['type'] == 'images') {
-				continue;
-			}
-			// Skip disabled fields
-			if ($data['disabled']) {
-				$xdata[$id] = $oldFields[$id];
-				continue;
-			}
-			if ($rcall[$id] != '') {
-				$xdata[$id] = $rcall[$id];
-			} else if ($data['required']) {
-				msg(array("type" => "error", "text" => str_replace('{field}', $id, $lang['xfields_msge_emptyrequired'])));
-
-				return 0;
-			}
-			// Check if we should save data into separate SQL field
-			if ($data['storage'])
-				$SQLnew['xfields_' . $id] = $rcall[$id];
-		}
-		// Prepare table data [if needed]
-		$haveTable = false;
-		if (isset($xf['tdata']) && is_array($xf['tdata']) && isset($_POST['xftable']) && is_array($xft = json_decode(iconv('Windows-1251', 'UTF-8', $_POST['xftable']), true))) {
-			$xft = arrayCharsetConvert(1, $xft);
-			//print "<pre>[".(is_array($xft)?'ARR':'NOARR')."]INCOMING ARRAY: ".var_export($xft, true)."</pre>";
-			$recList = array();
-			$queryList = array();
-			// SCAN records
-			foreach ($xft as $k => $v) {
-				if (is_array($v) && isset($v['#id'])) {
-					$editMode = 0;
-					$tOldRec = array();
-					$tOldRecX = array();
-					if (intval($v['#id'])) {
-						$recList [] = intval($v['#id']);
-						$editMode = 1;
-						$tOldRec = $mysql->record("select * from " . prefix . "_xfields where (id = " . intval($v['#id']) . ") and (linked_ds = 1) and (linked_id = " . intval($newsID) . ")");
-						$tOldRecX = unserialize($tOldRec['xfields']);
-					}
-					$tRec = array('xfields' => array());
-					foreach ($xf['tdata'] as $fId => $fData) {
-						// Manage disabled fields
-						if ($fData['disabled']) {
-							$tRec['xfields'][$fId] = $tOldRecX[$fId];
-							continue;
-						}
-						if ($fData['storage']) {
-							$tRec['xfields_' . $fId] = db_squote($v[$fId]);
-						}
-						$tRec['xfields'][$fId] = $v[$fId];
-					}
-					$tRec['xfields'] = db_squote(serialize($tRec['xfields']));
-					// Now update record info
-					$haveTable = true;
-					if ($editMode) {
-						$vt = array();
-						foreach ($tRec as $kx => $vx) {
-							$vt [] = $kx . " = " . $vx;
-						}
-						$query = "update " . prefix . "_xfields set " . join(", ", $vt) . " where (id = " . intval($v['#id']) . ") and (linked_ds = 1) and (linked_id = " . intval($newsID) . ")";
-						//print "SQL: $query <br/>\n";
-						$queryList [] = $query;
-						//$mysql->query($query);
-					} else {
-						$query = "insert into " . prefix . "_xfields (" . join(", ", array_keys($tRec)) . ", linked_ds, linked_id) values (" . join(", ", array_values($tRec)) . ", 1, " . (intval($newsID)) . ")";
-						//print "SQL: $query <br/>\n";
-						$queryList [] = $query;
-						//$mysql->query($query);
-					}
-					//print "GOT LINE:<pre>".var_export($tRec, true)."</pre>";
-				}
-			}
-			// Now delete old lines
-			if (count($recList)) {
-				$query = "delete from " . prefix . "_xfields where (linked_ds = 1) and (linked_id = " . intval($newsID) . ") and id not in (" . join(", ", $recList) . ")";
-			} else {
-				$query = "delete from " . prefix . "_xfields where (linked_ds = 1) and (linked_id = " . intval($newsID) . ")";
-			}
-			$mysql->query($query);
-			// Execute queries
-			foreach ($queryList as $query) {
-				$mysql->query($query);
-			}
-		}
-		// Save info about table data
-		if ($haveTable)
-			$xdata['#table'] = 1;
-		$SQLnew['xfields'] = xf_encode($xdata);
-
-		return 1;
-	}
-
-	// Delete news notifier [ after news is deleted ]
-	function deleteNewsNotify($newsID, $SQLnews) {
-
-		global $mysql;
-		$query = "delete from " . prefix . "_xfields where (linked_ds = 1) and (linked_id = " . intval($newsID) . ")";
-		$mysql->query($query);
-
-		return 1;
-	}
-
-	// Called before showing list of news
-	function onBeforeShowlist($callingParams) {
-
-		if (isset($linkedFiles['data']) && is_array($linkedFiles['data'])) {
-			// Check for news that have attached TABLE data and load this table into memory
-			// ...
-		}
-	}
-
-	// Show news call :: processor (call after all processing is finished and before show)
-	function showNews($newsID, $SQLnews, &$tvars, $mode = array()) {
-
-		global $mysql, $config, $twigLoader, $twig, $PFILTERS, $twig, $twigLoader, $parse;
-		// Try to load config. Stop processing if config was not loaded
-		if (($xf = xf_configLoad()) === false) return;
-		$fields = xf_decode($SQLnews['xfields']);
-		$content = $SQLnews['content'];
-		// Check if we have at least one `image` field and load TWIG template if any
-		if (is_array($xf['news']))
-			foreach ($xf['news'] as $k => $v) {
-				if ($v['type'] == 'images') {
-					// Yes, we have it!
-					$conversionParams = array();
-					$imagesTemplateFileName = 'plugins/xfields/tpl/news.show.images.tpl';
-					$twigLoader->setConversion($imagesTemplateFileName, $conversionConfig);
-					$xtImages = $twig->loadTemplate($imagesTemplateFileName);
-					break;
-				}
-			}
-		// Show extra fields if we have it
-		if (is_array($xf['news']))
-			foreach ($xf['news'] as $k => $v) {
-				$kp = preg_quote($k, "#");
-				$xfk = isset($fields[$k]) ? $fields[$k] : '';
-				// TWIG stype data fill
-				$tvars['vars']['p']['xfields'][$k]['type'] = $v['type'];
-				$tvars['vars']['p']['xfields'][$k]['title'] = secure_html($v['title']);
-				// Our behaviour depends on field type
-				if ($v['type'] == 'images') {
-					// Check if there're attached images
-					$imglist = array();
-					if ($xfk && count($ilist = explode(",", $xfk))) {
-						// Check if we have already preloaded (by engine) images
-						$ilk = array();
-						foreach ($ilist as $irec) {
-							if (isset($mode['linkedImages']['data'][$irec])) {
-								$imglist [] = $mode['linkedImages']['data'][$irec];
-							} else {
-								$ilk [] = $irec;
-							}
-						}
-						// Check if we have some not loaded news
-						if (count($ilk) && count($timglist = $mysql->select("select * from " . prefix . "_images where id in (" . $xfk . ")"))) {
-							$imglist = array_merge($imglist, $timglist);
-							unset($timglist);
-						}
-					}
-					//					if ($xfk && count($ilist = explode(",", $xfk)) && count($imglist = $mysql->select("select * from ".prefix."_images where id in (".$xfk.")"))) {
-					if (count($imglist)) {
-						// Yes, show field block
-						$tvars['regx']["#\[xfield_" . $kp . "\](.*?)\[/xfield_" . $kp . "\]#is"] = '$1';
-						$tvars['regx']["#\[nxfield_" . $kp . "\](.*?)\[/nxfield_" . $kp . "\]#is"] = '';
-						// Scan for images and prepare data for template show
-						$tiVars = array(
-							'fieldName'    => $k,
-							'fieldTitle'   => secure_html($v['title']),
-							'fieldType'    => $v['type'],
-							'entriesCount' => count($imglist),
-							'entries'      => array(),
-							'execStyle'    => $mode['style'],
-							'execPlugin'   => $mode['plugin'],
-						);
-						foreach ($imglist as $imgInfo) {
-							$tiEntry = array(
-								'url'         => ($imgInfo['storage'] ? $config['attach_url'] : $config['images_url']) . '/' . $imgInfo['folder'] . '/' . $imgInfo['name'],
-								'width'       => $imgInfo['width'],
-								'height'      => $imgInfo['height'],
-								'pwidth'      => $imgInfo['p_width'],
-								'pheight'     => $imgInfo['p_height'],
-								'name'        => $imgInfo['name'],
-								'origName'    => secure_html($imgInfo['orig_name']),
-								'description' => secure_html($imgInfo['description']),
-								'flags' => array(
-									'hasPreview' => $imgInfo['preview'],
-								),
-							);
-							if ($imgInfo['preview']) {
-								$tiEntry['purl'] = ($imgInfo['storage'] ? $config['attach_url'] : $config['images_url']) . '/' . $imgInfo['folder'] . '/thumb/' . $imgInfo['name'];
-							}
-							$tiVars['entries'] [] = $tiEntry;
-						}
-						// TWIG based variables
-						$tvars['vars']['p']['xfields'][$k]['entries'] = $tiVars['entries'];
-						$tvars['vars']['p']['xfields'][$k]['count'] = count($tiVars['entries']);
-						$xv = $xtImages->render($tiVars);
-						$tvars['vars']['p']['xfields'][$k]['value'] = $xv;
-						$tvars['vars']['[xvalue_' . $k . ']'] = $xv;
-					} else {
-						// TWIG based variables
-						$tvars['vars']['p']['xfields'][$k]['value'] = '';
-						$tvars['vars']['p']['xfields'][$k]['count'] = 0;
-						$tvars['vars']['p']['xfields'][$k]['entries'] = array();
-						// General variables
-						$tvars['regx']["#\[xfield_" . $kp . "\](.*?)\[/xfield_" . $kp . "\]#is"] = '';
-						$tvars['regx']["#\[nxfield_" . $kp . "\](.*?)\[/nxfield_" . $kp . "\]#is"] = '$1';
-						$tvars['vars']['[xvalue_' . $k . ']'] = '';
-					}
-				} else {
-					$tvars['regx']["#\[xfield_" . $kp . "\](.*?)\[/xfield_" . $kp . "\]#is"] = ($xfk == "") ? "" : "$1";
-					$tvars['regx']["#\[nxfield_" . $kp . "\](.*?)\[/nxfield_" . $kp . "\]#is"] = ($xfk == "") ? "$1" : "";
-					// Process `HTML` support feature
-					if ((!$v['html_support']) && (($v['type'] == 'textarea') || ($v['type'] == 'text'))) {
-						$xfk = str_replace("<", "&lt;", $xfk);
-					}
-					// Parse BB code [if required]
-					if ($config['use_bbcodes'] && $v['bb_support']) {
-						$xfk = $parse->bbcodes($xfk);
-					}
-					// Process formatting
-					if (($v['type'] == 'textarea') && (!$v['noformat'])) {
-						$xfk = (str_replace("\n", "<br/>\n", $xfk) . (strlen($xfk) ? '<br/>' : ''));
-					}
-					$tvars['vars']['p']['xfields'][$k]['value'] = $xfk;
-					$tvars['vars']['[xvalue_' . $k . ']'] = $xfk;
-				}
-			}
-		// Show table if we have it
-		if (isset($xf['tdata']) && is_array($xf['tdata']) && isset($fields['#table']) && ($fields['#table'] == 1)) {
-			// Yes, we have table. Display it!
-			// Prepare conversion table
-			$conversionConfig = array(
-				'[entries]'  => '{% for entry in entries %}',
-				'[/entries]' => '{% endfor %}',
-			);
-			$xrecs = array();
-			$npp = 1;
-			foreach ($mysql->select("select * from " . prefix . "_xfields where (linked_ds = 1) and (linked_id = " . db_squote($newsID) . ") order by id", 1) as $trec) {
-				$xrec = array(
-					'num'   => ($npp++),
-					'id'    => $trec['id'],
-					'flags' => array(),
-				);
-				foreach ($xf['tdata'] as $tid => $tval) {
-					// Skip disabled
-					if ($tval['disabled'])
-						continue;
-					//  Populate field data
-					$drec = unserialize($trec['xfields']);
-					$xrec['field_' . $tid] = $drec[$tid];
-					$xrec['flags']['field_' . $tid] = ($drec[$tid] != '') ? 1 : 0;
-					$conversionConfig['{entry_field_' . $tid . '}'] = '{{ entry.field_' . $tid . ' }}';
-				}
-				// Process filters (if any)
-				if (isset($PFILTERS['xfields']) && is_array($PFILTERS['xfields']))
-					foreach ($PFILTERS['xfields'] as $k => $v) {
-						$v->showTableEntry($newsID, $SQLnews, $trec, $xrec);
-					}
-				$xrecs [] = $xrec;
-			}
-			// Search for news.table.tpl template file
-			$tpath = locatePluginTemplates(array('news.table'), 'xfields');
-			// Show table
-			$templateName = $tpath['news.table'] . 'news.table.tpl';
-			$twigLoader->setConversion($templateName, $conversionConfig);
-			$xt = $twig->loadTemplate($templateName);
-			$tvars['vars']['plugin_xfields_table'] = $xt->render(array('entries' => $xrecs));
-			$tvars['vars']['p']['xfields']['_table']['countRec'] = count($xrecs);
-			$tvars['vars']['p']['xfields']['_table']['data'] = $xrecs;
-		} else {
-			$tvars['vars']['plugin_xfields_table'] = '';
-			$tvars['vars']['p']['xfields']['_table']['countRec'] = 0;
-		}
-		$SQLnews['content'] = $content;
-	}
+    // Show news call :: processor (call after all processing is finished and before show)
+    public function showNews($newsID, $SQLnews, &$tvars, $mode = [])
+    {
+        global $mysql, $config, $twigLoader, $twig, $PFILTERS, $twig, $twigLoader, $parse;
+        // Try to load config. Stop processing if config was not loaded
+        if (($xf = xf_configLoad()) === false) {
+            return;
+        }
+        $fields = xf_decode($SQLnews['xfields']);
+        $content = $SQLnews['content'];
+        // Check if we have at least one `image` field and load TWIG template if any
+        if (is_array($xf['news'])) {
+            foreach ($xf['news'] as $k => $v) {
+                if ($v['type'] == 'images') {
+                    // Yes, we have it!
+                    $conversionParams = [];
+                    $imagesTemplateFileName = 'plugins/xfields/tpl/news.show.images.tpl';
+                    $twigLoader->setConversion($imagesTemplateFileName, $conversionConfig);
+                    $xtImages = $twig->loadTemplate($imagesTemplateFileName);
+                    break;
+                }
+            }
+        }
+        // Show extra fields if we have it
+        if (is_array($xf['news'])) {
+            foreach ($xf['news'] as $k => $v) {
+                $kp = preg_quote($k, '#');
+                $xfk = isset($fields[$k]) ? $fields[$k] : '';
+                // TWIG stype data fill
+                $tvars['vars']['p']['xfields'][$k]['type'] = $v['type'];
+                $tvars['vars']['p']['xfields'][$k]['title'] = secure_html($v['title']);
+                // Our behaviour depends on field type
+                if ($v['type'] == 'images') {
+                    // Check if there're attached images
+                    $imglist = [];
+                    if ($xfk && count($ilist = explode(',', $xfk))) {
+                        // Check if we have already preloaded (by engine) images
+                        $ilk = [];
+                        foreach ($ilist as $irec) {
+                            if (isset($mode['linkedImages']['data'][$irec])) {
+                                $imglist[] = $mode['linkedImages']['data'][$irec];
+                            } else {
+                                $ilk[] = $irec;
+                            }
+                        }
+                        // Check if we have some not loaded news
+                        if (count($ilk) && count($timglist = $mysql->select('select * from '.prefix.'_images where id in ('.$xfk.')'))) {
+                            $imglist = array_merge($imglist, $timglist);
+                            unset($timglist);
+                        }
+                    }
+                    //					if ($xfk && count($ilist = explode(",", $xfk)) && count($imglist = $mysql->select("select * from ".prefix."_images where id in (".$xfk.")"))) {
+                    if (count($imglist)) {
+                        // Yes, show field block
+                        $tvars['regx']["#\[xfield_".$kp."\](.*?)\[/xfield_".$kp."\]#is"] = '$1';
+                        $tvars['regx']["#\[nxfield_".$kp."\](.*?)\[/nxfield_".$kp."\]#is"] = '';
+                        // Scan for images and prepare data for template show
+                        $tiVars = [
+                            'fieldName'    => $k,
+                            'fieldTitle'   => secure_html($v['title']),
+                            'fieldType'    => $v['type'],
+                            'entriesCount' => count($imglist),
+                            'entries'      => [],
+                            'execStyle'    => $mode['style'],
+                            'execPlugin'   => $mode['plugin'],
+                        ];
+                        foreach ($imglist as $imgInfo) {
+                            $tiEntry = [
+                                'url'         => ($imgInfo['storage'] ? $config['attach_url'] : $config['images_url']).'/'.$imgInfo['folder'].'/'.$imgInfo['name'],
+                                'width'       => $imgInfo['width'],
+                                'height'      => $imgInfo['height'],
+                                'pwidth'      => $imgInfo['p_width'],
+                                'pheight'     => $imgInfo['p_height'],
+                                'name'        => $imgInfo['name'],
+                                'origName'    => secure_html($imgInfo['orig_name']),
+                                'description' => secure_html($imgInfo['description']),
+                                'flags'       => [
+                                    'hasPreview' => $imgInfo['preview'],
+                                ],
+                            ];
+                            if ($imgInfo['preview']) {
+                                $tiEntry['purl'] = ($imgInfo['storage'] ? $config['attach_url'] : $config['images_url']).'/'.$imgInfo['folder'].'/thumb/'.$imgInfo['name'];
+                            }
+                            $tiVars['entries'][] = $tiEntry;
+                        }
+                        // TWIG based variables
+                        $tvars['vars']['p']['xfields'][$k]['entries'] = $tiVars['entries'];
+                        $tvars['vars']['p']['xfields'][$k]['count'] = count($tiVars['entries']);
+                        $xv = $xtImages->render($tiVars);
+                        $tvars['vars']['p']['xfields'][$k]['value'] = $xv;
+                        $tvars['vars']['[xvalue_'.$k.']'] = $xv;
+                    } else {
+                        // TWIG based variables
+                        $tvars['vars']['p']['xfields'][$k]['value'] = '';
+                        $tvars['vars']['p']['xfields'][$k]['count'] = 0;
+                        $tvars['vars']['p']['xfields'][$k]['entries'] = [];
+                        // General variables
+                        $tvars['regx']["#\[xfield_".$kp."\](.*?)\[/xfield_".$kp."\]#is"] = '';
+                        $tvars['regx']["#\[nxfield_".$kp."\](.*?)\[/nxfield_".$kp."\]#is"] = '$1';
+                        $tvars['vars']['[xvalue_'.$k.']'] = '';
+                    }
+                } else {
+                    $tvars['regx']["#\[xfield_".$kp."\](.*?)\[/xfield_".$kp."\]#is"] = ($xfk == '') ? '' : '$1';
+                    $tvars['regx']["#\[nxfield_".$kp."\](.*?)\[/nxfield_".$kp."\]#is"] = ($xfk == '') ? '$1' : '';
+                    // Process `HTML` support feature
+                    if ((!$v['html_support']) && (($v['type'] == 'textarea') || ($v['type'] == 'text'))) {
+                        $xfk = str_replace('<', '&lt;', $xfk);
+                    }
+                    // Parse BB code [if required]
+                    if ($config['use_bbcodes'] && $v['bb_support']) {
+                        $xfk = $parse->bbcodes($xfk);
+                    }
+                    // Process formatting
+                    if (($v['type'] == 'textarea') && (!$v['noformat'])) {
+                        $xfk = (str_replace("\n", "<br/>\n", $xfk).(strlen($xfk) ? '<br/>' : ''));
+                    }
+                    $tvars['vars']['p']['xfields'][$k]['value'] = $xfk;
+                    $tvars['vars']['[xvalue_'.$k.']'] = $xfk;
+                }
+            }
+        }
+        // Show table if we have it
+        if (isset($xf['tdata']) && is_array($xf['tdata']) && isset($fields['#table']) && ($fields['#table'] == 1)) {
+            // Yes, we have table. Display it!
+            // Prepare conversion table
+            $conversionConfig = [
+                '[entries]'  => '{% for entry in entries %}',
+                '[/entries]' => '{% endfor %}',
+            ];
+            $xrecs = [];
+            $npp = 1;
+            foreach ($mysql->select('select * from '.prefix.'_xfields where (linked_ds = 1) and (linked_id = '.db_squote($newsID).') order by id', 1) as $trec) {
+                $xrec = [
+                    'num'   => ($npp++),
+                    'id'    => $trec['id'],
+                    'flags' => [],
+                ];
+                foreach ($xf['tdata'] as $tid => $tval) {
+                    // Skip disabled
+                    if ($tval['disabled']) {
+                        continue;
+                    }
+                    //  Populate field data
+                    $drec = unserialize($trec['xfields']);
+                    $xrec['field_'.$tid] = $drec[$tid];
+                    $xrec['flags']['field_'.$tid] = ($drec[$tid] != '') ? 1 : 0;
+                    $conversionConfig['{entry_field_'.$tid.'}'] = '{{ entry.field_'.$tid.' }}';
+                }
+                // Process filters (if any)
+                if (isset($PFILTERS['xfields']) && is_array($PFILTERS['xfields'])) {
+                    foreach ($PFILTERS['xfields'] as $k => $v) {
+                        $v->showTableEntry($newsID, $SQLnews, $trec, $xrec);
+                    }
+                }
+                $xrecs[] = $xrec;
+            }
+            // Search for news.table.tpl template file
+            $tpath = locatePluginTemplates(['news.table'], 'xfields');
+            // Show table
+            $templateName = $tpath['news.table'].'news.table.tpl';
+            $twigLoader->setConversion($templateName, $conversionConfig);
+            $xt = $twig->loadTemplate($templateName);
+            $tvars['vars']['plugin_xfields_table'] = $xt->render(['entries' => $xrecs]);
+            $tvars['vars']['p']['xfields']['_table']['countRec'] = count($xrecs);
+            $tvars['vars']['p']['xfields']['_table']['data'] = $xrecs;
+        } else {
+            $tvars['vars']['plugin_xfields_table'] = '';
+            $tvars['vars']['p']['xfields']['_table']['countRec'] = 0;
+        }
+        $SQLnews['content'] = $content;
+    }
 }
 
 // Manage uprofile modifications
 if (getPluginStatusActive('uprofile')) {
-	loadPluginLibrary('uprofile', 'lib');
+    loadPluginLibrary('uprofile', 'lib');
 
-	class XFieldsUPrifileFilter extends p_uprofileFilter {
+    class XFieldsUPrifileFilter extends p_uprofileFilter
+    {
+        public function editProfileForm($userID, $SQLrow, &$tvars)
+        {
+            global $lang, $catz, $mysql, $config, $twig, $twigLoader;
+            //print "<pre>".var_export($lang, true)."</pre>";
+            // Load config
+            $xf = xf_configLoad();
+            if (!is_array($xf)) {
+                return false;
+            }
+            // Fetch xfields data
+            $xdata = xf_decode($SQLrow['xfields']);
+            if (!is_array($xdata)) {
+                return false;
+            }
+            $output = '';
+            $xfEntries = [];
+            $xfList = [];
+            foreach ($xf['users'] as $id => $data) {
+                if ($data['disabled']) {
+                    continue;
+                }
+                //print "FLD: [$id]<br>\n";
+                $xfEntry = [
+                    'title'        => $data['title'],
+                    'id'           => $id,
+                    'value'        => $xdata[$id],
+                    'secure_value' => secure_html($xdata[$id]),
+                    'data'         => $data,
+                    'required'     => $lang['xfields_fld_'.($data['required'] ? 'required' : 'optional')],
+                    'flags'        => [
+                        'required' => $data['required'] ? true : false,
+                    ],
+                ];
+                switch ($data['type']) {
+                    case 'checkbox':
+                        $val = '<input type="checkbox" id="form_xfields_'.$id.'" name="xfields['.$id.']" title="'.$data['title'].'" value="1" '.($data['default'] ? 'checked="checked"' : '').'"/>';
+                        $xfEntry['input'] = $val;
+                        break;
+                    case 'text':
+                        $val = '<input type="text" name="xfields['.$id.']"  id="form_xfields_'.$id.'" title="'.$data['title'].'" value="'.secure_html($xdata[$id]).'" />';
+                        $xfEntry['input'] = $val;
+                        break;
+                    case 'select':
+                        $val = '<select name="xfields['.$id.']" id="form_xfields_'.$id.'" >';
+                        if (!$data['required']) {
+                            $val .= '<option value="">&nbsp;</option>';
+                        }
+                        if (is_array($data['options'])) {
+                            foreach ($data['options'] as $k => $v) {
+                                $val .= '<option value="'.secure_html(($data['storekeys']) ? $k : $v).'"'.((($data['storekeys'] && ($xdata[$id] == $k)) || (!$data['storekeys'] && ($xdata[$id] == $v))) ? ' selected' : '').'>'.$v.'</option>';
+                            }
+                        }
+                        $val .= '</select>';
+                        $xfEntry['input'] = $val;
+                        break;
+                    case 'textarea':
+                        $val = '<textarea cols="30" rows="4" name="xfields['.$id.']" id="form_xfields_'.$id.'">'.$xdata[$id].'</textarea>';
+                        $xfEntry['input'] = $val;
+                        break;
+                    case 'images':
+                        // First - show already attached images
+                        $iCount = 0;
+                        $input = '';
+                        $tVars = ['images' => []];
+                        if (is_array($SQLrow['#images'])) {
+                            foreach ($SQLrow['#images'] as $irow) {
+                                // Skip images, that are not related to current field
+                                if (($irow['plugin'] != 'xfields') || ($irow['pidentity'] != $id)) {
+                                    continue;
+                                }
+                                // Show attached image
+                                $iCount++;
+                                $tImage = [
+                                    'number'  => $iCount,
+                                    'id'      => $id,
+                                    'preview' => [
+                                        'width'  => $irow['p_width'],
+                                        'height' => $irow['p_height'],
+                                        'url'    => $config['attach_url'].'/'.$irow['folder'].'/thumb/'.$irow['name'],
+                                    ],
+                                    'image'   => [
+                                        'id'     => $irow['id'],
+                                        'number' => $iCount,
+                                        'url'    => $config['attach_url'].'/'.$irow['folder'].'/'.$irow['name'],
+                                        'width'  => $irow['width'],
+                                        'height' => $irow['height'],
+                                    ],
+                                    'flags'   => [
+                                        'preview' => $irow['preview'] ? true : false,
+                                        'exist'   => true,
+                                    ],
+                                ];
+                                $tVars['images'][] = $tImage;
+                            }
+                        }
+                        // Second - show entries for allowed number of attaches
+                        for ($i = $iCount + 1; $i <= intval($data['maxCount']); $i++) {
+                            $tImage = [
+                                'number' => $i,
+                                'id'     => $id,
+                                'flags'  => [
+                                    'exist' => false,
+                                ],
+                            ];
+                            $tVars['images'][] = $tImage;
+                        }
+                        // Make template
+                        $xt = $twig->loadTemplate('plugins/xfields/tpl/ed_entry.image.tpl');
+                        $val = $xt->render($tVars);
+                        $xfEntry['input'] = $val;
+                        break;
+                    default:
+                        continue;
+                }
+                $xfEntries[intval($data['area'])][] = $xfEntry;
+                $xfList[$id] = $xfEntry;
+            }
+            // Prepare configuration array
+            $tVars = [];
+            // Area 0 should always be configured
+            if (!isset($xfEntries[0])) {
+                $xfEntries[0] = [];
+            }
+            // For compatibility with old template engine, init values for blocks 0 and 1
+            $tvars['plugin_xfields_0'] = '';
+            $tvars['plugin_xfields_1'] = '';
+            foreach ($xfEntries as $k => $v) {
+                // Check if we have template for specific area, elsewhere - use basic [0] template
+                $templateName = 'plugins/xfields/tpl/uprofile.edit.'.(file_exists(root.'plugins/xfields/tpl/uprofile.edit.'.$k.'.tpl') ? $k : '0').'.tpl';
+                $xt = $twig->loadTemplate($templateName);
+                $tVars['entries'] = $v;
+                $tVars['entryCount'] = count($v);
+                $tVars['area'] = $k;
+                // Render block
+                $render = $xt->render($tVars);
+                $tvars['plugin_xfields_'.$k] .= $render;
+                $tvars['p']['xfields'][$k] .= $render;
+            }
+            $tvars['p']['xfields']['fields'] = $xfList;
 
-		function editProfileForm($userID, $SQLrow, &$tvars) {
+            /*
+                        unset($tVars['entries']);
+                        unset($tVars['area']);
 
-			global $lang, $catz, $mysql, $config, $twig, $twigLoader;
-			//print "<pre>".var_export($lang, true)."</pre>";
-			// Load config
-			$xf = xf_configLoad();
-			if (!is_array($xf))
-				return false;
-			// Fetch xfields data
-			$xdata = xf_decode($SQLrow['xfields']);
-			if (!is_array($xdata))
-				return false;
-			$output = '';
-			$xfEntries = array();
-			$xfList = array();
-			foreach ($xf['users'] as $id => $data) {
-				if ($data['disabled'])
-					continue;
-				//print "FLD: [$id]<br>\n";
-				$xfEntry = array(
-					'title'        => $data['title'],
-					'id'           => $id,
-					'value'        => $xdata[$id],
-					'secure_value' => secure_html($xdata[$id]),
-					'data'         => $data,
-					'required'     => $lang['xfields_fld_' . ($data['required'] ? 'required' : 'optional')],
-					'flags'        => array(
-						'required' => $data['required'] ? true : false,
-					),
-				);
-				switch ($data['type']) {
-					case 'checkbox':
-						$val = '<input type="checkbox" id="form_xfields_' . $id . '" name="xfields[' . $id . ']" title="' . $data['title'] . '" value="1" ' . ($data['default'] ? 'checked="checked"' : '') . '"/>';
-						$xfEntry['input'] = $val;
-						break;
-					case 'text'  :
-						$val = '<input type="text" name="xfields[' . $id . ']"  id="form_xfields_' . $id . '" title="' . $data['title'] . '" value="' . secure_html($xdata[$id]) . '" />';
-						$xfEntry['input'] = $val;
-						break;
-					case 'select':
-						$val = '<select name="xfields[' . $id . ']" id="form_xfields_' . $id . '" >';
-						if (!$data['required']) $val .= '<option value="">&nbsp;</option>';
-						if (is_array($data['options']))
-							foreach ($data['options'] as $k => $v) {
-								$val .= '<option value="' . secure_html(($data['storekeys']) ? $k : $v) . '"' . ((($data['storekeys'] && ($xdata[$id] == $k)) || (!$data['storekeys'] && ($xdata[$id] == $v))) ? ' selected' : '') . '>' . $v . '</option>';
-							}
-						$val .= '</select>';
-						$xfEntry['input'] = $val;
-						break;
-					case 'textarea'    :
-						$val = '<textarea cols="30" rows="4" name="xfields[' . $id . ']" id="form_xfields_' . $id . '">' . $xdata[$id] . '</textarea>';
-						$xfEntry['input'] = $val;
-						break;
-					case 'images'    :
-						// First - show already attached images
-						$iCount = 0;
-						$input = '';
-						$tVars = array('images' => array());
-						if (is_array($SQLrow['#images'])) {
-							foreach ($SQLrow['#images'] as $irow) {
-								// Skip images, that are not related to current field
-								if (($irow['plugin'] != 'xfields') || ($irow['pidentity'] != $id)) continue;
-								// Show attached image
-								$iCount++;
-								$tImage = array(
-									'number'  => $iCount,
-									'id'      => $id,
-									'preview' => array(
-										'width'  => $irow['p_width'],
-										'height' => $irow['p_height'],
-										'url'    => $config['attach_url'] . '/' . $irow['folder'] . '/thumb/' . $irow['name'],
-									),
-									'image'   => array(
-										'id'     => $irow['id'],
-										'number' => $iCount,
-										'url'    => $config['attach_url'] . '/' . $irow['folder'] . '/' . $irow['name'],
-										'width'  => $irow['width'],
-										'height' => $irow['height'],
-									),
-									'flags'   => array(
-										'preview' => $irow['preview'] ? true : false,
-										'exist'   => true,
-									),
-								);
-								$tVars['images'][] = $tImage;
-							}
-						}
-						// Second - show entries for allowed number of attaches
-						for ($i = $iCount + 1; $i <= intval($data['maxCount']); $i++) {
-							$tImage = array(
-								'number' => $i,
-								'id'     => $id,
-								'flags'  => array(
-									'exist' => false,
-								),
-							);
-							$tVars['images'][] = $tImage;
-						}
-						// Make template
-						$xt = $twig->loadTemplate('plugins/xfields/tpl/ed_entry.image.tpl');
-						$val = $xt->render($tVars);
-						$xfEntry['input'] = $val;
-						break;
-					default:
-						continue;
-				}
-				$xfEntries[intval($data['area'])][] = $xfEntry;
-				$xfList[$id] = $xfEntry;
-			}
-			// Prepare configuration array
-			$tVars = array();
-			// Area 0 should always be configured
-			if (!isset($xfEntries[0])) {
-				$xfEntries[0] = array();
-			}
-			// For compatibility with old template engine, init values for blocks 0 and 1
-			$tvars['plugin_xfields_0'] = '';
-			$tvars['plugin_xfields_1'] = '';
-			foreach ($xfEntries as $k => $v) {
-				// Check if we have template for specific area, elsewhere - use basic [0] template
-				$templateName = 'plugins/xfields/tpl/uprofile.edit.' . (file_exists(root . 'plugins/xfields/tpl/uprofile.edit.' . $k . '.tpl') ? $k : '0') . '.tpl';
-				$xt = $twig->loadTemplate($templateName);
-				$tVars['entries'] = $v;
-				$tVars['entryCount'] = count($v);
-				$tVars['area'] = $k;
-				// Render block
-				$render = $xt->render($tVars);
-				$tvars['plugin_xfields_' . $k] .= $render;
-				$tvars['p']['xfields'][$k] .= $render;
-			}
-			$tvars['p']['xfields']['fields'] = $xfList;
-
-			/*
-						unset($tVars['entries']);
-						unset($tVars['area']);
-
-						// Render general part [with JavaScript]
-						$xt = $twig->loadTemplate('plugins/xfields/tpl/news.general.tpl');
-						$tvars['p']['xfields']['general'] = $xt->render($tVars);
+                        // Render general part [with JavaScript]
+                        $xt = $twig->loadTemplate('plugins/xfields/tpl/news.general.tpl');
+                        $tvars['p']['xfields']['general'] = $xt->render($tVars);
 
 
-						$xt = $twig->loadTemplate('plugins/xfields/tpl/ed_uprofile.tpl');
-						$tvars['vars']['plugin_xfields'] .= $xt->render($tVars);
-			*/
+                        $xt = $twig->loadTemplate('plugins/xfields/tpl/ed_uprofile.tpl');
+                        $tvars['vars']['plugin_xfields'] .= $xt->render($tVars);
+            */
 
-			return 1;
-		}
+            return 1;
+        }
 
-		function editProfile($userID, $SQLrow, &$SQLnew) {
+        public function editProfile($userID, $SQLrow, &$SQLnew)
+        {
+            global $lang, $config, $mysql, $DSlist;
+            //print "<pre>editProfile() POST VARS: ".var_export($_POST, true)."</pre>";
+            // Load config
+            $xf = xf_configLoad();
+            if (!is_array($xf)) {
+                return 1;
+            }
+            $rcall = $_POST['xfields'];
+            if (!is_array($rcall)) {
+                $rcall = [];
+            }
+            // Decode previusly stored data
+            $oldFields = xf_decode($SQLrow['xfields']);
+            // Manage attached images
+            xf_modifyAttachedImages($DSlist['users'], $userID, $xf, $SQLrow['#images']);
+            $xdata = [];
+            //print "XF[users]: <pre>".var_export($xf['users'], true)."</pre>";
+            // Scan fields and check if we have attached images for fields with type 'images'
+            $haveImages = false;
+            foreach ($xf['users'] as $fid => $fval) {
+                if ($fval['type'] == 'images') {
+                    $haveImages = true;
+                    break;
+                }
+            }
+            if ($haveImages) {
+                // Get real ID's of attached images and print here
+                $idlist = [];
+                foreach ($mysql->select('select id, plugin, pidentity from '.prefix.'_images where (linked_ds = '.$DSlist['users'].') and (linked_id = '.db_squote($userID).')') as $irec) {
+                    if ($irec['plugin'] == 'xfields') {
+                        $idlist[$irec['pidentity']][] = $irec['id'];
+                    }
+                }
+                // Scan for fields that should be configured to have attached images
+                foreach ($xf['users'] as $fid => $fval) {
+                    if (($fval['type'] == 'images') && (is_array($idlist[$fid]))) {
+                        $xdata[$fid] = implode(',', $idlist[$fid]);
+                    }
+                }
+            }
+            foreach ($xf['users'] as $id => $data) {
+                // Attached images are processed in special way
+                if ($data['type'] == 'images') {
+                    continue;
+                }
+                // Skip disabled fields
+                if ($data['disabled']) {
+                    $xdata[$id] = $SQLrow[$id];
+                    continue;
+                }
+                if ($rcall[$id] != '') {
+                    $xdata[$id] = $rcall[$id];
+                } elseif ($data['required']) {
+                    msg(['type' => 'error', 'text' => str_replace('{field}', $id, $lang['xfields_msge_emptyrequired'])]);
 
-			global $lang, $config, $mysql, $DSlist;
-			//print "<pre>editProfile() POST VARS: ".var_export($_POST, true)."</pre>";
-			// Load config
-			$xf = xf_configLoad();
-			if (!is_array($xf))
-				return 1;
-			$rcall = $_POST['xfields'];
-			if (!is_array($rcall)) $rcall = array();
-			// Decode previusly stored data
-			$oldFields = xf_decode($SQLrow['xfields']);
-			// Manage attached images
-			xf_modifyAttachedImages($DSlist['users'], $userID, $xf, $SQLrow['#images']);
-			$xdata = array();
-			//print "XF[users]: <pre>".var_export($xf['users'], true)."</pre>";
-			// Scan fields and check if we have attached images for fields with type 'images'
-			$haveImages = false;
-			foreach ($xf['users'] as $fid => $fval) {
-				if ($fval['type'] == 'images') {
-					$haveImages = true;
-					break;
-				}
-			}
-			if ($haveImages) {
-				// Get real ID's of attached images and print here
-				$idlist = array();
-				foreach ($mysql->select("select id, plugin, pidentity from " . prefix . "_images where (linked_ds = " . $DSlist['users'] . ") and (linked_id = " . db_squote($userID) . ")") as $irec) {
-					if ($irec['plugin'] == 'xfields') {
-						$idlist[$irec['pidentity']] [] = $irec['id'];
-					}
-				}
-				// Scan for fields that should be configured to have attached images
-				foreach ($xf['users'] as $fid => $fval) {
-					if (($fval['type'] == 'images') && (is_array($idlist[$fid]))) {
-						$xdata[$fid] = join(",", $idlist[$fid]);
-					}
-				}
-			}
-			foreach ($xf['users'] as $id => $data) {
-				// Attached images are processed in special way
-				if ($data['type'] == 'images') {
-					continue;
-				}
-				// Skip disabled fields
-				if ($data['disabled']) {
-					$xdata[$id] = $SQLrow[$id];
-					continue;
-				}
-				if ($rcall[$id] != '') {
-					$xdata[$id] = $rcall[$id];
-				} else if ($data['required']) {
-					msg(array("type" => "error", "text" => str_replace('{field}', $id, $lang['xfields_msge_emptyrequired'])));
+                    return 0;
+                }
+                // Check if we should save data into separate SQL field
+                if ($data['storage']) {
+                    $SQLnew['xfields_'.$id] = $rcall[$id];
+                }
+            }
+            $SQLnew['xfields'] = xf_encode($xdata);
 
-					return 0;
-				}
-				// Check if we should save data into separate SQL field
-				if ($data['storage'])
-					$SQLnew['xfields_' . $id] = $rcall[$id];
-			}
-			$SQLnew['xfields'] = xf_encode($xdata);
+            return 1;
+        }
 
-			return 1;
-		}
+        public function showProfile($userID, $SQLrow, &$tvars)
+        {
+            global $mysql, $config, $twig, $twigLoader, $parse;
+            // Try to load config. Stop processing if config was not loaded
+            if (($xf = xf_configLoad()) === false) {
+                return;
+            }
+            $fields = xf_decode($SQLrow['xfields']);
+            // Check if we have at least one `image` field and load TWIG template if any
+            if (is_array($xf['users'])) {
+                foreach ($xf['users'] as $k => $v) {
+                    if ($v['type'] == 'images') {
+                        // Yes, we have it!
+                        $conversionParams = [];
+                        $imagesTemplateFileName = 'plugins/xfields/tpl/profile.show.images.tpl';
+                        $twigLoader->setConversion($imagesTemplateFileName, $conversionConfig);
+                        $xtImages = $twig->loadTemplate($imagesTemplateFileName);
+                        break;
+                    }
+                }
+            }
+            // Show extra fields if we have it
+            if (is_array($xf['users'])) {
+                foreach ($xf['users'] as $k => $v) {
+                    $kp = preg_quote($k, '#');
+                    $xfk = isset($fields[$k]) ? $fields[$k] : '';
+                    // Our behaviour depends on field type
+                    if ($v['type'] == 'images') {
+                        // Check if there're attached images
+                        if ($xfk && count($ilist = explode(',', $xfk)) && count($imglist = $mysql->select('select * from '.prefix.'_images where id in ('.$xfk.')'))) {
+                            //print "-xGotIMG[$k]";
+                            // Yes, get list of images
+                            $imgInfo = $imglist[0];
+                            $tvars['regx']["#\[xfield_".$kp."\](.*?)\[/xfield_".$kp."\]#is"] = '$1';
+                            $tvars['regx']["#\[nxfield_".$kp."\](.*?)\[/nxfield_".$kp."\]#is"] = '';
+                            $iname = ($imgInfo['storage'] ? $config['attach_url'] : $config['files_url']).'/'.$imgInfo['folder'].'/'.$imgInfo['name'];
+                            $tvars['vars']['[xvalue_'.$k.']'] = $iname;
+                            // Scan for images and prepare data for template show
+                            $tiVars = [
+                                'fieldName'    => $k,
+                                'fieldTitle'   => secure_html($v['title']),
+                                'fieldType'    => $v['type'],
+                                'entriesCount' => count($imglist),
+                                'entries'      => [],
+                                'execStyle'    => $mode['style'],
+                                'execPlugin'   => $mode['plugin'],
+                            ];
+                            foreach ($imglist as $imgInfo) {
+                                $tiEntry = [
+                                    'url'         => ($imgInfo['storage'] ? $config['attach_url'] : $config['images_url']).'/'.$imgInfo['folder'].'/'.$imgInfo['name'],
+                                    'width'       => $imgInfo['width'],
+                                    'height'      => $imgInfo['height'],
+                                    'pwidth'      => $imgInfo['p_width'],
+                                    'pheight'     => $imgInfo['p_height'],
+                                    'name'        => $imgInfo['name'],
+                                    'origName'    => secure_html($imgInfo['orig_name']),
+                                    'description' => secure_html($imgInfo['description']),
+                                    'flags'       => [
+                                        'hasPreview' => $imgInfo['preview'],
+                                    ],
+                                ];
+                                if ($imgInfo['preview']) {
+                                    $tiEntry['purl'] = ($imgInfo['storage'] ? $config['attach_url'] : $config['images_url']).'/'.$imgInfo['folder'].'/thumb/'.$imgInfo['name'];
+                                }
+                                $tiVars['entries'][] = $tiEntry;
+                            }
+                            // TWIG based variables
+                            $tvars['p']['xfields'][$k]['entries'] = $tiVars['entries'];
+                            $tvars['p']['xfields'][$k]['count'] = count($tiVars['entries']);
+                            $xv = $xtImages->render($tiVars);
+                            $tvars['p']['xfields'][$k]['value'] = $xv;
+                        //$tvars['vars']['[xvalue_'.$k.']'] = $xv;
+                        } else {
+                            $tvars['regx']["#\[xfield_".$kp."\](.*?)\[/xfield_".$kp."\]#is"] = '';
+                            $tvars['regx']["#\[nxfield_".$kp."\](.*?)\[/nxfield_".$kp."\]#is"] = '$1';
+                        }
+                    } else {
+                        $tvars['regx']["#\[xfield_".$kp."\](.*?)\[/xfield_".$kp."\]#is"] = ($xfk == '') ? '' : '$1';
+                        $tvars['regx']["#\[nxfield_".$kp."\](.*?)\[/nxfield_".$kp."\]#is"] = ($xfk == '') ? '$1' : '';
+                        $tvars['vars']['[xvalue_'.$k.']'] = ($v['type'] == 'textarea') ? '<br/>'.(str_replace("\n", "<br/>\n", $xfk).(strlen($xfk) ? '<br/>' : '')) : $xfk;
+                        // 12345
+                        // Process `HTML` support feature
+                        if ((!$v['html_support']) && (($v['type'] == 'textarea') || ($v['type'] == 'text'))) {
+                            $xfk = str_replace('<', '&lt;', $xfk);
+                        }
+                        // Parse BB code [if required]
+                        if ($config['use_bbcodes'] && $v['bb_support']) {
+                            $xfk = $parse->bbcodes($xfk);
+                        }
+                        // Process formatting
+                        if (($v['type'] == 'textarea') && (!$v['noformat'])) {
+                            $xfk = (str_replace("\n", "<br/>\n", $xfk).(strlen($xfk) ? '<br/>' : ''));
+                        }
+                        // TWIG based variables
+                        $tvars['p']['xfields'][$k]['value'] = $xfk;
+                    }
+                }
+            }
+        }
+    }
 
-		function showProfile($userID, $SQLrow, &$tvars) {
-
-			global $mysql, $config, $twig, $twigLoader, $parse;
-			// Try to load config. Stop processing if config was not loaded
-			if (($xf = xf_configLoad()) === false) return;
-			$fields = xf_decode($SQLrow['xfields']);
-			// Check if we have at least one `image` field and load TWIG template if any
-			if (is_array($xf['users']))
-				foreach ($xf['users'] as $k => $v) {
-					if ($v['type'] == 'images') {
-						// Yes, we have it!
-						$conversionParams = array();
-						$imagesTemplateFileName = 'plugins/xfields/tpl/profile.show.images.tpl';
-						$twigLoader->setConversion($imagesTemplateFileName, $conversionConfig);
-						$xtImages = $twig->loadTemplate($imagesTemplateFileName);
-						break;
-					}
-				}
-			// Show extra fields if we have it
-			if (is_array($xf['users']))
-				foreach ($xf['users'] as $k => $v) {
-					$kp = preg_quote($k, "#");
-					$xfk = isset($fields[$k]) ? $fields[$k] : '';
-					// Our behaviour depends on field type
-					if ($v['type'] == 'images') {
-						// Check if there're attached images
-						if ($xfk && count($ilist = explode(",", $xfk)) && count($imglist = $mysql->select("select * from " . prefix . "_images where id in (" . $xfk . ")"))) {
-							//print "-xGotIMG[$k]";
-							// Yes, get list of images
-							$imgInfo = $imglist[0];
-							$tvars['regx']["#\[xfield_" . $kp . "\](.*?)\[/xfield_" . $kp . "\]#is"] = '$1';
-							$tvars['regx']["#\[nxfield_" . $kp . "\](.*?)\[/nxfield_" . $kp . "\]#is"] = '';
-							$iname = ($imgInfo['storage'] ? $config['attach_url'] : $config['files_url']) . '/' . $imgInfo['folder'] . '/' . $imgInfo['name'];
-							$tvars['vars']['[xvalue_' . $k . ']'] = $iname;
-							// Scan for images and prepare data for template show
-							$tiVars = array(
-								'fieldName'    => $k,
-								'fieldTitle'   => secure_html($v['title']),
-								'fieldType'    => $v['type'],
-								'entriesCount' => count($imglist),
-								'entries'      => array(),
-								'execStyle'    => $mode['style'],
-								'execPlugin'   => $mode['plugin'],
-							);
-							foreach ($imglist as $imgInfo) {
-								$tiEntry = array(
-									'url'         => ($imgInfo['storage'] ? $config['attach_url'] : $config['images_url']) . '/' . $imgInfo['folder'] . '/' . $imgInfo['name'],
-									'width'       => $imgInfo['width'],
-									'height'      => $imgInfo['height'],
-									'pwidth'      => $imgInfo['p_width'],
-									'pheight'     => $imgInfo['p_height'],
-									'name'        => $imgInfo['name'],
-									'origName'    => secure_html($imgInfo['orig_name']),
-									'description' => secure_html($imgInfo['description']),
-									'flags' => array(
-										'hasPreview' => $imgInfo['preview'],
-									),
-								);
-								if ($imgInfo['preview']) {
-									$tiEntry['purl'] = ($imgInfo['storage'] ? $config['attach_url'] : $config['images_url']) . '/' . $imgInfo['folder'] . '/thumb/' . $imgInfo['name'];
-								}
-								$tiVars['entries'] [] = $tiEntry;
-							}
-							// TWIG based variables
-							$tvars['p']['xfields'][$k]['entries'] = $tiVars['entries'];
-							$tvars['p']['xfields'][$k]['count'] = count($tiVars['entries']);
-							$xv = $xtImages->render($tiVars);
-							$tvars['p']['xfields'][$k]['value'] = $xv;
-							//$tvars['vars']['[xvalue_'.$k.']'] = $xv;
-						} else {
-							$tvars['regx']["#\[xfield_" . $kp . "\](.*?)\[/xfield_" . $kp . "\]#is"] = '';
-							$tvars['regx']["#\[nxfield_" . $kp . "\](.*?)\[/nxfield_" . $kp . "\]#is"] = '$1';
-						}
-					} else {
-						$tvars['regx']["#\[xfield_" . $kp . "\](.*?)\[/xfield_" . $kp . "\]#is"] = ($xfk == "") ? "" : "$1";
-						$tvars['regx']["#\[nxfield_" . $kp . "\](.*?)\[/nxfield_" . $kp . "\]#is"] = ($xfk == "") ? "$1" : "";
-						$tvars['vars']['[xvalue_' . $k . ']'] = ($v['type'] == 'textarea') ? '<br/>' . (str_replace("\n", "<br/>\n", $xfk) . (strlen($xfk) ? '<br/>' : '')) : $xfk;
-						// 12345
-						// Process `HTML` support feature
-						if ((!$v['html_support']) && (($v['type'] == 'textarea') || ($v['type'] == 'text'))) {
-							$xfk = str_replace("<", "&lt;", $xfk);
-						}
-						// Parse BB code [if required]
-						if ($config['use_bbcodes'] && $v['bb_support']) {
-							$xfk = $parse->bbcodes($xfk);
-						}
-						// Process formatting
-						if (($v['type'] == 'textarea') && (!$v['noformat'])) {
-							$xfk = (str_replace("\n", "<br/>\n", $xfk) . (strlen($xfk) ? '<br/>' : ''));
-						}
-						// TWIG based variables
-						$tvars['p']['xfields'][$k]['value'] = $xfk;
-					}
-				}
-		}
-	}
-
-	register_filter('plugin.uprofile', 'xfields', new XFieldsUPrifileFilter);
+    register_filter('plugin.uprofile', 'xfields', new XFieldsUPrifileFilter());
 }
 
-class XFieldsFilterAdminCategories extends FilterAdminCategories {
+class XFieldsFilterAdminCategories extends FilterAdminCategories
+{
+    public function addCategory(&$tvars, &$SQL)
+    {
+        $SQL['xf_group'] = $_REQUEST['xf_group'];
 
-	function addCategory(&$tvars, &$SQL) {
+        return 1;
+    }
 
-		$SQL['xf_group'] = $_REQUEST['xf_group'];
+    public function addCategoryForm(&$tvars)
+    {
+        global $lang;
+        loadPluginLang('xfields', 'config', '', '', ':');
+        // Get config
+        $xf = xf_configLoad();
+        // Prepare select
+        $ms = '<select name="xf_group"><option value="">** все поля **</option>';
+        if (isset($xf['grp.news'])) {
+            foreach ($xf['grp.news'] as $k => $v) {
+                $ms .= '<option value="'.$k.'">'.$k.' ('.$v['title'].')</option>';
+            }
+        }
+        $tvars['extend'] .= '<tr><td width="70%" class="contentEntry1">'.$lang['xfields:categories.group'].'<br/><small>'.$lang['xfields:categories.group#desc'].'</small></td><td width="30%" class="contentEntry2">'.$ms.'</td></tr>';
 
-		return 1;
-	}
+        return 1;
+    }
 
-	function addCategoryForm(&$tvars) {
+    public function editCategoryForm($categoryID, $SQL, &$tvars)
+    {
+        global $lang;
+        loadPluginLang('xfields', 'config', '', '', ':');
+        // Get config
+        $xf = xf_configLoad();
+        // Prepare select
+        $ms = '<select name="xf_group"><option value="">** все поля **</option>';
+        foreach ($xf['grp.news'] as $k => $v) {
+            $ms .= '<option value="'.$k.'"'.(($SQL['xf_group'] == $k) ? ' selected="selected"' : '').'>'.$k.' ('.$v['title'].')</option>';
+        }
+        $tvars['extend'] .= '<tr><td width="70%" class="contentEntry1">'.$lang['xfields:categories.group'].'<br/><small>'.$lang['xfields:categories.group#desc'].'</small></td><td width="30%" class="contentEntry2">'.$ms.'</td></tr>';
 
-		global $lang;
-		loadPluginLang('xfields', 'config', '', '', ':');
-		// Get config
-		$xf = xf_configLoad();
-		// Prepare select
-		$ms = '<select name="xf_group"><option value="">** все поля **</option>';
-		if (isset($xf['grp.news'])) {
-			foreach ($xf['grp.news'] as $k => $v) {
-				$ms .= '<option value="' . $k . '">' . $k . ' (' . $v['title'] . ')</option>';
-			}
-		}
-		$tvars['extend'] .= '<tr><td width="70%" class="contentEntry1">' . $lang['xfields:categories.group'] . '<br/><small>' . $lang['xfields:categories.group#desc'] . '</small></td><td width="30%" class="contentEntry2">' . $ms . '</td></tr>';
+        return 1;
+    }
 
-		return 1;
-	}
+    public function editCategory($categoryID, $SQL, &$SQLnew, &$tvars)
+    {
+        $SQLnew['xf_group'] = $_REQUEST['xf_group'];
 
-	function editCategoryForm($categoryID, $SQL, &$tvars) {
-
-		global $lang;
-		loadPluginLang('xfields', 'config', '', '', ':');
-		// Get config
-		$xf = xf_configLoad();
-		// Prepare select
-		$ms = '<select name="xf_group"><option value="">** все поля **</option>';
-		foreach ($xf['grp.news'] as $k => $v) {
-			$ms .= '<option value="' . $k . '"' . (($SQL['xf_group'] == $k) ? ' selected="selected"' : '') . '>' . $k . ' (' . $v['title'] . ')</option>';
-		}
-		$tvars['extend'] .= '<tr><td width="70%" class="contentEntry1">' . $lang['xfields:categories.group'] . '<br/><small>' . $lang['xfields:categories.group#desc'] . '</small></td><td width="30%" class="contentEntry2">' . $ms . '</td></tr>';
-
-		return 1;
-	}
-
-	function editCategory($categoryID, $SQL, &$SQLnew, &$tvars) {
-
-		$SQLnew['xf_group'] = $_REQUEST['xf_group'];
-
-		return 1;
-	}
+        return 1;
+    }
 }
 
-class XFieldsCoreFilter extends CoreFilter {
+class XFieldsCoreFilter extends CoreFilter
+{
+    public function registerUserForm(&$tvars)
+    {
 
-	function registerUserForm(&$tvars) {
+        // Load config
+        $xf = xf_configLoad();
+        if (!is_array($xf) || !isset($xf['users']) || !is_array($xf['users'])) {
+            return 1;
+        }
+        foreach ($xf['users'] as $k => $v) {
+            if ($v['regpage'] && !$v['disabled']) {
+                //print "$k: <pre>".var_export($v, true)."</pre>";
+                $tEntry = [
+                    'name'  => 'xfield_'.$k,
+                    'title' => $v['title'],
+                ];
+                switch ($v['type']) {
+                    case 'text':
+                        $tEntry['type'] = 'input';
+                        $tEntry['value'] = $v['default'];
+                        break;
+                    case 'textarea':
+                        $tEntry['type'] = 'text';
+                        $tEntry['value'] = $v['default'];
+                        break;
+                    case 'select':
+                        $tEntry['type'] = 'select';
+                        if ($v['required']) {
+                            $tEntry['values'] = $v['options'];
+                        } else {
+                            $tEntry['values'] = ['' => ''] + $v['options'];
+                        }
+                        $tEntry['value'] = $v['default'];
+                        break;
+                }
+                $tvars['entries'][] = $tEntry;
+            }
+        }
 
-		// Load config
-		$xf = xf_configLoad();
-		if (!is_array($xf) || !isset($xf['users']) || !is_array($xf['users']))
-			return 1;
-		foreach ($xf['users'] as $k => $v) {
-			if ($v['regpage'] && !$v['disabled']) {
-				//print "$k: <pre>".var_export($v, true)."</pre>";
-				$tEntry = array(
-					'name'  => 'xfield_' . $k,
-					'title' => $v['title'],
-				);
-				switch ($v['type']) {
-					case 'text':
-						$tEntry['type'] = 'input';
-						$tEntry['value'] = $v['default'];
-						break;
-					case 'textarea':
-						$tEntry['type'] = 'text';
-						$tEntry['value'] = $v['default'];
-						break;
-					case 'select':
-						$tEntry['type'] = 'select';
-						if ($v['required']) {
-							$tEntry['values'] = $v['options'];
-						} else {
-							$tEntry['values'] = array('' => '') + $v['options'];
-						}
-						$tEntry['value'] = $v['default'];
-						break;
-				}
-				$tvars['entries'] [] = $tEntry;
-			}
-		}
+        return 1;
+    }
 
-		return 1;
-	}
+    public function registerUserNotify($userID, $userRec)
+    {
+        global $mysql;
+        // Load config
+        $xf = xf_configLoad();
+        if (!is_array($xf) || !isset($xf['users']) || !is_array($xf['users'])) {
+            return 1;
+        }
+        $xdata = [];
+        $SQL = [];
+        foreach ($xf['users'] as $k => $v) {
+            if ($v['regpage'] && !$v['disabled']) {
+                switch ($v['type']) {
+                    case 'text':
+                    case 'textarea':
+                    case 'select':
+                        $xdata[$k] = $_POST['xfield_'.$k];
+                        if ($v['storage']) {
+                            $SQL['xfields_'.$k] = $xdata[$k];
+                        }
+                        break;
+                }
+            }
+        }
+        $SQL['xfields'] = xf_encode($xdata);
+        $SQ = [];
+        foreach ($SQL as $sk => $sv) {
+            $SQ[] = $sk.'='.db_squote($sv);
+        }
+        $mysql->query('update '.uprefix.'_users set '.implode(',', $SQ).' where id = '.intval($userID));
 
-	function registerUserNotify($userID, $userRec) {
-
-		global $mysql;
-		// Load config
-		$xf = xf_configLoad();
-		if (!is_array($xf) || !isset($xf['users']) || !is_array($xf['users']))
-			return 1;
-		$xdata = array();
-		$SQL = array();
-		foreach ($xf['users'] as $k => $v) {
-			if ($v['regpage'] && !$v['disabled']) {
-				switch ($v['type']) {
-					case 'text':
-					case 'textarea':
-					case 'select':
-						$xdata[$k] = $_POST['xfield_' . $k];
-						if ($v['storage'])
-							$SQL['xfields_' . $k] = $xdata[$k];
-						break;
-				}
-			}
-		}
-		$SQL['xfields'] = xf_encode($xdata);
-		$SQ = array();
-		foreach ($SQL as $sk => $sv) {
-			$SQ [] = $sk . '=' . db_squote($sv);
-		}
-		$mysql->query("update " . uprefix . "_users set " . join(",", $SQ) . " where id = " . intval($userID));
-
-		return 1;
-	}
+        return 1;
+    }
 }
 
-register_filter('news', 'xfields', new XFieldsNewsFilter);
-register_filter('core.registerUser', 'xfields', new XFieldsCoreFilter);
-register_admin_filter('categories', 'xfields', new XFieldsFilterAdminCategories);
+register_filter('news', 'xfields', new XFieldsNewsFilter());
+register_filter('core.registerUser', 'xfields', new XFieldsCoreFilter());
+register_admin_filter('categories', 'xfields', new XFieldsFilterAdminCategories());

--- a/xnews/config.php
+++ b/xnews/config.php
@@ -1,212 +1,246 @@
 <?php
-# protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
-# preload config file
+
+// protect against hack attempts
+if (!defined('NGCMS')) {
+    die('HAL');
+}
+// preload config file
 pluginsLoadConfig();
 LoadPluginLang('xnews', 'config', '', 'tn', ':');
 $count = intval(pluginGetVariable($plugin, 'count'));
-if ($count < 1 || $count > 50)
-	$count = 1;
-# fill configuration parameters
-$cfg = array();
-array_push($cfg, array('descr' => $lang['tn:description']));
-array_push($cfg, array(
-	'name'  => 'count',
-	'title' => $lang['tn:count_title'],
-	'type'  => 'input',
-	'value' => $count
-));
+if ($count < 1 || $count > 50) {
+    $count = 1;
+}
+// fill configuration parameters
+$cfg = [];
+array_push($cfg, ['descr' => $lang['tn:description']]);
+array_push($cfg, [
+    'name'  => 'count',
+    'title' => $lang['tn:count_title'],
+    'type'  => 'input',
+    'value' => $count,
+]);
 for ($i = 1; $i <= $count; $i++) {
-	$cfgX = array();
-	$currentVar = "{$i}";
-	array_push($cfgX, array(
-			'name'  => "{$currentVar}_name",
-			'title' => 'Идентификатор блока<br/><small>По данному ID можно будет формировать данный блок через вызов <b>TWIG</b> функции <b>callPlugin()</b>',
-			'type'  => 'input',
-			'value' => pluginGetVariable($plugin, "{$currentVar}_name")
-		)
-	);
-	array_push($cfgX, array(
-			'name'  => "{$currentVar}_template",
-			'title' => 'Используемый шаблон',
-			'type'  => 'input',
-			//						'values'	=> $templateDirectories,
-			'value' => pluginGetVariable($plugin, "{$currentVar}_template")
-		)
-	);
-	array_push($cfgX, array(
-			'name'   => "{$currentVar}_visibilityMode",
-			'title'  => 'Область видимости<br/><small>Укажите на каких страницах будет отображаться данный блок</small>',
-			'type'   => 'select',
-			'values' => array('0' => 'Везде', 1 => 'На странице категорий', 2 => 'На странице новостей', 3 => 'Страница категорий + новостей'),
-			'value'  => pluginGetVariable($plugin, "{$currentVar}_visibilityMode")
-		)
-	);
-	array_push($cfgX, array(
-			'name'  => "{$currentVar}_visibilityCList",
-			'title' => 'Список категорий на которых отображается блок<br/><small>Можно указать конкретные категории при выборе <b>категории/новости</b> в предыдущем пункте',
-			'type'  => 'input',
-			'value' => pluginGetVariable($plugin, "{$currentVar}_visibilityCList")
-		)
-	);
-	array_push($cfgX, array(
-			'name'   => "{$currentVar}_categoryMode",
-			'title'  => 'Из каких категорий генерируется лента новостей',
-			'type'   => 'select',
-			'values' => array('0' => 'Список категорий', 1 => 'Текущая категория', 2 => 'Список + текущая'),
-			'value'  => pluginGetVariable($plugin, "{$currentVar}_categoryMode")
-		)
-	);
-	array_push($cfgX, array(
-			'name'  => "{$currentVar}_categories",
-			'title' => 'Список категорий для генерации ленты<br/><small>Задаётся список категорий (через запятую) при выборе <b>список</b> в предыдущем поле. Оставьте поле пустым для генерации ленты по всем категориям</small>',
-			'type'  => 'input',
-			'value' => pluginGetVariable($plugin, "{$currentVar}_categories")
-		)
-	);
-	array_push($cfgX, array(
-		'name'   => "{$currentVar}_mainMode",
-		'title'  => "Отображение новостей с главной страницы<br/><small>Выберите тип новостей, которые будут отображаться в блоке</small>",
-		'type'   => 'select',
-		'value'  => pluginGetVariable($plugin, "{$currentVar}_mainMode"),
-		'values' => array('0' => 'Все', 1 => 'С главной', 2 => 'Не с главной'),
-	));
-	array_push($cfgX, array(
-		'name'   => "{$currentVar}_pinMode",
-		'title'  => "Отображение прикрепленных новостей<br/><small>Выберите тип новостей, которые будут отображаться в блоке</small>",
-		'type'   => 'select',
-		'value'  => pluginGetVariable($plugin, "{$currentVar}_pinMode"),
-		'values' => array('0' => 'Все', 1 => 'Прикрепленные', 2 => 'Не прикрепленные'),
-	));
-	array_push($cfgX, array(
-		'name'   => "{$currentVar}_favMode",
-		'title'  => "Отображение новостей из закладок<br/><small>Выберите тип новостей, которые будут отображаться в блоке</small>",
-		'type'   => 'select',
-		'value'  => pluginGetVariable($plugin, "{$currentVar}_favMode"),
-		'values' => array('0' => 'Все', 1 => 'Только из закладок', 2 => 'Не добавленные в закладки'),
-	));
-	array_push($cfgX, array(
-		'name'   => "{$currentVar}_skipCurrent",
-		'title'  => "Не отображать в блоке текущую новость<br/><small>Данный режим не позволяет использовать кеширование блоков и повышает нагрузку на систему</small>",
-		'type'   => 'select',
-		'value'  => pluginGetVariable($plugin, "{$currentVar}_skipCurrent"),
-		'values' => array('0' => 'Нет', 1 => 'Да'),
-	));
-	array_push($cfgX, array(
-		'name'   => "{$currentVar}_extractEmbeddedItems",
-		'title'  => "Извлекать URL'ы изображений из текста новости<br/><small>Список URL'ов будет доступен в массиве news.embed.images, кол-во - в news.embed.imgCount</small>",
-		'type'   => 'select',
-		'value'  => pluginGetVariable($plugin, "{$currentVar}_extractEmbeddedItems"),
-		'values' => array('0' => 'Нет', 1 => 'Да'),
-	));
-	array_push($cfgX, array(
-			'name'  => "{$currentVar}_showNoNews",
-			'title' => 'Выводить блок если в нём нет новостей',
-			'type'  => 'checkbox',
-			'value' => pluginGetVariable($plugin, "{$currentVar}_showNoNews")
-		)
-	);
-	array_push($cfgX, array(
-			'name'  => "{$currentVar}_count",
-			'title' => $lang['tn:number_title'],
-			'type'  => 'input',
-			'value' => intval(pluginGetVariable($plugin, "{$currentVar}_count")) ? pluginGetVariable($plugin, "{$currentVar}_count") : '10'
-		)
-	);
-	array_push($cfgX, array(
-			'name'  => "{$currentVar}_skip",
-			'title' => 'Пропустить первые <b>X</b> новостей при показе блока<br/><small>Значение по умолчанию: 0',
-			'type'  => 'input',
-			'value' => intval(pluginGetVariable($plugin, "{$currentVar}_skip")) ? pluginGetVariable($plugin, "{$currentVar}_skip") : '0'
-		)
-	);
-	array_push($cfgX, array(
-			'name'  => "{$currentVar}_maxAge",
-			'title' => $lang['tn:date'],
-			'type'  => 'input',
-			'value' => intval(pluginGetVariable($plugin, "{$currentVar}_maxAge"))
-		)
-	);
-	$orderby = array(
-		'viewed'    => $lang['tn:orderby_views'],
-		'commented' => $lang['tn:orderby_comments'],
-		'random'    => $lang['tn:orderby_random'],
-		'last'      => $lang['tn:orderby_last']
-	);
-	array_push($cfgX, array(
-			'name'   => "{$currentVar}_order",
-			'type'   => 'select',
-			'title'  => $lang['tn:orderby_title'],
-			'values' => $orderby,
-			'value'  => pluginGetVariable($plugin, "{$currentVar}_order")
-		)
-	);
-	/*
-		array_push($cfgX, array(
-							'name' => "{$currentVar}_content",
-							'title' => $lang['tn:content'],
-							'type' => 'checkbox',
-							'value' => pluginGetVariable($plugin ,"{$currentVar}_content"))
-		);
-		array_push($cfgX, array(
-							'name'  => "{$currentVar}_img",
-							'title' => $lang['tn:img'],
-							'type'  => 'checkbox',
-							'value' => pluginGetVariable('xnews',"{$currentVar}_img"))
-		);
-	*/
-	$blockName = pluginGetVariable($plugin, "{$currentVar}_name") ? pluginGetVariable('xnews', "{$currentVar}_name") : '# ' . $currentVar;
-	array_push($cfg, array(
-			'mode'        => 'group',
-			'title'       => $lang['tn:group'] . $blockName,
-			'toggle'      => '1',
-			'toggle.mode' => 'hide',
-			'entries'     => $cfgX
-		)
-	);
+    $cfgX = [];
+    $currentVar = "{$i}";
+    array_push(
+        $cfgX,
+        [
+            'name'  => "{$currentVar}_name",
+            'title' => 'Идентификатор блока<br/><small>По данному ID можно будет формировать данный блок через вызов <b>TWIG</b> функции <b>callPlugin()</b>',
+            'type'  => 'input',
+            'value' => pluginGetVariable($plugin, "{$currentVar}_name"),
+        ]
+    );
+    array_push(
+        $cfgX,
+        [
+            'name'  => "{$currentVar}_template",
+            'title' => 'Используемый шаблон',
+            'type'  => 'input',
+            //						'values'	=> $templateDirectories,
+            'value' => pluginGetVariable($plugin, "{$currentVar}_template"),
+        ]
+    );
+    array_push(
+        $cfgX,
+        [
+            'name'   => "{$currentVar}_visibilityMode",
+            'title'  => 'Область видимости<br/><small>Укажите на каких страницах будет отображаться данный блок</small>',
+            'type'   => 'select',
+            'values' => ['0' => 'Везде', 1 => 'На странице категорий', 2 => 'На странице новостей', 3 => 'Страница категорий + новостей'],
+            'value'  => pluginGetVariable($plugin, "{$currentVar}_visibilityMode"),
+        ]
+    );
+    array_push(
+        $cfgX,
+        [
+            'name'  => "{$currentVar}_visibilityCList",
+            'title' => 'Список категорий на которых отображается блок<br/><small>Можно указать конкретные категории при выборе <b>категории/новости</b> в предыдущем пункте',
+            'type'  => 'input',
+            'value' => pluginGetVariable($plugin, "{$currentVar}_visibilityCList"),
+        ]
+    );
+    array_push(
+        $cfgX,
+        [
+            'name'   => "{$currentVar}_categoryMode",
+            'title'  => 'Из каких категорий генерируется лента новостей',
+            'type'   => 'select',
+            'values' => ['0' => 'Список категорий', 1 => 'Текущая категория', 2 => 'Список + текущая'],
+            'value'  => pluginGetVariable($plugin, "{$currentVar}_categoryMode"),
+        ]
+    );
+    array_push(
+        $cfgX,
+        [
+            'name'  => "{$currentVar}_categories",
+            'title' => 'Список категорий для генерации ленты<br/><small>Задаётся список категорий (через запятую) при выборе <b>список</b> в предыдущем поле. Оставьте поле пустым для генерации ленты по всем категориям</small>',
+            'type'  => 'input',
+            'value' => pluginGetVariable($plugin, "{$currentVar}_categories"),
+        ]
+    );
+    array_push($cfgX, [
+        'name'   => "{$currentVar}_mainMode",
+        'title'  => 'Отображение новостей с главной страницы<br/><small>Выберите тип новостей, которые будут отображаться в блоке</small>',
+        'type'   => 'select',
+        'value'  => pluginGetVariable($plugin, "{$currentVar}_mainMode"),
+        'values' => ['0' => 'Все', 1 => 'С главной', 2 => 'Не с главной'],
+    ]);
+    array_push($cfgX, [
+        'name'   => "{$currentVar}_pinMode",
+        'title'  => 'Отображение прикрепленных новостей<br/><small>Выберите тип новостей, которые будут отображаться в блоке</small>',
+        'type'   => 'select',
+        'value'  => pluginGetVariable($plugin, "{$currentVar}_pinMode"),
+        'values' => ['0' => 'Все', 1 => 'Прикрепленные', 2 => 'Не прикрепленные'],
+    ]);
+    array_push($cfgX, [
+        'name'   => "{$currentVar}_favMode",
+        'title'  => 'Отображение новостей из закладок<br/><small>Выберите тип новостей, которые будут отображаться в блоке</small>',
+        'type'   => 'select',
+        'value'  => pluginGetVariable($plugin, "{$currentVar}_favMode"),
+        'values' => ['0' => 'Все', 1 => 'Только из закладок', 2 => 'Не добавленные в закладки'],
+    ]);
+    array_push($cfgX, [
+        'name'   => "{$currentVar}_skipCurrent",
+        'title'  => 'Не отображать в блоке текущую новость<br/><small>Данный режим не позволяет использовать кеширование блоков и повышает нагрузку на систему</small>',
+        'type'   => 'select',
+        'value'  => pluginGetVariable($plugin, "{$currentVar}_skipCurrent"),
+        'values' => ['0' => 'Нет', 1 => 'Да'],
+    ]);
+    array_push($cfgX, [
+        'name'   => "{$currentVar}_extractEmbeddedItems",
+        'title'  => "Извлекать URL'ы изображений из текста новости<br/><small>Список URL'ов будет доступен в массиве news.embed.images, кол-во - в news.embed.imgCount</small>",
+        'type'   => 'select',
+        'value'  => pluginGetVariable($plugin, "{$currentVar}_extractEmbeddedItems"),
+        'values' => ['0' => 'Нет', 1 => 'Да'],
+    ]);
+    array_push(
+        $cfgX,
+        [
+            'name'  => "{$currentVar}_showNoNews",
+            'title' => 'Выводить блок если в нём нет новостей',
+            'type'  => 'checkbox',
+            'value' => pluginGetVariable($plugin, "{$currentVar}_showNoNews"),
+        ]
+    );
+    array_push(
+        $cfgX,
+        [
+            'name'  => "{$currentVar}_count",
+            'title' => $lang['tn:number_title'],
+            'type'  => 'input',
+            'value' => intval(pluginGetVariable($plugin, "{$currentVar}_count")) ? pluginGetVariable($plugin, "{$currentVar}_count") : '10',
+        ]
+    );
+    array_push(
+        $cfgX,
+        [
+            'name'  => "{$currentVar}_skip",
+            'title' => 'Пропустить первые <b>X</b> новостей при показе блока<br/><small>Значение по умолчанию: 0',
+            'type'  => 'input',
+            'value' => intval(pluginGetVariable($plugin, "{$currentVar}_skip")) ? pluginGetVariable($plugin, "{$currentVar}_skip") : '0',
+        ]
+    );
+    array_push(
+        $cfgX,
+        [
+            'name'  => "{$currentVar}_maxAge",
+            'title' => $lang['tn:date'],
+            'type'  => 'input',
+            'value' => intval(pluginGetVariable($plugin, "{$currentVar}_maxAge")),
+        ]
+    );
+    $orderby = [
+        'viewed'    => $lang['tn:orderby_views'],
+        'commented' => $lang['tn:orderby_comments'],
+        'random'    => $lang['tn:orderby_random'],
+        'last'      => $lang['tn:orderby_last'],
+    ];
+    array_push(
+        $cfgX,
+        [
+            'name'   => "{$currentVar}_order",
+            'type'   => 'select',
+            'title'  => $lang['tn:orderby_title'],
+            'values' => $orderby,
+            'value'  => pluginGetVariable($plugin, "{$currentVar}_order"),
+        ]
+    );
+    /*
+        array_push($cfgX, array(
+                            'name' => "{$currentVar}_content",
+                            'title' => $lang['tn:content'],
+                            'type' => 'checkbox',
+                            'value' => pluginGetVariable($plugin ,"{$currentVar}_content"))
+        );
+        array_push($cfgX, array(
+                            'name'  => "{$currentVar}_img",
+                            'title' => $lang['tn:img'],
+                            'type'  => 'checkbox',
+                            'value' => pluginGetVariable('xnews',"{$currentVar}_img"))
+        );
+    */
+    $blockName = pluginGetVariable($plugin, "{$currentVar}_name") ? pluginGetVariable('xnews', "{$currentVar}_name") : '# '.$currentVar;
+    array_push(
+        $cfg,
+        [
+            'mode'        => 'group',
+            'title'       => $lang['tn:group'].$blockName,
+            'toggle'      => '1',
+            'toggle.mode' => 'hide',
+            'entries'     => $cfgX,
+        ]
+    );
 }
 /*
 $cfgX = array();
 array_push($cfgX, array(
-					'name'   => 'localsource',
-					'title'  => $lang['tn:localsource'],
-					'type'   => 'select',
-					'values' => array ( '0' => $lang['tn:localsource_0'], '1' => $lang['tn:localsource_1']),
-					'value'  => intval(pluginGetVariable($plugin, 'localsource')))
+                    'name'   => 'localsource',
+                    'title'  => $lang['tn:localsource'],
+                    'type'   => 'select',
+                    'values' => array ( '0' => $lang['tn:localsource_0'], '1' => $lang['tn:localsource_1']),
+                    'value'  => intval(pluginGetVariable($plugin, 'localsource')))
 );
 array_push($cfg, array(
-					'mode'    => 'group',
-					'title'   => $lang['tn:group_2'],
-					'entries' => $cfgX)
+                    'mode'    => 'group',
+                    'title'   => $lang['tn:group_2'],
+                    'entries' => $cfgX)
 );
 */
-$cfgX = array();
-array_push($cfgX, array(
-		'name'   => 'cache',
-		'title'  => $lang['tn:cache'],
-		'type'   => 'select',
-		'values' => array('1' => $lang['yesa'], '0' => $lang['noa']),
-		'value'  => intval(pluginGetVariable($plugin, 'cache'))
-	)
+$cfgX = [];
+array_push(
+    $cfgX,
+    [
+        'name'   => 'cache',
+        'title'  => $lang['tn:cache'],
+        'type'   => 'select',
+        'values' => ['1' => $lang['yesa'], '0' => $lang['noa']],
+        'value'  => intval(pluginGetVariable($plugin, 'cache')),
+    ]
 );
-array_push($cfgX, array(
-		'name'  => 'cacheExpire',
-		'title' => $lang['tn:cacheExpire'],
-		'type'  => 'input',
-		'value' => intval(pluginGetVariable($plugin, 'cacheExpire')) ? pluginGetVariable($plugin, 'cacheExpire') : '60'
-	)
+array_push(
+    $cfgX,
+    [
+        'name'  => 'cacheExpire',
+        'title' => $lang['tn:cacheExpire'],
+        'type'  => 'input',
+        'value' => intval(pluginGetVariable($plugin, 'cacheExpire')) ? pluginGetVariable($plugin, 'cacheExpire') : '60',
+    ]
 );
-array_push($cfg, array(
-		'mode'    => 'group',
-		'title'   => $lang['tn:group_3'],
-		'entries' => $cfgX
-	)
+array_push(
+    $cfg,
+    [
+        'mode'    => 'group',
+        'title'   => $lang['tn:group_3'],
+        'entries' => $cfgX,
+    ]
 );
-# RUN
+// RUN
 if ($_REQUEST['action'] == 'commit') {
-	# if submit requested, do config save
-	commit_plugin_config_changes($plugin, $cfg);
-	print_commit_complete($plugin);
+    // if submit requested, do config save
+    commit_plugin_config_changes($plugin, $cfg);
+    print_commit_complete($plugin);
 } else {
-	generate_config_page($plugin, $cfg);
+    generate_config_page($plugin, $cfg);
 }

--- a/xnews/xnews.php
+++ b/xnews/xnews.php
@@ -1,10 +1,13 @@
 <?php
+
 // Plugin `xnews` (c) Vitaly Ponomarev
 // Redesined original plugin top_news by Alexey N. Zhukov (http://digitalplace.ru) [ email: zhukov.alexei@gmail.com ]
-# Protect against hack attempts
-if (!defined('NGCMS')) die ('HAL');
+// Protect against hack attempts
+if (!defined('NGCMS')) {
+    die('HAL');
+}
 // Load shared library
-include_once root . 'includes/inc/libnews.php';
+include_once root.'includes/inc/libnews.php';
 //
 // Show data block for xnews plugin
 // Params:
@@ -25,220 +28,230 @@ include_once root . 'includes/inc/libnews.php';
 // * template - ID/directory of template to use (directory from engine/plugins/xnews/tpl/
 // * extractEmbeddedItems - flag if news engine should extract embedded (via <img src=".."/>) images into array news.embed.images
 // * cacheAge - age of cache [in seconds]
-function xNewsShowBlock($params) {
+function xNewsShowBlock($params)
+{
+    global $CurrentHandler, $twig, $config;
+    if (isset($params['id']) && $params['id']) {
+        // Scan blocks
+        $isFound = false;
+        for ($i = 1; $i < 50; $i++) {
+            if (pluginGetVariable('xnews', $i.'_name') == $params['id']) {
+                // BLOCK FOUND. MAKE PRESETS !!!
+                $isFound = true;
+                if (pluginGetVariable('xnews', 'cache') && (!isset($params['cacheAge']))) {
+                    $params['cacheAge'] = pluginGetVariable('xnews', 'cacheExpire');
+                }
+                foreach (['categoryMode', 'categories', 'visibilityMode', 'visibilityCList', 'mainMode', 'pinMode', 'favMode', 'count', 'skip', 'maxAge', 'order', 'showNoNews', 'skipCurrent', 'extractEmbeddedItems'] as $k) {
+                    if (!isset($params[$k])) {
+                        $params[$k] = pluginGetVariable('xnews', $i.'_'.$k);
+                    }
+                }
+                // Load template only if it's defined
+                if (!isset($params['template']) && (pluginGetVariable('xnews', $i.'_template') != '')) {
+                    $params['template'] = pluginGetVariable('xnews', $i.'_template');
+                }
+                break;
+            }
+        }
+        if (!$isFound) {
+            return '[XNEWS: No profile found "'.$params['id'].'"]';
+        }
+    }
+    // Convert category list into array
+    if (isset($params['categories']) && (!is_array($params['categories']))) {
+        $params['categories'] = preg_split('# *, *#', $params['categories'], -1, PREG_SPLIT_NO_EMPTY);
+    }
+    if (isset($params['visibilityCList']) && (!is_array($params['visibilityCList']))) {
+        $params['visibilityCList'] = preg_split('# *, *#', $params['visibilityCList'], -1, PREG_SPLIT_NO_EMPTY);
+    }
+    $currentCategory = getCurrentNewsCategory();
+    //print "<pre>".var_export($CurrentHandler, true)."</pre>";
+    //print "Call params: <pre>".var_export($params, true)."</pre>";
+    // Check if block should be displayed
+    if ($params['visibilityMode'] > 0) {
+        if ($CurrentHandler['pluginName'] != 'news') {
+            return;
+        }
+        switch ($params['visibilityMode']) {
+            // Everywhere
+            case 0:
+                break;
+            // Only on category page
+            case 1:
+                if ($CurrentHandler['handlerName'] != 'by.category') {
+                    return false;
+                }
+                break;
+            // Only on news page
+            case 2:
+                if (($CurrentHandler['handlerName'] != 'news') && ($CurrentHandler['handlerName'] != 'print')) {
+                    return false;
+                }
+                break;
+            // On category/news page
+            case 3:
+                if (($CurrentHandler['handlerName'] != 'news') && ($CurrentHandler['handlerName'] != 'print') && ($CurrentHandler['handlerName'] != 'by.category')) {
+                    return false;
+                }
+                break;
+        }
+        // Check if we're now in allowed category
+        if (count($params['visibilityCList']) > 0) {
+            $catched = false;
+            foreach ($params['visibilityCList'] as $cx) {
+                if (trim($cx) == $currentCategory[1]) {
+                    $catched = true;
+                    break;
+                }
+            }
+            if (!$catched) {
+                return false;
+            }
+        }
+    }
+    // ** Prepare a list of categories where this block should be displayed
+    $categoryList = [];
+    // Category display mode
+    switch ($params['categoryMode']) {
+        // Only selected categories
+        case 0:
+            $categoryList = $params['categories'];
+            break;
+        // Only current category
+        case 1:
+            if (!is_array($currentCategory)) {
+                return false;
+            }
+            $categoryList = [$currentCategory[1]];
+            break;
+        // Selected + current categories
+        case 2:
+            $categoryList = $params['categories'];
+            if (is_array($currentCategory) && !array_search($currentCategory[1], $categoryList)) {
+                $categoryList[] = $currentCategory[1];
+            }
+            break;
+    }
+    // Prepare filters
+    $filterList = [];
+    // Prepare keys for cacheing
+    $cacheKeys = [];
+    $cacheDisabled = false;
+    // mainMode
+    if ($params['mainMode'] > 0) {
+        $filterList[] = '(mainpage = '.(($params['mainMode'] > 1) ? '0' : '1').')';
+        $cacheKeys[] = '|mainMode='.$params['mainMode'];
+    }
+    // pinMode
+    if (isset($params['pinMode']) && ($params['pinMode'] > 0)) {
+        $filterList[] = '(pinned = '.(($params['pinMode'] > 1) ? '0' : '1').')';
+        $cacheKeys[] = '|pinMode='.$params['pinMode'];
+    }
+    // favMode
+    if (isset($params['favMode']) && ($params['favMode'] > 0)) {
+        $filterList[] = '(favorite = '.(($params['favMode'] > 1) ? '0' : '1').')';
+        $cacheKeys[] = '|favMode='.$params['favMode'];
+    }
+    // skipCurrent
+    if (isset($params['skipCurrent']) && $params['skipCurrent'] && (($CurrentHandler['handlerName'] == 'news') || ($CurrentHandler['handlerName'] == 'print'))) {
+        list($xm, $null, $xi) = getCurrentNewsCategory();
+        if (($xm == 'full') && ($xi > 0)) {
+            $filterList[] = '(id <> '.intval($xi).')';
+            $cacheDisabled = true;
+        }
+    }
+    $showCount = ($params['count'] > 0) ? intval($params['count']) : 10;
+    $showSkip = ($params['skip'] > 0) ? intval($params['skip']) : 0;
+    $showAge = ($params['maxAge'] > 0) ? intval($params['maxAge']) : 0;
+    $cacheKeys[] = '|count='.$showCount;
+    $cacheKeys[] = '|skip='.$showSkip;
+    $cacheKeys[] = '|maxAge='.$showAge;
+    $cacheKeys[] = '|embed='.intval($params['extractEmbeddedItems']);
+    $cacheKeys[] = '|categoryMode='.$params['categoryMode'];
+    $cacheKeys[] = '|categories='.implode(',', $categoryList);
+    if ($showAge > 0) {
+        $filterList[] = '((unix_timestamp(now()) - postdate) < '.($showAge * 86400).')';
+    }
+    if ((is_array($categoryList) && count($categoryList))) {
+        //print "categoryList [".var_export($categoryList, true)."]";
+        $catFilter = [];
+        foreach ($categoryList as $cat) {
+            $catFilter[] = "(catid regexp '[[:<:]](".trim($cat).")[[:>:]]')";
+        }
+        $filterList[] = '('.implode(' OR ', $catFilter).')';
+    }
+    $orderAllowed = ['viewed' => 'views desc', 'commented' => 'com desc', 'last' => 'postdate desc', 'random' => 'rand()'];
+    if ($params['order'] && isset($orderAllowed[$params['order']])) {
+        $orderBy = $orderAllowed[$params['order']];
+    } else {
+        $orderBy = $orderAllowed['viewed'];
+    }
+    $cacheKeys[] = '|order='.$orderBy;
+    // Show only published news
+    $filterList[] = '(approve > 0)';
+    // Prepare SQL query
+    $requestQuery = 'SELECT * FROM '.prefix.'_news '.((count($filterList) > 0) ? 'WHERE '.implode(' AND ', $filterList) : '')." ORDER BY {$orderBy} LIMIT {$showSkip}, {$showCount}";
+    // Check if template directory is specified and exists
+    $templateDir = '';
+    if (isset($params['template'])) {
+        if (is_dir(tpl_site.'plugins/xnews/'.$params['template']) && file_exists(tpl_site.'plugins/xnews/'.$params['template'].'/entries.tpl') && file_exists(tpl_site.'plugins/xnews/'.$params['template'].'/xnews.tpl')) {
+            // TEMPLATE FOUND: SITE
+            $templateDir = tpl_site.'plugins/xnews/'.$params['template'];
+        } elseif (is_dir(extras_dir.'/xnews/tpl/'.$params['template']) && file_exists(extras_dir.'/xnews/tpl/'.$params['template'].'/entries.tpl') && file_exists(extras_dir.'/xnews/tpl/'.$params['template'].'/xnews.tpl')) {
+            // TEMPLATE FOUND: PLUGIN
+            $templateDir = extras_dir.'/xnews/tpl/'.$params['template'];
+        } else {
+            // TEMPLATE IS LOST
+            return '[XNEWS: NO TEMPLATE "'.$params['template'].'"]';
+        }
+    } else {
+        if (is_dir(extras_dir.'/xnews/tpl/example') && file_exists(extras_dir.'/xnews/tpl/example/entries.tpl') && file_exists(extras_dir.'/xnews/tpl/example/xnews.tpl')) {
+            // TEMPLATE FOUND: default template
+            $templateDir = extras_dir.'/xnews/tpl/example';
+        } else {
+            // TEMPLATE IS LOST
+            return '[XNEWS: NO TEMPLATE "example"]';
+        }
+    }
+    $cacheKeys[] = '|template='.$params['template'];
+    //print "CACHE [AGE:".$params['cacheAge']."][".($cacheDisabled?'DISA':'ok')."][".join('', $cacheKeys)."]<br/>";
+    // Generate cache file name [ we should take into account SWITCHER plugin ]
+    $cacheFileName = md5('xnews'.$config['theme'].$config['default_lang'].implode('', $cacheKeys)).'.txt';
+    if (!$cacheDisabled && ($params['cacheAge'] > 0)) {
+        $cacheData = cacheRetrieveFile($cacheFileName, $params['cacheAge'], 'xnews');
+        if ($cacheData != false) {
+            // We got data from cache. Return it and stop
+            return $cacheData;
+        }
+    }
+    //print "SQL QUERY [".$requestQuery."][".count($filterList)."]<br/>\n";
+    // Retrieve data
+    $showResult = news_showlist([], [], [
+        'plugin'               => 'xnews',
+        'extractEmbeddedItems' => $params['extractEmbeddedItems'],
+        'overrideSQLquery'     => $requestQuery,
+        'extendedReturn'       => true,
+        'extendedReturnData'   => true,
+        'overrideTemplatePath' => $templateDir,
+        'overrideTemplateName' => 'entries',
+        'twig'                 => true,
+    ]);
+    // Generate main block
+    $tVars = [
+        'entries'      => $showResult['data'],
+        'entriesCount' => $showResult['count'],
+    ];
+    $xt = $twig->loadTemplate($templateDir.'/xnews.tpl');
+    $xOut = $xt->render($tVars);
+    // Manage `showNoNews` flag
+    if (($showResult['count'] < 1) && (isset($params['showNoNews']) || ($params['showNoNews']))) {
+        $xOut = '';
+    }
+    if (!$cacheDisabled && ($params['cacheAge'] > 0)) {
+        cacheStoreFile($cacheFileName, $xOut, 'xnews');
+    }
 
-	global $CurrentHandler, $twig, $config;
-	if (isset($params['id']) && $params['id']) {
-		// Scan blocks
-		$isFound = false;
-		for ($i = 1; $i < 50; $i++) {
-			if (pluginGetVariable('xnews', $i . '_name') == $params['id']) {
-				// BLOCK FOUND. MAKE PRESETS !!!
-				$isFound = true;
-				if (pluginGetVariable('xnews', 'cache') && (!isset($params['cacheAge']))) {
-					$params['cacheAge'] = pluginGetVariable('xnews', 'cacheExpire');
-				}
-				foreach (array('categoryMode', 'categories', 'visibilityMode', 'visibilityCList', 'mainMode', 'pinMode', 'favMode', 'count', 'skip', 'maxAge', 'order', 'showNoNews', 'skipCurrent', 'extractEmbeddedItems') as $k)
-					if (!isset($params[$k])) $params[$k] = pluginGetVariable('xnews', $i . '_' . $k);
-				// Load template only if it's defined
-				if (!isset($params['template']) && (pluginGetVariable('xnews', $i . '_template') != ''))
-					$params['template'] = pluginGetVariable('xnews', $i . '_template');
-				break;
-			}
-		}
-		if (!$isFound) {
-			return '[XNEWS: No profile found "' . $params['id'] . '"]';
-		}
-	}
-	// Convert category list into array
-	if (isset($params['categories']) && (!is_array($params['categories']))) {
-		$params['categories'] = preg_split('# *, *#', $params['categories'], -1, PREG_SPLIT_NO_EMPTY);
-	}
-	if (isset($params['visibilityCList']) && (!is_array($params['visibilityCList']))) {
-		$params['visibilityCList'] = preg_split('# *, *#', $params['visibilityCList'], -1, PREG_SPLIT_NO_EMPTY);
-	}
-	$currentCategory = getCurrentNewsCategory();
-	//print "<pre>".var_export($CurrentHandler, true)."</pre>";
-	//print "Call params: <pre>".var_export($params, true)."</pre>";
-	// Check if block should be displayed
-	if ($params['visibilityMode'] > 0) {
-		if ($CurrentHandler['pluginName'] != 'news')
-			return;
-		switch ($params['visibilityMode']) {
-			// Everywhere
-			case 0:
-				break;
-			// Only on category page
-			case 1:
-				if ($CurrentHandler['handlerName'] != 'by.category')
-					return false;
-				break;
-			// Only on news page
-			case 2:
-				if (($CurrentHandler['handlerName'] != 'news') && ($CurrentHandler['handlerName'] != 'print'))
-					return false;
-				break;
-			// On category/news page
-			case 3:
-				if (($CurrentHandler['handlerName'] != 'news') && ($CurrentHandler['handlerName'] != 'print') && ($CurrentHandler['handlerName'] != 'by.category'))
-					return false;
-				break;
-		}
-		// Check if we're now in allowed category
-		if (count($params['visibilityCList']) > 0) {
-			$catched = false;
-			foreach ($params['visibilityCList'] as $cx) {
-				if (trim($cx) == $currentCategory[1]) {
-					$catched = true;
-					break;
-				}
-			}
-			if (!$catched)
-				return false;
-		}
-	}
-	// ** Prepare a list of categories where this block should be displayed
-	$categoryList = array();
-	// Category display mode
-	switch ($params['categoryMode']) {
-		// Only selected categories
-		case 0:
-			$categoryList = $params['categories'];
-			break;
-		// Only current category
-		case 1:
-			if (!is_array($currentCategory))
-				return false;
-			$categoryList = array($currentCategory[1]);
-			break;
-		// Selected + current categories
-		case 2:
-			$categoryList = $params['categories'];
-			if (is_array($currentCategory) && !array_search($currentCategory[1], $categoryList))
-				$categoryList [] = $currentCategory[1];
-			break;
-	}
-	// Prepare filters
-	$filterList = array();
-	// Prepare keys for cacheing
-	$cacheKeys = array();
-	$cacheDisabled = false;
-	// mainMode
-	if ($params['mainMode'] > 0) {
-		$filterList [] = '(mainpage = ' . (($params['mainMode'] > 1) ? '0' : '1') . ')';
-		$cacheKeys [] = '|mainMode=' . $params['mainMode'];
-	}
-	// pinMode
-	if (isset($params['pinMode']) && ($params['pinMode'] > 0)) {
-		$filterList [] = '(pinned = ' . (($params['pinMode'] > 1) ? '0' : '1') . ')';
-		$cacheKeys [] = '|pinMode=' . $params['pinMode'];
-	}
-	// favMode
-	if (isset($params['favMode']) && ($params['favMode'] > 0)) {
-		$filterList [] = '(favorite = ' . (($params['favMode'] > 1) ? '0' : '1') . ')';
-		$cacheKeys [] = '|favMode=' . $params['favMode'];
-	}
-	// skipCurrent
-	if (isset($params['skipCurrent']) && $params['skipCurrent'] && (($CurrentHandler['handlerName'] == 'news') || ($CurrentHandler['handlerName'] == 'print'))) {
-		list($xm, $null, $xi) = getCurrentNewsCategory();
-		if (($xm == 'full') && ($xi > 0)) {
-			$filterList [] = '(id <> ' . intval($xi) . ')';
-			$cacheDisabled = true;
-		}
-	}
-	$showCount = ($params['count'] > 0) ? intval($params['count']) : 10;
-	$showSkip = ($params['skip'] > 0) ? intval($params['skip']) : 0;
-	$showAge = ($params['maxAge'] > 0) ? intval($params['maxAge']) : 0;
-	$cacheKeys [] = '|count=' . $showCount;
-	$cacheKeys [] = '|skip=' . $showSkip;
-	$cacheKeys [] = '|maxAge=' . $showAge;
-	$cacheKeys [] = '|embed=' . intval($params['extractEmbeddedItems']);
-	$cacheKeys [] = '|categoryMode=' . $params['categoryMode'];
-	$cacheKeys [] = '|categories=' . join(",", $categoryList);
-	if ($showAge > 0) {
-		$filterList [] = '((unix_timestamp(now()) - postdate) < ' . ($showAge * 86400) . ')';
-	}
-	if ((is_array($categoryList) && count($categoryList))) {
-		//print "categoryList [".var_export($categoryList, true)."]";
-		$catFilter = array();
-		foreach ($categoryList as $cat) {
-			$catFilter [] = "(catid regexp '[[:<:]](" . trim($cat) . ")[[:>:]]')";
-		}
-		$filterList [] = '(' . join(' OR ', $catFilter) . ')';
-	}
-	$orderAllowed = array('viewed' => 'views desc', 'commented' => 'com desc', 'last' => 'postdate desc', 'random' => 'rand()');
-	if ($params['order'] && isset($orderAllowed[$params['order']])) {
-		$orderBy = $orderAllowed[$params['order']];
-	} else {
-		$orderBy = $orderAllowed['viewed'];
-	}
-	$cacheKeys [] = '|order=' . $orderBy;
-	// Show only published news
-	$filterList [] = '(approve > 0)';
-	// Prepare SQL query
-	$requestQuery = "SELECT * FROM " . prefix . "_news " . ((count($filterList) > 0) ? "WHERE " . implode(" AND ", $filterList) : "") . " ORDER BY {$orderBy} LIMIT {$showSkip}, {$showCount}";
-	// Check if template directory is specified and exists
-	$templateDir = '';
-	if (isset($params['template'])) {
-		if (is_dir(tpl_site . 'plugins/xnews/' . $params['template']) && file_exists(tpl_site . 'plugins/xnews/' . $params['template'] . '/entries.tpl') && file_exists(tpl_site . 'plugins/xnews/' . $params['template'] . '/xnews.tpl')) {
-			// TEMPLATE FOUND: SITE
-			$templateDir = tpl_site . 'plugins/xnews/' . $params['template'];
-		} else if (is_dir(extras_dir . '/xnews/tpl/' . $params['template']) && file_exists(extras_dir . '/xnews/tpl/' . $params['template'] . '/entries.tpl') && file_exists(extras_dir . '/xnews/tpl/' . $params['template'] . '/xnews.tpl')) {
-			// TEMPLATE FOUND: PLUGIN
-			$templateDir = extras_dir . '/xnews/tpl/' . $params['template'];
-		} else {
-			// TEMPLATE IS LOST
-			return '[XNEWS: NO TEMPLATE "' . $params['template'] . '"]';
-		}
-	} else {
-		if (is_dir(extras_dir . '/xnews/tpl/example') && file_exists(extras_dir . '/xnews/tpl/example/entries.tpl') && file_exists(extras_dir . '/xnews/tpl/example/xnews.tpl')) {
-			// TEMPLATE FOUND: default template
-			$templateDir = extras_dir . '/xnews/tpl/example';
-		} else {
-			// TEMPLATE IS LOST
-			return '[XNEWS: NO TEMPLATE "example"]';
-		}
-	}
-	$cacheKeys [] = '|template=' . $params['template'];
-	//print "CACHE [AGE:".$params['cacheAge']."][".($cacheDisabled?'DISA':'ok')."][".join('', $cacheKeys)."]<br/>";
-	// Generate cache file name [ we should take into account SWITCHER plugin ]
-	$cacheFileName = md5('xnews' . $config['theme'] . $config['default_lang'] . join('', $cacheKeys)) . '.txt';
-	if (!$cacheDisabled && ($params['cacheAge'] > 0)) {
-		$cacheData = cacheRetrieveFile($cacheFileName, $params['cacheAge'], 'xnews');
-		if ($cacheData != false) {
-			// We got data from cache. Return it and stop
-			return $cacheData;
-		}
-	}
-	//print "SQL QUERY [".$requestQuery."][".count($filterList)."]<br/>\n";
-	// Retrieve data
-	$showResult = news_showlist(array(), array(), array(
-		'plugin'               => 'xnews',
-		'extractEmbeddedItems' => $params['extractEmbeddedItems'],
-		'overrideSQLquery'     => $requestQuery,
-		'extendedReturn'       => true,
-		'extendedReturnData'   => true,
-		'overrideTemplatePath' => $templateDir,
-		'overrideTemplateName' => 'entries',
-		'twig'                 => true,
-	));
-	// Generate main block
-	$tVars = array(
-		'entries'      => $showResult['data'],
-		'entriesCount' => $showResult['count'],
-	);
-	$xt = $twig->loadTemplate($templateDir . '/xnews.tpl');
-	$xOut = $xt->render($tVars);
-	// Manage `showNoNews` flag
-	if (($showResult['count'] < 1) && (isset($params['showNoNews']) || ($params['showNoNews']))) {
-		$xOut = '';
-	}
-	if (!$cacheDisabled && ($params['cacheAge'] > 0)) {
-		cacheStoreFile($cacheFileName, $xOut, 'xnews');
-	}
-
-	return $xOut;
+    return $xOut;
 }
 
 twigRegisterFunction('xnews', 'show', xNewsShowBlock);
-


### PR DESCRIPTION
Для форматирования кода использовался [сервис](https://styleci.io/) с рекомендуемыми параметрами.

Применяемые настройки:

```
preset: recommended
risky: true
finder:
  path:
    - "/archive/"
    - "/auth_basic/"
    - "/autokeys/"
    - "/breadcrumbs/"
    - "/calendar/"
    - "/clear_config/"
    - "/comments/"
    - "/feedback/"
    - "/gsmg/"
    - "/lastcomments/"
    - "/rss_export/"
    - "/subscribe_comments/"
    - "/tags/"
    - "/voting/"
    - "/xfields/"
    - "/xnews/"
  name: "*.php"
```