### PR TITLE
[gsmg] Неопознанная кодировка

### DIFF
--- a/gsmg/lib/common.php
+++ b/gsmg/lib/common.php
@@ -15,7 +15,7 @@ function create_gsmg_urls() {
 	$ULIB->registerCommand('gsmg', '',
 		array(
 			'vars'  => array(),
-			'descr' => array('russian' => 'Ëåíòà gsmg'),
+			'descr' => array('russian' => 'Ð›ÐµÐ½Ñ‚Ð° gsmg'),
 		)
 	);
 	$ULIB->saveConfig();


### PR DESCRIPTION
Из-за этого бага после установки плагина слетали все ссылки в разделе `Управление форматом ссылок`